### PR TITLE
Testability enhancement:  interfaces extracted from AerospikeClient and AsyncClient 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@ doc
 *.zip
 *.out
 *.jar
+.idea
+*.iml
+*.ipr
+*.iws

--- a/benchmarks/src/com/aerospike/benchmarks/Main.java
+++ b/benchmarks/src/com/aerospike/benchmarks/Main.java
@@ -29,6 +29,8 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicIntegerArray;
 
+import com.aerospike.client.DefaultAerospikeClient;
+import com.aerospike.client.async.DefaultAsyncClient;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
 import org.apache.commons.cli.HelpFormatter;
@@ -455,7 +457,7 @@ public class Main implements Log.Callback {
 
 	public void runBenchmarks() throws Exception {
 		if (this.asyncEnabled) {
-			AsyncClient client = new AsyncClient(clientPolicy, hosts[0], port);		
+			AsyncClient client = new DefaultAsyncClient(clientPolicy, hosts[0], port);
 
 			try {
 				if (writeKeys) {
@@ -470,7 +472,7 @@ public class Main implements Log.Callback {
 			}			
 		}
 		else {			
-			AerospikeClient client = new AerospikeClient(clientPolicy, hosts[0], port);		
+			AerospikeClient client = new DefaultAerospikeClient(clientPolicy, hosts[0], port);
 
 			try {
 				if (writeKeys) {

--- a/client/src/com/aerospike/client/AerospikeClient.java
+++ b/client/src/com/aerospike/client/AerospikeClient.java
@@ -1,1043 +1,490 @@
-/*******************************************************************************
- * Copyright 2012-2014 by Aerospike.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to
- * deal in the Software without restriction, including without limitation the
- * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
- * sell copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
- * IN THE SOFTWARE.
- ******************************************************************************/
 package com.aerospike.client;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-
-import com.aerospike.client.Info.NameValueParser;
-import com.aerospike.client.cluster.Cluster;
-import com.aerospike.client.cluster.Connection;
 import com.aerospike.client.cluster.Node;
-import com.aerospike.client.command.BatchExecutor;
-import com.aerospike.client.command.Command;
-import com.aerospike.client.command.DeleteCommand;
-import com.aerospike.client.command.ExecuteCommand;
-import com.aerospike.client.command.ExistsCommand;
-import com.aerospike.client.command.OperateCommand;
-import com.aerospike.client.command.ReadCommand;
-import com.aerospike.client.command.ReadHeaderCommand;
-import com.aerospike.client.command.ScanCommand;
-import com.aerospike.client.command.ScanExecutor;
-import com.aerospike.client.command.TouchCommand;
-import com.aerospike.client.command.WriteCommand;
 import com.aerospike.client.large.LargeList;
 import com.aerospike.client.large.LargeMap;
 import com.aerospike.client.large.LargeSet;
 import com.aerospike.client.large.LargeStack;
-import com.aerospike.client.policy.ClientPolicy;
 import com.aerospike.client.policy.Policy;
 import com.aerospike.client.policy.QueryPolicy;
 import com.aerospike.client.policy.ScanPolicy;
 import com.aerospike.client.policy.WritePolicy;
 import com.aerospike.client.query.IndexType;
-import com.aerospike.client.query.QueryAggregateExecutor;
-import com.aerospike.client.query.QueryRecordExecutor;
 import com.aerospike.client.query.RecordSet;
 import com.aerospike.client.query.ResultSet;
-import com.aerospike.client.query.ServerExecutor;
 import com.aerospike.client.query.Statement;
 import com.aerospike.client.task.ExecuteTask;
 import com.aerospike.client.task.IndexTask;
 import com.aerospike.client.task.RegisterTask;
-import com.aerospike.client.util.Environment;
-import com.aerospike.client.util.Util;
 
-/**
- * Instantiate an <code>AerospikeClient</code> object to access an Aerospike
- * database cluster and perform database operations.
- * <p>
- * This client is thread-safe. One client instance should be used per cluster.
- * Multiple threads should share this cluster instance.
- * <p>
- * Your application uses this class API to perform database operations such as
- * writing and reading records, and selecting sets of records. Write operations
- * include specialized functionality such as append/prepend and arithmetic
- * addition.
- * <p>
- * Each record may have multiple bins, unless the Aerospike server nodes are
- * configured as "single-bin". In "multi-bin" mode, partial records may be
- * written or read by specifying the relevant subset of bins.
- */
-public class AerospikeClient {
-	//-------------------------------------------------------
-	// Member variables.
-	//-------------------------------------------------------
-	
-	protected Cluster cluster;
-	
-	//-------------------------------------------------------
-	// Constructors
-	//-------------------------------------------------------
+import java.util.List;
 
-	/**
-	 * Initialize Aerospike client.
-	 * If the host connection succeeds, the client will:
-	 * <p>
-	 * - Add host to the cluster map <br>
-	 * - Request host's list of other nodes in cluster <br>
-	 * - Add these nodes to cluster map <br>
-	 * <p>
-	 * If the connection succeeds, the client is ready to process database requests.
-	 * If the connection fails, the cluster will remain in a disconnected state
-	 * until the server is activated.
-	 * 
-	 * @param hostname				host name
-	 * @param port					host port
-	 * @throws AerospikeException	if host connection fails
-	 */
-	public AerospikeClient(String hostname, int port) throws AerospikeException {
-		this(new ClientPolicy(), new Host(hostname, port));
-	}
+public interface AerospikeClient {
+    /**
+     * Close all client connections to database server nodes.
+     */
+    void close();
 
-	/**
-	 * Initialize Aerospike client.
-	 * The client policy is used to set defaults and size internal data structures.
-	 * If the host connection succeeds, the client will:
-	 * <p>
-	 * - Add host to the cluster map <br>
-	 * - Request host's list of other nodes in cluster <br>
-	 * - Add these nodes to cluster map <br>
-	 * <p>
-	 * If the connection succeeds, the client is ready to process database requests.
-	 * If the connection fails and the policy's failOnInvalidHosts is true, a connection 
-	 * exception will be thrown. Otherwise, the cluster will remain in a disconnected state
-	 * until the server is activated.
-	 * 
-	 * @param policy				client configuration parameters, pass in null for defaults
-	 * @param hostname				host name
-	 * @param port					host port
-	 * @throws AerospikeException	if host connection fails
-	 */
-	public AerospikeClient(ClientPolicy policy, String hostname, int port) throws AerospikeException {
-		this(policy, new Host(hostname, port));
-	}
+    /**
+     * Determine if we are ready to talk to the database server cluster.
+     *
+     * @return	<code>true</code> if cluster is ready,
+     * 			<code>false</code> if cluster is not ready
+     */
+    boolean isConnected();
 
-	/**
-	 * Initialize Aerospike client with suitable hosts to seed the cluster map.
-	 * The client policy is used to set defaults and size internal data structures.
-	 * For each host connection that succeeds, the client will:
-	 * <p>
-	 * - Add host to the cluster map <br>
-	 * - Request host's list of other nodes in cluster <br>
-	 * - Add these nodes to cluster map <br>
-	 * <p>
-	 * In most cases, only one host is necessary to seed the cluster. The remaining hosts 
-	 * are added as future seeds in case of a complete network failure.
-	 * <p>
-	 * If one connection succeeds, the client is ready to process database requests.
-	 * If all connections fail and the policy's failIfNotConnected is true, a connection 
-	 * exception will be thrown. Otherwise, the cluster will remain in a disconnected state
-	 * until the server is activated.
-	 * 
-	 * @param policy				client configuration parameters, pass in null for defaults
-	 * @param hosts					array of potential hosts to seed the cluster
-	 * @throws AerospikeException	if all host connections fail
-	 */
-	public AerospikeClient(ClientPolicy policy, Host... hosts) throws AerospikeException {
-		if (policy == null) {
-			policy = new ClientPolicy();
-		}
-		cluster = new Cluster(policy, hosts);
-		cluster.initTendThread();
-		
-		if (policy.failIfNotConnected && ! cluster.isConnected()) {
-			throw new AerospikeException.Connection("Failed to connect to host(s): " + Arrays.toString(hosts));
-		}
-	}
+    /**
+     * Return array of active server nodes in the cluster.
+     *
+     * @return	array of active nodes
+     */
+    Node[] getNodes();
 
-	//-------------------------------------------------------
-	// Compatibility Layer Initialization
-	//-------------------------------------------------------
+    /**
+     * Return list of active server node names in the cluster.
+     *
+     * @return	list of active node names
+     */
+    List<String> getNodeNames();
 
-	/**
-	 * Compatibility layer constructor.  Do not use.
-	 */
-	protected AerospikeClient() {
-	}
-	
-	/**
-	 * Compatibility layer host initialization. Do not use.
-	 */
-	protected final void addServer(String hostname, int port) throws AerospikeException {
-		Host[] hosts = new Host[] {new Host(hostname, port)};
-		
-		// If cluster has already been initialized, add hosts to existing cluster.
-		if (cluster != null) {
-			cluster.addSeeds(hosts);
-			return;
-		}	
-		cluster = new Cluster(new ClientPolicy(), hosts);
-		cluster.initTendThread();
-	}
+    /**
+     * Write record bin(s).
+     * The policy specifies the transaction timeout, record expiration and how the transaction is
+     * handled when the record already exists.
+     *
+     * @param policy				write configuration parameters, pass in null for defaults
+     * @param key					unique record identifier
+     * @param bins					array of bin name/value pairs
+     * @throws com.aerospike.client.AerospikeException	if write fails
+     */
+    void put(WritePolicy policy, Key key, Bin... bins) throws AerospikeException;
 
-	//-------------------------------------------------------
-	// Cluster Connection Management
-	//-------------------------------------------------------
-		
-	/**
-	 * Close all client connections to database server nodes.
-	 */
-	public final void close() {
-		cluster.close();
-	}
+    /**
+     * Append bin string values to existing record bin values.
+     * The policy specifies the transaction timeout, record expiration and how the transaction is
+     * handled when the record already exists.
+     * This call only works for string values.
+     *
+     * @param policy				write configuration parameters, pass in null for defaults
+     * @param key					unique record identifier
+     * @param bins					array of bin name/value pairs
+     * @throws com.aerospike.client.AerospikeException	if append fails
+     */
+    void append(WritePolicy policy, Key key, Bin... bins) throws AerospikeException;
 
-	/**
-	 * Determine if we are ready to talk to the database server cluster.
-	 * 
-	 * @return	<code>true</code> if cluster is ready,
-	 * 			<code>false</code> if cluster is not ready
-	 */
-	public final boolean isConnected() {
-		return cluster.isConnected();
-	}
+    /**
+     * Prepend bin string values to existing record bin values.
+     * The policy specifies the transaction timeout, record expiration and how the transaction is
+     * handled when the record already exists.
+     * This call works only for string values.
+     *
+     * @param policy				write configuration parameters, pass in null for defaults
+     * @param key					unique record identifier
+     * @param bins					array of bin name/value pairs
+     * @throws com.aerospike.client.AerospikeException	if prepend fails
+     */
+    void prepend(WritePolicy policy, Key key, Bin... bins) throws AerospikeException;
 
-	/**
-	 * Return array of active server nodes in the cluster.
-	 * 
-	 * @return	array of active nodes
-	 */
-	public final Node[] getNodes() {
-		return cluster.getNodes();
-	}
+    /**
+     * Add integer bin values to existing record bin values.
+     * The policy specifies the transaction timeout, record expiration and how the transaction is
+     * handled when the record already exists.
+     * This call only works for integer values.
+     *
+     * @param policy				write configuration parameters, pass in null for defaults
+     * @param key					unique record identifier
+     * @param bins					array of bin name/value pairs
+     * @throws com.aerospike.client.AerospikeException	if add fails
+     */
+    void add(WritePolicy policy, Key key, Bin... bins) throws AerospikeException;
 
-	/**
-	 * Return list of active server node names in the cluster.
-	 * 
-	 * @return	list of active node names
-	 */
-	public final List<String> getNodeNames() {
-		Node[] nodes = cluster.getNodes();		
-		ArrayList<String> names = new ArrayList<String>(nodes.length);
-		
-		for (Node node : nodes) {
-			names.add(node.getName());
-		}
-		return names;
-	}
+    /**
+     * Delete record for specified key.
+     * The policy specifies the transaction timeout.
+     *
+     * @param policy				delete configuration parameters, pass in null for defaults
+     * @param key					unique record identifier
+     * @return						whether record existed on server before deletion
+     * @throws com.aerospike.client.AerospikeException	if delete fails
+     */
+    boolean delete(WritePolicy policy, Key key) throws AerospikeException;
 
-	//-------------------------------------------------------
-	// Write Record Operations
-	//-------------------------------------------------------
-	
-	/**
-	 * Write record bin(s).
-	 * The policy specifies the transaction timeout, record expiration and how the transaction is
-	 * handled when the record already exists.
-	 * 
-	 * @param policy				write configuration parameters, pass in null for defaults
-	 * @param key					unique record identifier
-	 * @param bins					array of bin name/value pairs
-	 * @throws AerospikeException	if write fails
-	 */
-	public final void put(WritePolicy policy, Key key, Bin... bins) throws AerospikeException {
-		WriteCommand command = new WriteCommand(cluster, policy, key, bins, Operation.Type.WRITE);
-		command.execute();
-	}
+    /**
+     * Create record if it does not already exist.  If the record exists, the record's
+     * time to expiration will be reset to the policy's expiration.
+     *
+     * @param policy				write configuration parameters, pass in null for defaults
+     * @param key					unique record identifier
+     * @throws com.aerospike.client.AerospikeException	if touch fails
+     */
+    void touch(WritePolicy policy, Key key) throws AerospikeException;
 
-	//-------------------------------------------------------
-	// String Operations
-	//-------------------------------------------------------
-	
-	/**
-	 * Append bin string values to existing record bin values.
-	 * The policy specifies the transaction timeout, record expiration and how the transaction is
-	 * handled when the record already exists.
-	 * This call only works for string values. 
-	 * 
-	 * @param policy				write configuration parameters, pass in null for defaults
-	 * @param key					unique record identifier
-	 * @param bins					array of bin name/value pairs
-	 * @throws AerospikeException	if append fails
-	 */
-	public final void append(WritePolicy policy, Key key, Bin... bins) throws AerospikeException {
-		WriteCommand command = new WriteCommand(cluster, policy, key, bins, Operation.Type.APPEND);
-		command.execute();
-	}
-	
-	/**
-	 * Prepend bin string values to existing record bin values.
-	 * The policy specifies the transaction timeout, record expiration and how the transaction is
-	 * handled when the record already exists.
-	 * This call works only for string values. 
-	 * 
-	 * @param policy				write configuration parameters, pass in null for defaults
-	 * @param key					unique record identifier
-	 * @param bins					array of bin name/value pairs
-	 * @throws AerospikeException	if prepend fails
-	 */
-	public final void prepend(WritePolicy policy, Key key, Bin... bins) throws AerospikeException {
-		WriteCommand command = new WriteCommand(cluster, policy, key, bins, Operation.Type.PREPEND);
-		command.execute();
-	}
+    /**
+     * Determine if a record key exists.
+     * The policy can be used to specify timeouts.
+     *
+     * @param policy				generic configuration parameters, pass in null for defaults
+     * @param key					unique record identifier
+     * @return						whether record exists or not
+     * @throws com.aerospike.client.AerospikeException	if command fails
+     */
+    boolean exists(Policy policy, Key key) throws AerospikeException;
 
-	//-------------------------------------------------------
-	// Arithmetic Operations
-	//-------------------------------------------------------
-	
-	/**
-	 * Add integer bin values to existing record bin values.
-	 * The policy specifies the transaction timeout, record expiration and how the transaction is
-	 * handled when the record already exists.
-	 * This call only works for integer values. 
-	 * 
-	 * @param policy				write configuration parameters, pass in null for defaults
-	 * @param key					unique record identifier
-	 * @param bins					array of bin name/value pairs
-	 * @throws AerospikeException	if add fails
-	 */
-	public final void add(WritePolicy policy, Key key, Bin... bins) throws AerospikeException {
-		WriteCommand command = new WriteCommand(cluster, policy, key, bins, Operation.Type.ADD);
-		command.execute();
-	}
+    /**
+     * Check if multiple record keys exist in one batch call.
+     * The returned boolean array is in positional order with the original key array order.
+     * The policy can be used to specify timeouts.
+     *
+     * @param policy				generic configuration parameters, pass in null for defaults
+     * @param keys					array of unique record identifiers
+     * @return						array key/existence status pairs
+     * @throws com.aerospike.client.AerospikeException	if command fails
+     */
+    boolean[] exists(Policy policy, Key[] keys) throws AerospikeException;
 
-	//-------------------------------------------------------
-	// Delete Operations
-	//-------------------------------------------------------
+    /**
+     * Read entire record for specified key.
+     * The policy can be used to specify timeouts.
+     *
+     * @param policy				generic configuration parameters, pass in null for defaults
+     * @param key					unique record identifier
+     * @return						if found, return record instance.  If not found, return null.
+     * @throws com.aerospike.client.AerospikeException	if read fails
+     */
+    Record get(Policy policy, Key key) throws AerospikeException;
 
-	/**
-	 * Delete record for specified key.
-	 * The policy specifies the transaction timeout.
-	 * 
-	 * @param policy				delete configuration parameters, pass in null for defaults
-	 * @param key					unique record identifier
-	 * @return						whether record existed on server before deletion 
-	 * @throws AerospikeException	if delete fails
-	 */
-	public final boolean delete(WritePolicy policy, Key key) throws AerospikeException {
-		DeleteCommand command = new DeleteCommand(cluster, policy, key);
-		command.execute();
-		return command.existed();
-	}
+    /**
+     * Read record header and bins for specified key.
+     * The policy can be used to specify timeouts.
+     *
+     * @param policy				generic configuration parameters, pass in null for defaults
+     * @param key					unique record identifier
+     * @param binNames				bins to retrieve
+     * @return						if found, return record instance.  If not found, return null.
+     * @throws com.aerospike.client.AerospikeException	if read fails
+     */
+    Record get(Policy policy, Key key, String... binNames) throws AerospikeException;
 
-	//-------------------------------------------------------
-	// Touch Operations
-	//-------------------------------------------------------
+    /**
+     * Read record generation and expiration only for specified key.  Bins are not read.
+     * The policy can be used to specify timeouts.
+     *
+     * @param policy				generic configuration parameters, pass in null for defaults
+     * @param key					unique record identifier
+     * @return						if found, return record instance.  If not found, return null.
+     * @throws com.aerospike.client.AerospikeException	if read fails
+     */
+    Record getHeader(Policy policy, Key key) throws AerospikeException;
 
-	/**
-	 * Create record if it does not already exist.  If the record exists, the record's 
-	 * time to expiration will be reset to the policy's expiration. 
-	 * 
-	 * @param policy				write configuration parameters, pass in null for defaults
-	 * @param key					unique record identifier
-	 * @throws AerospikeException	if touch fails
-	 */
-	public final void touch(WritePolicy policy, Key key) throws AerospikeException {
-		TouchCommand command = new TouchCommand(cluster, policy, key);
-		command.execute();
-	}
+    /**
+     * Read multiple records for specified keys in one batch call.
+     * The returned records are in positional order with the original key array order.
+     * If a key is not found, the positional record will be null.
+     * The policy can be used to specify timeouts.
+     *
+     * @param policy				generic configuration parameters, pass in null for defaults
+     * @param keys					array of unique record identifiers
+     * @return						array of records
+     * @throws com.aerospike.client.AerospikeException	if read fails
+     */
+    Record[] get(Policy policy, Key[] keys) throws AerospikeException;
 
-	//-------------------------------------------------------
-	// Existence-Check Operations
-	//-------------------------------------------------------
+    /**
+     * Read multiple record headers and bins for specified keys in one batch call.
+     * The returned records are in positional order with the original key array order.
+     * If a key is not found, the positional record will be null.
+     * The policy can be used to specify timeouts.
+     *
+     * @param policy				generic configuration parameters, pass in null for defaults
+     * @param keys					array of unique record identifiers
+     * @param binNames				array of bins to retrieve
+     * @return						array of records
+     * @throws com.aerospike.client.AerospikeException	if read fails
+     */
+    Record[] get(Policy policy, Key[] keys, String... binNames)
+        throws AerospikeException;
 
-	/**
-	 * Determine if a record key exists.
-	 * The policy can be used to specify timeouts.
-	 * 
-	 * @param policy				generic configuration parameters, pass in null for defaults
-	 * @param key					unique record identifier
-	 * @return						whether record exists or not 
-	 * @throws AerospikeException	if command fails
-	 */
-	public final boolean exists(Policy policy, Key key) throws AerospikeException {
-		ExistsCommand command = new ExistsCommand(cluster, policy, key);
-		command.execute();
-		return command.exists();
-	}
+    /**
+     * Read multiple record header data for specified keys in one batch call.
+     * The returned records are in positional order with the original key array order.
+     * If a key is not found, the positional record will be null.
+     * The policy can be used to specify timeouts.
+     *
+     * @param policy				generic configuration parameters, pass in null for defaults
+     * @param keys					array of unique record identifiers
+     * @return						array of records
+     * @throws com.aerospike.client.AerospikeException	if read fails
+     */
+    Record[] getHeader(Policy policy, Key[] keys) throws AerospikeException;
 
-	/**
-	 * Check if multiple record keys exist in one batch call.
-	 * The returned boolean array is in positional order with the original key array order.
-	 * The policy can be used to specify timeouts.
-	 *  
-	 * @param policy				generic configuration parameters, pass in null for defaults
-	 * @param keys					array of unique record identifiers
-	 * @return						array key/existence status pairs
-	 * @throws AerospikeException	if command fails
-	 */
-	public final boolean[] exists(Policy policy, Key[] keys) throws AerospikeException {
-		boolean[] existsArray = new boolean[keys.length];
-		new BatchExecutor(cluster, policy, keys, existsArray, null, null, Command.INFO1_READ | Command.INFO1_NOBINDATA);
-		return existsArray;
-	}
+    /**
+     * Perform multiple read/write operations on a single key in one batch call.
+     * An example would be to add an integer value to an existing record and then
+     * read the result, all in one database call.
+     * <p>
+     * Write operations are always performed first, regardless of operation order
+     * relative to read operations.
+     *
+     * @param policy				write configuration parameters, pass in null for defaults
+     * @param key					unique record identifier
+     * @param operations			database operations to perform
+     * @return						record if there is a read in the operations list
+     * @throws com.aerospike.client.AerospikeException	if command fails
+     */
+    Record operate(WritePolicy policy, Key key, Operation... operations)
+        throws AerospikeException;
 
-	//-------------------------------------------------------
-	// Read Record Operations
-	//-------------------------------------------------------
+    /**
+     * Read all records in specified namespace and set.  If the policy's
+     * <code>concurrentNodes</code> is specified, each server node will be read in
+     * parallel.  Otherwise, server nodes are read in series.
+     * <p>
+     * This call will block until the scan is complete - callbacks are made
+     * within the scope of this call.
+     *
+     * @param policy				scan configuration parameters, pass in null for defaults
+     * @param namespace				namespace - equivalent to database name
+     * @param setName				optional set name - equivalent to database table
+     * @param callback				read callback method - called with record data
+     * @param binNames				optional bin to retrieve. All bins will be returned if not specified.
+     * 								Aerospike 2 servers ignore this parameter.
+     * @throws com.aerospike.client.AerospikeException	if scan fails
+     */
+    void scanAll(ScanPolicy policy, String namespace, String setName, ScanCallback callback, String... binNames)
+        throws AerospikeException;
 
-	/**
-	 * Read entire record for specified key.
-	 * The policy can be used to specify timeouts.
-	 * 
-	 * @param policy				generic configuration parameters, pass in null for defaults
-	 * @param key					unique record identifier
-	 * @return						if found, return record instance.  If not found, return null.
-	 * @throws AerospikeException	if read fails
-	 */
-	public final Record get(Policy policy, Key key) throws AerospikeException {
-		ReadCommand command = new ReadCommand(cluster, policy, key, null);
-		command.execute();
-		return command.getRecord();
-	}
+    /**
+     * Read all records in specified namespace and set for one node only.
+     * The node is specified by name.
+     * <p>
+     * This call will block until the scan is complete - callbacks are made
+     * within the scope of this call.
+     *
+     * @param policy				scan configuration parameters, pass in null for defaults
+     * @param nodeName				server node name
+     * @param namespace				namespace - equivalent to database name
+     * @param setName				optional set name - equivalent to database table
+     * @param callback				read callback method - called with record data
+     * @param binNames				optional bin to retrieve. All bins will be returned if not specified.
+     * 								Aerospike 2 servers ignore this parameter.
+     * @throws com.aerospike.client.AerospikeException	if scan fails
+     */
+    void scanNode(ScanPolicy policy, String nodeName, String namespace, String setName, ScanCallback callback, String... binNames)
+        throws AerospikeException;
 
-	/**
-	 * Read record header and bins for specified key.
-	 * The policy can be used to specify timeouts.
-	 * 
-	 * @param policy				generic configuration parameters, pass in null for defaults
-	 * @param key					unique record identifier
-	 * @param binNames				bins to retrieve
-	 * @return						if found, return record instance.  If not found, return null.
-	 * @throws AerospikeException	if read fails
-	 */
-	public final Record get(Policy policy, Key key, String... binNames) throws AerospikeException {	
-		ReadCommand command = new ReadCommand(cluster, policy, key, binNames);
-		command.execute();
-		return command.getRecord();
-	}
+    /**
+     * Read all records in specified namespace and set for one node only.
+     * <p>
+     * This call will block until the scan is complete - callbacks are made
+     * within the scope of this call.
+     *
+     * @param policy				scan configuration parameters, pass in null for defaults
+     * @param node					server node
+     * @param namespace				namespace - equivalent to database name
+     * @param setName				optional set name - equivalent to database table
+     * @param callback				read callback method - called with record data
+     * @param binNames				optional bin to retrieve. All bins will be returned if not specified.
+     * 								Aerospike 2 servers ignore this parameter.
+     * @throws com.aerospike.client.AerospikeException	if transaction fails
+     */
+    void scanNode(ScanPolicy policy, Node node, String namespace, String setName, ScanCallback callback, String... binNames)
+        throws AerospikeException;
 
-	/**
-	 * Read record generation and expiration only for specified key.  Bins are not read.
-	 * The policy can be used to specify timeouts.
-	 * 
-	 * @param policy				generic configuration parameters, pass in null for defaults
-	 * @param key					unique record identifier
-	 * @return						if found, return record instance.  If not found, return null.
-	 * @throws AerospikeException	if read fails
-	 */
-	public final Record getHeader(Policy policy, Key key) throws AerospikeException {
-		ReadHeaderCommand command = new ReadHeaderCommand(cluster, policy, key);
-		command.execute();
-		return command.getRecord();
-	}
+    /**
+     * Initialize large list operator.  This operator can be used to create and manage a list
+     * within a single bin.
+     * <p>
+     * This method is only supported by Aerospike 3 servers.
+     *
+     * @param policy				generic configuration parameters, pass in null for defaults
+     * @param key					unique record identifier
+     * @param binName				bin name
+     * @param userModule			Lua function name that initializes list configuration parameters, pass null for default
+     */
+    LargeList getLargeList(Policy policy, Key key, String binName, String userModule);
 
-	//-------------------------------------------------------
-	// Batch Read Operations
-	//-------------------------------------------------------
+    /**
+     * Initialize large map operator.  This operator can be used to create and manage a map
+     * within a single bin.
+     * <p>
+     * This method is only supported by Aerospike 3 servers.
+     *
+     * @param policy				generic configuration parameters, pass in null for defaults
+     * @param key					unique record identifier
+     * @param binName				bin name
+     * @param userModule			Lua function name that initializes list configuration parameters, pass null for default
+     */
+    LargeMap getLargeMap(Policy policy, Key key, String binName, String userModule);
 
-	/**
-	 * Read multiple records for specified keys in one batch call.
-	 * The returned records are in positional order with the original key array order.
-	 * If a key is not found, the positional record will be null.
-	 * The policy can be used to specify timeouts.
-	 * 
-	 * @param policy				generic configuration parameters, pass in null for defaults
-	 * @param keys					array of unique record identifiers
-	 * @return						array of records
-	 * @throws AerospikeException	if read fails
-	 */
-	public final Record[] get(Policy policy, Key[] keys) throws AerospikeException {
-		Record[] records = new Record[keys.length];
-		new BatchExecutor(cluster, policy, keys, null, records, null, Command.INFO1_READ | Command.INFO1_GET_ALL);
-		return records;
-	}
+    /**
+     * Initialize large set operator.  This operator can be used to create and manage a set
+     * within a single bin.
+     * <p>
+     * This method is only supported by Aerospike 3 servers.
+     *
+     * @param policy				generic configuration parameters, pass in null for defaults
+     * @param key					unique record identifier
+     * @param binName				bin name
+     * @param userModule			Lua function name that initializes list configuration parameters, pass null for default
+     */
+    LargeSet getLargeSet(Policy policy, Key key, String binName, String userModule);
 
-	/**
-	 * Read multiple record headers and bins for specified keys in one batch call.
-	 * The returned records are in positional order with the original key array order.
-	 * If a key is not found, the positional record will be null.
-	 * The policy can be used to specify timeouts.
-	 * 
-	 * @param policy				generic configuration parameters, pass in null for defaults
-	 * @param keys					array of unique record identifiers
-	 * @param binNames				array of bins to retrieve
-	 * @return						array of records
-	 * @throws AerospikeException	if read fails
-	 */
-	public final Record[] get(Policy policy, Key[] keys, String... binNames) 
-		throws AerospikeException {
-		Record[] records = new Record[keys.length];
-		HashSet<String> names = binNamesToHashSet(binNames);
-		new BatchExecutor(cluster, policy, keys, null, records, names, Command.INFO1_READ);
-		return records;
-	}
+    /**
+     * Initialize large stack operator.  This operator can be used to create and manage a stack
+     * within a single bin.
+     * <p>
+     * This method is only supported by Aerospike 3 servers.
+     *
+     * @param policy				generic configuration parameters, pass in null for defaults
+     * @param key					unique record identifier
+     * @param binName				bin name
+     * @param userModule			Lua function name that initializes list configuration parameters, pass null for default
+     */
+    LargeStack getLargeStack(Policy policy, Key key, String binName, String userModule);
 
-	/**
-	 * Read multiple record header data for specified keys in one batch call.
-	 * The returned records are in positional order with the original key array order.
-	 * If a key is not found, the positional record will be null.
-	 * The policy can be used to specify timeouts.
-	 * 
-	 * @param policy				generic configuration parameters, pass in null for defaults
-	 * @param keys					array of unique record identifiers
-	 * @return						array of records
-	 * @throws AerospikeException	if read fails
-	 */
-	public final Record[] getHeader(Policy policy, Key[] keys) throws AerospikeException {
-		Record[] records = new Record[keys.length];
-		new BatchExecutor(cluster, policy, keys, null, records, null, Command.INFO1_READ | Command.INFO1_NOBINDATA);
-		return records;
-	}
+    /**
+     * Register package containing user defined functions with server.
+     * This asynchronous server call will return before command is complete.
+     * The user can optionally wait for command completion by using the returned
+     * RegisterTask instance.
+     * <p>
+     * This method is only supported by Aerospike 3 servers.
+     *
+     * @param policy				generic configuration parameters, pass in null for defaults
+     * @param clientPath			path of client file containing user defined functions, relative to current directory
+     * @param serverPath			path to store user defined functions on the server, relative to configured script directory.
+     * @param language				language of user defined functions
+     * @throws com.aerospike.client.AerospikeException	if register fails
+     */
+    RegisterTask register(Policy policy, String clientPath, String serverPath, Language language)
+        throws AerospikeException;
 
-	//-------------------------------------------------------
-	// Generic Database Operations
-	//-------------------------------------------------------
+    /**
+     * Execute user defined function on server and return results.
+     * The function operates on a single record.
+     * The package name is used to locate the udf file location:
+     * <p>
+     * udf file = <server udf dir>/<package name>.lua
+     * <p>
+     * This method is only supported by Aerospike 3 servers.
+     *
+     * @param policy				generic configuration parameters, pass in null for defaults
+     * @param key					unique record identifier
+     * @param packageName			server package name where user defined function resides
+     * @param functionName			user defined function
+     * @param args					arguments passed in to user defined function
+     * @return						return value of user defined function
+     * @throws com.aerospike.client.AerospikeException	if transaction fails
+     */
+    Object execute(Policy policy, Key key, String packageName, String functionName, Value... args)
+        throws AerospikeException;
 
-	/**
-	 * Perform multiple read/write operations on a single key in one batch call.
-	 * An example would be to add an integer value to an existing record and then
-	 * read the result, all in one database call.
-	 * <p>
-	 * Write operations are always performed first, regardless of operation order 
-	 * relative to read operations.
-	 * 
-	 * @param policy				write configuration parameters, pass in null for defaults
-	 * @param key					unique record identifier
-	 * @param operations			database operations to perform
-	 * @return						record if there is a read in the operations list
-	 * @throws AerospikeException	if command fails
-	 */
-	public final Record operate(WritePolicy policy, Key key, Operation... operations) 
-		throws AerospikeException {		
-		OperateCommand command = new OperateCommand(cluster, policy, key, operations);
-		command.execute();
-		return command.getRecord();
-	}
+    /**
+     * Apply user defined function on records that match the statement filter.
+     * Records are not returned to the client.
+     * This asynchronous server call will return before command is complete.
+     * The user can optionally wait for command completion by using the returned
+     * ExecuteTask instance.
+     * <p>
+     * This method is only supported by Aerospike 3 servers.
+     *
+     * @param policy				scan configuration parameters, pass in null for defaults
+     * @param statement				record filter
+     * @param packageName			server package where user defined function resides
+     * @param functionName			function name
+     * @param functionArgs			to pass to function name, if any
+     * @throws com.aerospike.client.AerospikeException	if command fails
+     */
+    ExecuteTask execute(
+            Policy policy,
+            Statement statement,
+            String packageName,
+            String functionName,
+            Value... functionArgs
+    ) throws AerospikeException;
 
-	//-------------------------------------------------------
-	// Scan Operations
-	//-------------------------------------------------------
-	
-	/**
-	 * Read all records in specified namespace and set.  If the policy's 
-	 * <code>concurrentNodes</code> is specified, each server node will be read in
-	 * parallel.  Otherwise, server nodes are read in series.
-	 * <p>
-	 * This call will block until the scan is complete - callbacks are made
-	 * within the scope of this call.
-	 * 
-	 * @param policy				scan configuration parameters, pass in null for defaults
-	 * @param namespace				namespace - equivalent to database name
-	 * @param setName				optional set name - equivalent to database table
-	 * @param callback				read callback method - called with record data
-	 * @param binNames				optional bin to retrieve. All bins will be returned if not specified.
-	 * 								Aerospike 2 servers ignore this parameter.
-	 * @throws AerospikeException	if scan fails
-	 */
-	public final void scanAll(ScanPolicy policy, String namespace, String setName, ScanCallback callback, String... binNames)
-		throws AerospikeException {	
-		if (policy == null) {
-			policy = new ScanPolicy();
-		}
-		// Retry policy must be one-shot for scans.
-		policy.maxRetries = 0;
-		
-		Node[] nodes = cluster.getNodes();		
-		if (nodes.length == 0) {
-			throw new AerospikeException(ResultCode.SERVER_NOT_AVAILABLE, "Scan failed because cluster is empty.");
-		}
+    /**
+     * Execute query and return record iterator.  The query executor puts records on a queue in
+     * separate threads.  The calling thread concurrently pops records off the queue through the
+     * record iterator.
+     * <p>
+     * This method is only supported by Aerospike 3 servers.
+     *
+     * @param policy				generic configuration parameters, pass in null for defaults
+     * @param statement				database query command
+     * @return						record iterator
+     * @throws com.aerospike.client.AerospikeException	if query fails
+     */
+    RecordSet query(QueryPolicy policy, Statement statement) throws AerospikeException;
 
-		if (policy.concurrentNodes) {
-			ScanExecutor executor = new ScanExecutor(cluster, nodes, policy, namespace, setName, callback, binNames);
-			executor.scanParallel();
-		}
-		else {
-			for (Node node : nodes) {
-				scanNode(policy, node, namespace, setName, callback, binNames);
-			}
-		}
-	}
+    /**
+     * Execute query, apply statement's aggregation function, and return result iterator. The query
+     * executor puts results on a queue in separate threads.  The calling thread concurrently pops
+     * results off the queue through the result iterator.
+     * <p>
+     * The aggregation function is called on both server and client (final reduce).  Therefore,
+     * the Lua script files must also reside on both server and client.
+     * The package name is used to locate the udf file location:
+     * <p>
+     * udf file = <udf dir>/<package name>.lua
+     * <p>
+     * This method is only supported by Aerospike 3 servers.
+     *
+     * @param policy				generic configuration parameters, pass in null for defaults
+     * @param statement				database query command
+     * @param packageName			server package where user defined function resides
+     * @param functionName			aggregation function name
+     * @param functionArgs			arguments to pass to function name, if any
+     * @return						result iterator
+     * @throws com.aerospike.client.AerospikeException	if query fails
+     */
+    ResultSet queryAggregate(
+            QueryPolicy policy,
+            Statement statement,
+            String packageName,
+            String functionName,
+            Value... functionArgs
+    ) throws AerospikeException;
 
-	/**
-	 * Read all records in specified namespace and set for one node only.
-	 * The node is specified by name.
-	 * <p>
-	 * This call will block until the scan is complete - callbacks are made
-	 * within the scope of this call.
-	 * 
-	 * @param policy				scan configuration parameters, pass in null for defaults
-	 * @param nodeName				server node name
-	 * @param namespace				namespace - equivalent to database name
-	 * @param setName				optional set name - equivalent to database table
-	 * @param callback				read callback method - called with record data
-	 * @param binNames				optional bin to retrieve. All bins will be returned if not specified.  
-	 * 								Aerospike 2 servers ignore this parameter.
-	 * @throws AerospikeException	if scan fails
-	 */
-	public final void scanNode(ScanPolicy policy, String nodeName, String namespace, String setName, ScanCallback callback, String... binNames) 
-		throws AerospikeException {		
-		Node node = cluster.getNode(nodeName);
-		scanNode(policy, node, namespace, setName, callback, binNames);
-	}
+    /**
+     * Create secondary index.
+     * This asynchronous server call will return before command is complete.
+     * The user can optionally wait for command completion by using the returned
+     * IndexTask instance.
+     * <p>
+     * This method is only supported by Aerospike 3 servers.
+     *
+     * @param policy				generic configuration parameters, pass in null for defaults
+     * @param namespace				namespace - equivalent to database name
+     * @param setName				optional set name - equivalent to database table
+     * @param indexName				name of secondary index
+     * @param binName				bin name that data is indexed on
+     * @param indexType				type of secondary index
+     * @throws com.aerospike.client.AerospikeException	if index create fails
+     */
+    IndexTask createIndex(
+            Policy policy,
+            String namespace,
+            String setName,
+            String indexName,
+            String binName,
+            IndexType indexType
+    ) throws AerospikeException;
 
-	/**
-	 * Read all records in specified namespace and set for one node only.
-	 * <p>
-	 * This call will block until the scan is complete - callbacks are made
-	 * within the scope of this call.
-	 * 
-	 * @param policy				scan configuration parameters, pass in null for defaults
-	 * @param node					server node
-	 * @param namespace				namespace - equivalent to database name
-	 * @param setName				optional set name - equivalent to database table
-	 * @param callback				read callback method - called with record data
-	 * @param binNames				optional bin to retrieve. All bins will be returned if not specified.  
-	 * 								Aerospike 2 servers ignore this parameter.
-	 * @throws AerospikeException	if transaction fails
-	 */
-	public final void scanNode(ScanPolicy policy, Node node, String namespace, String setName, ScanCallback callback, String... binNames) 
-		throws AerospikeException {
-		if (policy == null) {
-			policy = new ScanPolicy();
-		}
-		// Retry policy must be one-shot for scans.
-		policy.maxRetries = 0;
-
-		ScanCommand command = new ScanCommand(node, policy, namespace, setName, callback, binNames);
-		command.execute();
-	}
-
-	//-------------------------------------------------------------------
-	// Large collection functions (Supported by Aerospike 3 servers only)
-	//-------------------------------------------------------------------
-
-	/**
-	 * Initialize large list operator.  This operator can be used to create and manage a list 
-	 * within a single bin.
-	 * <p>
-	 * This method is only supported by Aerospike 3 servers.
-	 * 
-	 * @param policy				generic configuration parameters, pass in null for defaults
-	 * @param key					unique record identifier
-	 * @param binName				bin name
-	 * @param userModule			Lua function name that initializes list configuration parameters, pass null for default
-	 */
-	public final LargeList getLargeList(Policy policy, Key key, String binName, String userModule) {
-		return new LargeList(this, policy, key, binName, userModule);
-	}	
-
-	/**
-	 * Initialize large map operator.  This operator can be used to create and manage a map 
-	 * within a single bin.
-	 * <p>
-	 * This method is only supported by Aerospike 3 servers.
-	 * 
-	 * @param policy				generic configuration parameters, pass in null for defaults
-	 * @param key					unique record identifier
-	 * @param binName				bin name
-	 * @param userModule			Lua function name that initializes list configuration parameters, pass null for default
-	 */
-	public final LargeMap getLargeMap(Policy policy, Key key, String binName, String userModule) {
-		return new LargeMap(this, policy, key, binName, userModule);
-	}	
-
-	/**
-	 * Initialize large set operator.  This operator can be used to create and manage a set 
-	 * within a single bin.
-	 * <p>
-	 * This method is only supported by Aerospike 3 servers.
-	 * 
-	 * @param policy				generic configuration parameters, pass in null for defaults
-	 * @param key					unique record identifier
-	 * @param binName				bin name
-	 * @param userModule			Lua function name that initializes list configuration parameters, pass null for default
-	 */
-	public final LargeSet getLargeSet(Policy policy, Key key, String binName, String userModule) {
-		return new LargeSet(this, policy, key, binName, userModule);
-	}	
-
-	/**
-	 * Initialize large stack operator.  This operator can be used to create and manage a stack 
-	 * within a single bin.
-	 * <p>
-	 * This method is only supported by Aerospike 3 servers.
-	 * 
-	 * @param policy				generic configuration parameters, pass in null for defaults
-	 * @param key					unique record identifier
-	 * @param binName				bin name
-	 * @param userModule			Lua function name that initializes list configuration parameters, pass null for default
-	 */
-	public final LargeStack getLargeStack(Policy policy, Key key, String binName, String userModule) {
-		return new LargeStack(this, policy, key, binName, userModule);
-	}	
-
-	//---------------------------------------------------------------
-	// User defined functions (Supported by Aerospike 3 servers only)
-	//---------------------------------------------------------------
-	
-	/**
-	 * Register package containing user defined functions with server.
-	 * This asynchronous server call will return before command is complete.
-	 * The user can optionally wait for command completion by using the returned
-	 * RegisterTask instance.
-	 * <p>
-	 * This method is only supported by Aerospike 3 servers.
-	 * 
-	 * @param policy				generic configuration parameters, pass in null for defaults
-	 * @param clientPath			path of client file containing user defined functions, relative to current directory
-	 * @param serverPath			path to store user defined functions on the server, relative to configured script directory.
-	 * @param language				language of user defined functions
-	 * @throws AerospikeException	if register fails
-	 */
-	public final RegisterTask register(Policy policy, String clientPath, String serverPath, Language language) 
-		throws AerospikeException {
-		
-		String content = Util.readFileEncodeBase64(clientPath);
-		
-		StringBuilder sb = new StringBuilder(serverPath.length() + content.length() + 100);
-		sb.append("udf-put:filename=");
-		sb.append(serverPath);
-		sb.append(";content=");
-		sb.append(content);
-		sb.append(";content-len=");
-		sb.append(content.length());
-		sb.append(";udf-type=");
-		sb.append(language);
-		sb.append(";");
-		
-		// Send UDF to one node. That node will distribute the UDF to other nodes.
-		String command = sb.toString();
-		Node node = cluster.getRandomNode();
-		int timeout = (policy == null)? 0 : policy.timeout;
-		Connection conn = node.getConnection(timeout);
-		
-		try {			
-			Info info = new Info(conn, command);
-			NameValueParser parser = info.getNameValueParser();
-			String error = null;
-			String file = null;
-			String line = null;
-			String message = null;
-			
-			while (parser.next()) {
-				String name = parser.getName();
-
-				if (name.equals("error")) {
-					error = parser.getValue();
-				}
-				else if (name.equals("file")) {
-					file = parser.getValue();				
-				}
-				else if (name.equals("line")) {
-					line = parser.getValue();				
-				}
-				else if (name.equals("message")) {
-					message = parser.getStringBase64();					
-				}
-			}
-			
-			if (error != null) {			
-				throw new AerospikeException("Registration failed: " + error + Environment.Newline +
-					"File: " + file + Environment.Newline + 
-					"Line: " + line + Environment.Newline +
-					"Message: " + message
-					);
-			}
-			
-			node.putConnection(conn);
-			return new RegisterTask(cluster, serverPath);
-		}
-		catch (AerospikeException ae) {
-			conn.close();
-			throw ae;
-		}
-		catch (RuntimeException re) {
-			conn.close();
-			throw new AerospikeException(re);
-		}
-	}
-	
-	/**
-	 * Execute user defined function on server and return results.
-	 * The function operates on a single record.
-	 * The package name is used to locate the udf file location:
-	 * <p>
-	 * udf file = <server udf dir>/<package name>.lua
-	 * <p>
-	 * This method is only supported by Aerospike 3 servers.
-	 * 
-	 * @param policy				generic configuration parameters, pass in null for defaults
-	 * @param key					unique record identifier
-	 * @param packageName			server package name where user defined function resides
-	 * @param functionName			user defined function
-	 * @param args					arguments passed in to user defined function
-	 * @return						return value of user defined function
-	 * @throws AerospikeException	if transaction fails
-	 */
-	public final Object execute(Policy policy, Key key, String packageName, String functionName, Value... args) 
-		throws AerospikeException {
-		ExecuteCommand command = new ExecuteCommand(cluster, policy, key, packageName, functionName, args);
-		command.execute();
-		
-		Record record = command.getRecord();
-		
-		if (record == null || record.bins == null) {
-			return null;
-		}
-		
-		Map<String,Object> map = record.bins;
-
-		Object obj = map.get("SUCCESS");
-		
-		if (obj != null) {
-			return obj;
-		}
-		
-		// User defined functions don't have to return a value.
-		if (map.containsKey("SUCCESS")) {
-			return null;
-		}
-		
-		obj = map.get("FAILURE");
-		
-		if (obj != null) {
-			throw new AerospikeException(obj.toString());
-		}
-		throw new AerospikeException("Invalid UDF return value");
-	}
-	
-	//----------------------------------------------------------
-	// Query/Execute UDF (Supported by Aerospike 3 servers only)
-	//----------------------------------------------------------
-
-	/**
-	 * Apply user defined function on records that match the statement filter.
-	 * Records are not returned to the client.
-	 * This asynchronous server call will return before command is complete.
-	 * The user can optionally wait for command completion by using the returned
-	 * ExecuteTask instance.
-	 * <p>
-	 * This method is only supported by Aerospike 3 servers.
-	 * 
-	 * @param policy				scan configuration parameters, pass in null for defaults
-	 * @param statement				record filter
-	 * @param packageName			server package where user defined function resides
-	 * @param functionName			function name
-	 * @param functionArgs			to pass to function name, if any
-	 * @throws AerospikeException	if command fails
-	 */
-	public final ExecuteTask execute(
-		Policy policy,
-		Statement statement,
-		String packageName,
-		String functionName,
-		Value... functionArgs
-	) throws AerospikeException {
-		if (policy == null) {
-			policy = new Policy();
-		}
-		new ServerExecutor(cluster, policy, statement, packageName, functionName, functionArgs);
-		return new ExecuteTask(cluster, statement);
-	}
-
-	//--------------------------------------------------------
-	// Query functions (Supported by Aerospike 3 servers only)
-	//--------------------------------------------------------
-
-	/**
-	 * Execute query and return record iterator.  The query executor puts records on a queue in 
-	 * separate threads.  The calling thread concurrently pops records off the queue through the 
-	 * record iterator.
-	 * <p>
-	 * This method is only supported by Aerospike 3 servers.
-	 * 
-	 * @param policy				generic configuration parameters, pass in null for defaults
-	 * @param statement				database query command
-	 * @return						record iterator
-	 * @throws AerospikeException	if query fails
-	 */
-	public final RecordSet query(QueryPolicy policy, Statement statement) throws AerospikeException {
-		if (policy == null) {
-			policy = new QueryPolicy();
-		}
-		QueryRecordExecutor executor = new QueryRecordExecutor(cluster, policy, statement);
-		executor.execute();
-		return executor.getRecordSet();
-	}
-	
-	/**
-	 * Execute query, apply statement's aggregation function, and return result iterator. The query 
-	 * executor puts results on a queue in separate threads.  The calling thread concurrently pops 
-	 * results off the queue through the result iterator.
-	 * <p>
-	 * The aggregation function is called on both server and client (final reduce).  Therefore,
-	 * the Lua script files must also reside on both server and client.
-	 * The package name is used to locate the udf file location:
-	 * <p>
-	 * udf file = <udf dir>/<package name>.lua
-	 * <p>
-	 * This method is only supported by Aerospike 3 servers.
-	 * 
-	 * @param policy				generic configuration parameters, pass in null for defaults
-	 * @param statement				database query command
-	 * @param packageName			server package where user defined function resides
-	 * @param functionName			aggregation function name
-	 * @param functionArgs			arguments to pass to function name, if any
-	 * @return						result iterator
-	 * @throws AerospikeException	if query fails
-	 */
-	public final ResultSet queryAggregate(
-		QueryPolicy policy,
-		Statement statement,
-		String packageName,
-		String functionName,
-		Value... functionArgs
-	) throws AerospikeException {
-		if (policy == null) {
-			policy = new QueryPolicy();
-		}
-		QueryAggregateExecutor executor = new QueryAggregateExecutor(cluster, policy, statement, packageName, functionName, functionArgs);
-		executor.execute();
-		return executor.getResultSet();
-	}
-
-	/**
-	 * Create secondary index.
-	 * This asynchronous server call will return before command is complete.
-	 * The user can optionally wait for command completion by using the returned
-	 * IndexTask instance.
-	 * <p>
-	 * This method is only supported by Aerospike 3 servers.
-	 * 
-	 * @param policy				generic configuration parameters, pass in null for defaults
-	 * @param namespace				namespace - equivalent to database name
-	 * @param setName				optional set name - equivalent to database table
-	 * @param indexName				name of secondary index
-	 * @param binName				bin name that data is indexed on
-	 * @param indexType				type of secondary index
-	 * @throws AerospikeException	if index create fails
-	 */
-	public final IndexTask createIndex(
-		Policy policy, 
-		String namespace, 
-		String setName, 
-		String indexName, 
-		String binName,
-		IndexType indexType
-	) throws AerospikeException {
-						
-		StringBuilder sb = new StringBuilder(500);
-		sb.append("sindex-create:ns=");
-		sb.append(namespace);
-		
-		if (setName != null && setName.length() > 0) {
-			sb.append(";set=");
-			sb.append(setName);
-		}
-		
-		sb.append(";indexname=");
-		sb.append(indexName);
-		sb.append(";numbins=1");
-		sb.append(";indexdata=");
-		sb.append(binName);
-		sb.append(",");
-		sb.append(indexType);
-		sb.append(";priority=normal");
-
-		// Send index command to one node. That node will distribute the command to other nodes.
-		String response = sendInfoCommand(policy, sb.toString());
-		
-		if (response.equalsIgnoreCase("OK")) {
-			// Return task that could optionally be polled for completion.
-			return new IndexTask(cluster, namespace, indexName);
-		}
-		
-		if (response.startsWith("FAIL:200")) {
-			// Index has already been created.  Do not need to poll for completion.
-			return new IndexTask();
-		}
-			
-		throw new AerospikeException("Create index failed: " + response);
-	}
-
-	/**
-	 * Delete secondary index.
-	 * This method is only supported by Aerospike 3 servers.
-	 * 
-	 * @param policy				generic configuration parameters, pass in null for defaults
-	 * @param namespace				namespace - equivalent to database name
-	 * @param setName				optional set name - equivalent to database table
-	 * @param indexName				name of secondary index
-	 * @throws AerospikeException	if index create fails
-	 */
-	public final void dropIndex(
-		Policy policy, 
-		String namespace, 
-		String setName, 
-		String indexName
-	) throws AerospikeException {
-						
-		StringBuilder sb = new StringBuilder(500);
-		sb.append("sindex-delete:ns=");
-		sb.append(namespace);
-		
-		if (setName != null && setName.length() > 0) {
-			sb.append(";set=");
-			sb.append(setName);
-		}		
-		sb.append(";indexname=");
-		sb.append(indexName);
-		
-		// Send index command to one node. That node will distribute the command to other nodes.
-		String response = sendInfoCommand(policy, sb.toString());
-
-		if (response.equalsIgnoreCase("OK")) {
-			return;
-		}
-		
-		if (response.startsWith("FAIL:201")) {
-			// Index did not previously exist. Return without error.
-			return;
-		}
-			
-		throw new AerospikeException("Drop index failed: " + response);
-	}
-	
-	//-------------------------------------------------------
-	// Internal Methods
-	//-------------------------------------------------------
-
-	protected static HashSet<String> binNamesToHashSet(String[] binNames) {
-		// Create lookup table for bin name filtering.
-		HashSet<String> names = new HashSet<String>(binNames.length);
-		
-		for (String binName : binNames) {
-			names.add(binName);
-		}
-		return names;
-	}
-	
-	private String sendInfoCommand(Policy policy, String command) throws AerospikeException {		
-		Node node = cluster.getRandomNode();
-		int timeout = (policy == null)? 0 : policy.timeout;
-		Connection conn = node.getConnection(timeout);
-		Info info;
-		
-		try {
-			info = new Info(conn, command);
-			node.putConnection(conn);
-		}
-		catch (AerospikeException ae) {
-			conn.close();
-			throw ae;
-		}
-		catch (RuntimeException re) {
-			conn.close();
-			throw new AerospikeException(re);
-		}
-		return info.getValue();
-	}
+    /**
+     * Delete secondary index.
+     * This method is only supported by Aerospike 3 servers.
+     *
+     * @param policy				generic configuration parameters, pass in null for defaults
+     * @param namespace				namespace - equivalent to database name
+     * @param setName				optional set name - equivalent to database table
+     * @param indexName				name of secondary index
+     * @throws com.aerospike.client.AerospikeException	if index create fails
+     */
+    void dropIndex(
+            Policy policy,
+            String namespace,
+            String setName,
+            String indexName
+    ) throws AerospikeException;
 }

--- a/client/src/com/aerospike/client/DefaultAerospikeClient.java
+++ b/client/src/com/aerospike/client/DefaultAerospikeClient.java
@@ -1,0 +1,705 @@
+/*******************************************************************************
+ * Copyright 2012-2014 by Aerospike.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ ******************************************************************************/
+package com.aerospike.client;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+
+import com.aerospike.client.Info.NameValueParser;
+import com.aerospike.client.cluster.Cluster;
+import com.aerospike.client.cluster.Connection;
+import com.aerospike.client.cluster.Node;
+import com.aerospike.client.command.BatchExecutor;
+import com.aerospike.client.command.Command;
+import com.aerospike.client.command.DeleteCommand;
+import com.aerospike.client.command.ExecuteCommand;
+import com.aerospike.client.command.ExistsCommand;
+import com.aerospike.client.command.OperateCommand;
+import com.aerospike.client.command.ReadCommand;
+import com.aerospike.client.command.ReadHeaderCommand;
+import com.aerospike.client.command.ScanCommand;
+import com.aerospike.client.command.ScanExecutor;
+import com.aerospike.client.command.TouchCommand;
+import com.aerospike.client.command.WriteCommand;
+import com.aerospike.client.large.LargeList;
+import com.aerospike.client.large.LargeMap;
+import com.aerospike.client.large.LargeSet;
+import com.aerospike.client.large.LargeStack;
+import com.aerospike.client.policy.ClientPolicy;
+import com.aerospike.client.policy.Policy;
+import com.aerospike.client.policy.QueryPolicy;
+import com.aerospike.client.policy.ScanPolicy;
+import com.aerospike.client.policy.WritePolicy;
+import com.aerospike.client.query.IndexType;
+import com.aerospike.client.query.QueryAggregateExecutor;
+import com.aerospike.client.query.QueryRecordExecutor;
+import com.aerospike.client.query.RecordSet;
+import com.aerospike.client.query.ResultSet;
+import com.aerospike.client.query.ServerExecutor;
+import com.aerospike.client.query.Statement;
+import com.aerospike.client.task.ExecuteTask;
+import com.aerospike.client.task.IndexTask;
+import com.aerospike.client.task.RegisterTask;
+import com.aerospike.client.util.Environment;
+import com.aerospike.client.util.Util;
+
+/**
+ * Instantiate an <code>AerospikeClient</code> object to access an Aerospike
+ * database cluster and perform database operations.
+ * <p>
+ * This client is thread-safe. One client instance should be used per cluster.
+ * Multiple threads should share this cluster instance.
+ * <p>
+ * Your application uses this class API to perform database operations such as
+ * writing and reading records, and selecting sets of records. Write operations
+ * include specialized functionality such as append/prepend and arithmetic
+ * addition.
+ * <p>
+ * Each record may have multiple bins, unless the Aerospike server nodes are
+ * configured as "single-bin". In "multi-bin" mode, partial records may be
+ * written or read by specifying the relevant subset of bins.
+ */
+public class DefaultAerospikeClient implements AerospikeClient {
+	//-------------------------------------------------------
+	// Member variables.
+	//-------------------------------------------------------
+	
+	protected Cluster cluster;
+	
+	//-------------------------------------------------------
+	// Constructors
+	//-------------------------------------------------------
+
+	/**
+	 * Initialize Aerospike client.
+	 * If the host connection succeeds, the client will:
+	 * <p>
+	 * - Add host to the cluster map <br>
+	 * - Request host's list of other nodes in cluster <br>
+	 * - Add these nodes to cluster map <br>
+	 * <p>
+	 * If the connection succeeds, the client is ready to process database requests.
+	 * If the connection fails, the cluster will remain in a disconnected state
+	 * until the server is activated.
+	 * 
+	 * @param hostname				host name
+	 * @param port					host port
+	 * @throws AerospikeException	if host connection fails
+	 */
+	public DefaultAerospikeClient(String hostname, int port) throws AerospikeException {
+		this(new ClientPolicy(), new Host(hostname, port));
+	}
+
+	/**
+	 * Initialize Aerospike client.
+	 * The client policy is used to set defaults and size internal data structures.
+	 * If the host connection succeeds, the client will:
+	 * <p>
+	 * - Add host to the cluster map <br>
+	 * - Request host's list of other nodes in cluster <br>
+	 * - Add these nodes to cluster map <br>
+	 * <p>
+	 * If the connection succeeds, the client is ready to process database requests.
+	 * If the connection fails and the policy's failOnInvalidHosts is true, a connection 
+	 * exception will be thrown. Otherwise, the cluster will remain in a disconnected state
+	 * until the server is activated.
+	 * 
+	 * @param policy				client configuration parameters, pass in null for defaults
+	 * @param hostname				host name
+	 * @param port					host port
+	 * @throws AerospikeException	if host connection fails
+	 */
+	public DefaultAerospikeClient(ClientPolicy policy, String hostname, int port) throws AerospikeException {
+		this(policy, new Host(hostname, port));
+	}
+
+	/**
+	 * Initialize Aerospike client with suitable hosts to seed the cluster map.
+	 * The client policy is used to set defaults and size internal data structures.
+	 * For each host connection that succeeds, the client will:
+	 * <p>
+	 * - Add host to the cluster map <br>
+	 * - Request host's list of other nodes in cluster <br>
+	 * - Add these nodes to cluster map <br>
+	 * <p>
+	 * In most cases, only one host is necessary to seed the cluster. The remaining hosts 
+	 * are added as future seeds in case of a complete network failure.
+	 * <p>
+	 * If one connection succeeds, the client is ready to process database requests.
+	 * If all connections fail and the policy's failIfNotConnected is true, a connection 
+	 * exception will be thrown. Otherwise, the cluster will remain in a disconnected state
+	 * until the server is activated.
+	 * 
+	 * @param policy				client configuration parameters, pass in null for defaults
+	 * @param hosts					array of potential hosts to seed the cluster
+	 * @throws AerospikeException	if all host connections fail
+	 */
+	public DefaultAerospikeClient(ClientPolicy policy, Host... hosts) throws AerospikeException {
+		if (policy == null) {
+			policy = new ClientPolicy();
+		}
+		cluster = new Cluster(policy, hosts);
+		cluster.initTendThread();
+		
+		if (policy.failIfNotConnected && ! cluster.isConnected()) {
+			throw new AerospikeException.Connection("Failed to connect to host(s): " + Arrays.toString(hosts));
+		}
+	}
+
+	//-------------------------------------------------------
+	// Compatibility Layer Initialization
+	//-------------------------------------------------------
+
+	/**
+	 * Compatibility layer constructor.  Do not use.
+	 */
+	protected DefaultAerospikeClient() {
+	}
+	
+	/**
+	 * Compatibility layer host initialization. Do not use.
+	 */
+	protected final void addServer(String hostname, int port) throws AerospikeException {
+		Host[] hosts = new Host[] {new Host(hostname, port)};
+		
+		// If cluster has already been initialized, add hosts to existing cluster.
+		if (cluster != null) {
+			cluster.addSeeds(hosts);
+			return;
+		}	
+		cluster = new Cluster(new ClientPolicy(), hosts);
+		cluster.initTendThread();
+	}
+
+	//-------------------------------------------------------
+	// Cluster Connection Management
+	//-------------------------------------------------------
+		
+	@Override
+    public final void close() {
+		cluster.close();
+	}
+
+	@Override
+    public final boolean isConnected() {
+		return cluster.isConnected();
+	}
+
+	@Override
+    public final Node[] getNodes() {
+		return cluster.getNodes();
+	}
+
+	@Override
+    public final List<String> getNodeNames() {
+		Node[] nodes = cluster.getNodes();		
+		ArrayList<String> names = new ArrayList<String>(nodes.length);
+		
+		for (Node node : nodes) {
+			names.add(node.getName());
+		}
+		return names;
+	}
+
+	//-------------------------------------------------------
+	// Write Record Operations
+	//-------------------------------------------------------
+	
+	@Override
+    public final void put(WritePolicy policy, Key key, Bin... bins) throws AerospikeException {
+		WriteCommand command = new WriteCommand(cluster, policy, key, bins, Operation.Type.WRITE);
+		command.execute();
+	}
+
+	//-------------------------------------------------------
+	// String Operations
+	//-------------------------------------------------------
+	
+	@Override
+    public final void append(WritePolicy policy, Key key, Bin... bins) throws AerospikeException {
+		WriteCommand command = new WriteCommand(cluster, policy, key, bins, Operation.Type.APPEND);
+		command.execute();
+	}
+	
+	@Override
+    public final void prepend(WritePolicy policy, Key key, Bin... bins) throws AerospikeException {
+		WriteCommand command = new WriteCommand(cluster, policy, key, bins, Operation.Type.PREPEND);
+		command.execute();
+	}
+
+	//-------------------------------------------------------
+	// Arithmetic Operations
+	//-------------------------------------------------------
+	
+	@Override
+    public final void add(WritePolicy policy, Key key, Bin... bins) throws AerospikeException {
+		WriteCommand command = new WriteCommand(cluster, policy, key, bins, Operation.Type.ADD);
+		command.execute();
+	}
+
+	//-------------------------------------------------------
+	// Delete Operations
+	//-------------------------------------------------------
+
+	@Override
+    public final boolean delete(WritePolicy policy, Key key) throws AerospikeException {
+		DeleteCommand command = new DeleteCommand(cluster, policy, key);
+		command.execute();
+		return command.existed();
+	}
+
+	//-------------------------------------------------------
+	// Touch Operations
+	//-------------------------------------------------------
+
+	@Override
+    public final void touch(WritePolicy policy, Key key) throws AerospikeException {
+		TouchCommand command = new TouchCommand(cluster, policy, key);
+		command.execute();
+	}
+
+	//-------------------------------------------------------
+	// Existence-Check Operations
+	//-------------------------------------------------------
+
+	@Override
+    public final boolean exists(Policy policy, Key key) throws AerospikeException {
+		ExistsCommand command = new ExistsCommand(cluster, policy, key);
+		command.execute();
+		return command.exists();
+	}
+
+	@Override
+    public final boolean[] exists(Policy policy, Key[] keys) throws AerospikeException {
+		boolean[] existsArray = new boolean[keys.length];
+		new BatchExecutor(cluster, policy, keys, existsArray, null, null, Command.INFO1_READ | Command.INFO1_NOBINDATA);
+		return existsArray;
+	}
+
+	//-------------------------------------------------------
+	// Read Record Operations
+	//-------------------------------------------------------
+
+	@Override
+    public final Record get(Policy policy, Key key) throws AerospikeException {
+		ReadCommand command = new ReadCommand(cluster, policy, key, null);
+		command.execute();
+		return command.getRecord();
+	}
+
+	@Override
+    public final Record get(Policy policy, Key key, String... binNames) throws AerospikeException {
+		ReadCommand command = new ReadCommand(cluster, policy, key, binNames);
+		command.execute();
+		return command.getRecord();
+	}
+
+	@Override
+    public final Record getHeader(Policy policy, Key key) throws AerospikeException {
+		ReadHeaderCommand command = new ReadHeaderCommand(cluster, policy, key);
+		command.execute();
+		return command.getRecord();
+	}
+
+	//-------------------------------------------------------
+	// Batch Read Operations
+	//-------------------------------------------------------
+
+	@Override
+    public final Record[] get(Policy policy, Key[] keys) throws AerospikeException {
+		Record[] records = new Record[keys.length];
+		new BatchExecutor(cluster, policy, keys, null, records, null, Command.INFO1_READ | Command.INFO1_GET_ALL);
+		return records;
+	}
+
+	@Override
+    public final Record[] get(Policy policy, Key[] keys, String... binNames)
+		throws AerospikeException {
+		Record[] records = new Record[keys.length];
+		HashSet<String> names = binNamesToHashSet(binNames);
+		new BatchExecutor(cluster, policy, keys, null, records, names, Command.INFO1_READ);
+		return records;
+	}
+
+	@Override
+    public final Record[] getHeader(Policy policy, Key[] keys) throws AerospikeException {
+		Record[] records = new Record[keys.length];
+		new BatchExecutor(cluster, policy, keys, null, records, null, Command.INFO1_READ | Command.INFO1_NOBINDATA);
+		return records;
+	}
+
+	//-------------------------------------------------------
+	// Generic Database Operations
+	//-------------------------------------------------------
+
+	@Override
+    public final Record operate(WritePolicy policy, Key key, Operation... operations)
+		throws AerospikeException {		
+		OperateCommand command = new OperateCommand(cluster, policy, key, operations);
+		command.execute();
+		return command.getRecord();
+	}
+
+	//-------------------------------------------------------
+	// Scan Operations
+	//-------------------------------------------------------
+	
+	@Override
+    public final void scanAll(ScanPolicy policy, String namespace, String setName, ScanCallback callback, String... binNames)
+		throws AerospikeException {	
+		if (policy == null) {
+			policy = new ScanPolicy();
+		}
+		// Retry policy must be one-shot for scans.
+		policy.maxRetries = 0;
+		
+		Node[] nodes = cluster.getNodes();		
+		if (nodes.length == 0) {
+			throw new AerospikeException(ResultCode.SERVER_NOT_AVAILABLE, "Scan failed because cluster is empty.");
+		}
+
+		if (policy.concurrentNodes) {
+			ScanExecutor executor = new ScanExecutor(cluster, nodes, policy, namespace, setName, callback, binNames);
+			executor.scanParallel();
+		}
+		else {
+			for (Node node : nodes) {
+				scanNode(policy, node, namespace, setName, callback, binNames);
+			}
+		}
+	}
+
+	@Override
+    public final void scanNode(ScanPolicy policy, String nodeName, String namespace, String setName, ScanCallback callback, String... binNames)
+		throws AerospikeException {		
+		Node node = cluster.getNode(nodeName);
+		scanNode(policy, node, namespace, setName, callback, binNames);
+	}
+
+	@Override
+    public final void scanNode(ScanPolicy policy, Node node, String namespace, String setName, ScanCallback callback, String... binNames)
+		throws AerospikeException {
+		if (policy == null) {
+			policy = new ScanPolicy();
+		}
+		// Retry policy must be one-shot for scans.
+		policy.maxRetries = 0;
+
+		ScanCommand command = new ScanCommand(node, policy, namespace, setName, callback, binNames);
+		command.execute();
+	}
+
+	//-------------------------------------------------------------------
+	// Large collection functions (Supported by Aerospike 3 servers only)
+	//-------------------------------------------------------------------
+
+	@Override
+    public final LargeList getLargeList(Policy policy, Key key, String binName, String userModule) {
+		return new LargeList(this, policy, key, binName, userModule);
+	}	
+
+	@Override
+    public final LargeMap getLargeMap(Policy policy, Key key, String binName, String userModule) {
+		return new LargeMap(this, policy, key, binName, userModule);
+	}	
+
+	@Override
+    public final LargeSet getLargeSet(Policy policy, Key key, String binName, String userModule) {
+		return new LargeSet(this, policy, key, binName, userModule);
+	}	
+
+	@Override
+    public final LargeStack getLargeStack(Policy policy, Key key, String binName, String userModule) {
+		return new LargeStack(this, policy, key, binName, userModule);
+	}	
+
+	//---------------------------------------------------------------
+	// User defined functions (Supported by Aerospike 3 servers only)
+	//---------------------------------------------------------------
+	
+	@Override
+    public final RegisterTask register(Policy policy, String clientPath, String serverPath, Language language)
+		throws AerospikeException {
+		
+		String content = Util.readFileEncodeBase64(clientPath);
+		
+		StringBuilder sb = new StringBuilder(serverPath.length() + content.length() + 100);
+		sb.append("udf-put:filename=");
+		sb.append(serverPath);
+		sb.append(";content=");
+		sb.append(content);
+		sb.append(";content-len=");
+		sb.append(content.length());
+		sb.append(";udf-type=");
+		sb.append(language);
+		sb.append(";");
+		
+		// Send UDF to one node. That node will distribute the UDF to other nodes.
+		String command = sb.toString();
+		Node node = cluster.getRandomNode();
+		int timeout = (policy == null)? 0 : policy.timeout;
+		Connection conn = node.getConnection(timeout);
+		
+		try {			
+			Info info = new Info(conn, command);
+			NameValueParser parser = info.getNameValueParser();
+			String error = null;
+			String file = null;
+			String line = null;
+			String message = null;
+			
+			while (parser.next()) {
+				String name = parser.getName();
+
+				if (name.equals("error")) {
+					error = parser.getValue();
+				}
+				else if (name.equals("file")) {
+					file = parser.getValue();				
+				}
+				else if (name.equals("line")) {
+					line = parser.getValue();				
+				}
+				else if (name.equals("message")) {
+					message = parser.getStringBase64();					
+				}
+			}
+			
+			if (error != null) {			
+				throw new AerospikeException("Registration failed: " + error + Environment.Newline +
+					"File: " + file + Environment.Newline + 
+					"Line: " + line + Environment.Newline +
+					"Message: " + message
+					);
+			}
+			
+			node.putConnection(conn);
+			return new RegisterTask(cluster, serverPath);
+		}
+		catch (AerospikeException ae) {
+			conn.close();
+			throw ae;
+		}
+		catch (RuntimeException re) {
+			conn.close();
+			throw new AerospikeException(re);
+		}
+	}
+	
+	@Override
+    public final Object execute(Policy policy, Key key, String packageName, String functionName, Value... args)
+		throws AerospikeException {
+		ExecuteCommand command = new ExecuteCommand(cluster, policy, key, packageName, functionName, args);
+		command.execute();
+		
+		Record record = command.getRecord();
+		
+		if (record == null || record.bins == null) {
+			return null;
+		}
+		
+		Map<String,Object> map = record.bins;
+
+		Object obj = map.get("SUCCESS");
+		
+		if (obj != null) {
+			return obj;
+		}
+		
+		// User defined functions don't have to return a value.
+		if (map.containsKey("SUCCESS")) {
+			return null;
+		}
+		
+		obj = map.get("FAILURE");
+		
+		if (obj != null) {
+			throw new AerospikeException(obj.toString());
+		}
+		throw new AerospikeException("Invalid UDF return value");
+	}
+	
+	//----------------------------------------------------------
+	// Query/Execute UDF (Supported by Aerospike 3 servers only)
+	//----------------------------------------------------------
+
+	@Override
+    public final ExecuteTask execute(
+            Policy policy,
+            Statement statement,
+            String packageName,
+            String functionName,
+            Value... functionArgs
+    ) throws AerospikeException {
+		if (policy == null) {
+			policy = new Policy();
+		}
+		new ServerExecutor(cluster, policy, statement, packageName, functionName, functionArgs);
+		return new ExecuteTask(cluster, statement);
+	}
+
+	//--------------------------------------------------------
+	// Query functions (Supported by Aerospike 3 servers only)
+	//--------------------------------------------------------
+
+	@Override
+    public final RecordSet query(QueryPolicy policy, Statement statement) throws AerospikeException {
+		if (policy == null) {
+			policy = new QueryPolicy();
+		}
+		QueryRecordExecutor executor = new QueryRecordExecutor(cluster, policy, statement);
+		executor.execute();
+		return executor.getRecordSet();
+	}
+	
+	@Override
+    public final ResultSet queryAggregate(
+            QueryPolicy policy,
+            Statement statement,
+            String packageName,
+            String functionName,
+            Value... functionArgs
+    ) throws AerospikeException {
+		if (policy == null) {
+			policy = new QueryPolicy();
+		}
+		QueryAggregateExecutor executor = new QueryAggregateExecutor(cluster, policy, statement, packageName, functionName, functionArgs);
+		executor.execute();
+		return executor.getResultSet();
+	}
+
+	@Override
+    public final IndexTask createIndex(
+            Policy policy,
+            String namespace,
+            String setName,
+            String indexName,
+            String binName,
+            IndexType indexType
+    ) throws AerospikeException {
+						
+		StringBuilder sb = new StringBuilder(500);
+		sb.append("sindex-create:ns=");
+		sb.append(namespace);
+		
+		if (setName != null && setName.length() > 0) {
+			sb.append(";set=");
+			sb.append(setName);
+		}
+		
+		sb.append(";indexname=");
+		sb.append(indexName);
+		sb.append(";numbins=1");
+		sb.append(";indexdata=");
+		sb.append(binName);
+		sb.append(",");
+		sb.append(indexType);
+		sb.append(";priority=normal");
+
+		// Send index command to one node. That node will distribute the command to other nodes.
+		String response = sendInfoCommand(policy, sb.toString());
+		
+		if (response.equalsIgnoreCase("OK")) {
+			// Return task that could optionally be polled for completion.
+			return new IndexTask(cluster, namespace, indexName);
+		}
+		
+		if (response.startsWith("FAIL:200")) {
+			// Index has already been created.  Do not need to poll for completion.
+			return new IndexTask();
+		}
+			
+		throw new AerospikeException("Create index failed: " + response);
+	}
+
+	@Override
+    public final void dropIndex(
+            Policy policy,
+            String namespace,
+            String setName,
+            String indexName
+    ) throws AerospikeException {
+						
+		StringBuilder sb = new StringBuilder(500);
+		sb.append("sindex-delete:ns=");
+		sb.append(namespace);
+		
+		if (setName != null && setName.length() > 0) {
+			sb.append(";set=");
+			sb.append(setName);
+		}		
+		sb.append(";indexname=");
+		sb.append(indexName);
+		
+		// Send index command to one node. That node will distribute the command to other nodes.
+		String response = sendInfoCommand(policy, sb.toString());
+
+		if (response.equalsIgnoreCase("OK")) {
+			return;
+		}
+		
+		if (response.startsWith("FAIL:201")) {
+			// Index did not previously exist. Return without error.
+			return;
+		}
+			
+		throw new AerospikeException("Drop index failed: " + response);
+	}
+	
+	//-------------------------------------------------------
+	// Internal Methods
+	//-------------------------------------------------------
+
+	protected static HashSet<String> binNamesToHashSet(String[] binNames) {
+		// Create lookup table for bin name filtering.
+		HashSet<String> names = new HashSet<String>(binNames.length);
+		
+		for (String binName : binNames) {
+			names.add(binName);
+		}
+		return names;
+	}
+	
+	private String sendInfoCommand(Policy policy, String command) throws AerospikeException {		
+		Node node = cluster.getRandomNode();
+		int timeout = (policy == null)? 0 : policy.timeout;
+		Connection conn = node.getConnection(timeout);
+		Info info;
+		
+		try {
+			info = new Info(conn, command);
+			node.putConnection(conn);
+		}
+		catch (AerospikeException ae) {
+			conn.close();
+			throw ae;
+		}
+		catch (RuntimeException re) {
+			conn.close();
+			throw new AerospikeException(re);
+		}
+		return info.getValue();
+	}
+}

--- a/client/src/com/aerospike/client/async/AsyncClient.java
+++ b/client/src/com/aerospike/client/async/AsyncClient.java
@@ -1,556 +1,319 @@
-/*******************************************************************************
- * Copyright 2012-2014 by Aerospike.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to
- * deal in the Software without restriction, including without limitation the
- * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
- * sell copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
- * IN THE SOFTWARE.
- ******************************************************************************/
 package com.aerospike.client.async;
 
-import java.util.Arrays;
-import java.util.HashSet;
-
-import com.aerospike.client.AerospikeClient;
-import com.aerospike.client.AerospikeException;
-import com.aerospike.client.Bin;
-import com.aerospike.client.Host;
-import com.aerospike.client.Key;
-import com.aerospike.client.Operation;
-import com.aerospike.client.command.Command;
-import com.aerospike.client.listener.DeleteListener;
-import com.aerospike.client.listener.ExistsArrayListener;
-import com.aerospike.client.listener.ExistsListener;
-import com.aerospike.client.listener.ExistsSequenceListener;
-import com.aerospike.client.listener.RecordArrayListener;
-import com.aerospike.client.listener.RecordListener;
-import com.aerospike.client.listener.RecordSequenceListener;
-import com.aerospike.client.listener.WriteListener;
+import com.aerospike.client.*;
+import com.aerospike.client.listener.*;
 import com.aerospike.client.policy.Policy;
 import com.aerospike.client.policy.ScanPolicy;
 import com.aerospike.client.policy.WritePolicy;
 
-/**
- * Asynchronous Aerospike client.
- * <p>
- * Your application uses this class to perform asynchronous database operations 
- * such as writing and reading records, and selecting sets of records. Write 
- * operations include specialized functionality such as append/prepend and arithmetic
- * addition.
- * <p>
- * This client is thread-safe. One client instance should be used per cluster.
- * Multiple threads should share this cluster instance.
- * <p>
- * Each record may have multiple bins, unless the Aerospike server nodes are
- * configured as "single-bin". In "multi-bin" mode, partial records may be
- * written or read by specifying the relevant subset of bins.
- */
-public class AsyncClient extends AerospikeClient {	
-	//-------------------------------------------------------
-	// Member variables.
-	//-------------------------------------------------------
-	
-	private final AsyncCluster cluster;
-	
-	//-------------------------------------------------------
-	// Constructors
-	//-------------------------------------------------------
+public interface AsyncClient extends AerospikeClient {
+    /**
+     * Asynchronously write record bin(s).
+     * This method schedules the put command with a channel selector and returns.
+     * Another thread will process the command and send the results to the listener.
+     * <p>
+     * The policy specifies the transaction timeout, record expiration and how the transaction is
+     * handled when the record already exists.
+     *
+     * @param policy				write configuration parameters, pass in null for defaults
+     * @param listener				where to send results, pass in null for fire and forget
+     * @param key					unique record identifier
+     * @param bins					array of bin name/value pairs
+     * @throws com.aerospike.client.AerospikeException    if queue is full
+     */
+    void put(WritePolicy policy, WriteListener listener, Key key, Bin... bins) throws AerospikeException;
 
-	/**
-	 * Initialize asynchronous client.
-	 * If the host connection succeeds, the client will:
-	 * <p>
-	 * - Add host to the cluster map <br>
-	 * - Request host's list of other nodes in cluster <br>
-	 * - Add these nodes to cluster map <br>
-	 * <p>
-	 * If the connection succeeds, the client is ready to process database requests.
-	 * If the connection fails, the cluster will remain in a disconnected state
-	 * until the server is activated.
-	 * 
-	 * @param hostname				host name
-	 * @param port					host port
-	 * @throws AerospikeException	if host connection fails
-	 */
-	public AsyncClient(String hostname, int port) throws AerospikeException {
-		this(new AsyncClientPolicy(), new Host(hostname, port));
-	}
+    /**
+     * Asynchronously append bin string values to existing record bin values.
+     * This method schedules the append command with a channel selector and returns.
+     * Another thread will process the command and send the results to the listener.
+     * <p>
+     * The policy specifies the transaction timeout, record expiration and how the transaction is
+     * handled when the record already exists.
+     * This call only works for string values.
+     *
+     * @param policy				write configuration parameters, pass in null for defaults
+     * @param listener				where to send results, pass in null for fire and forget
+     * @param key					unique record identifier
+     * @param bins					array of bin name/value pairs
+     * @throws com.aerospike.client.AerospikeException	if queue is full
+     */
+    void append(WritePolicy policy, WriteListener listener, Key key, Bin... bins) throws AerospikeException;
 
-	/**
-	 * Initialize asynchronous client.
-	 * The client policy is used to set defaults and size internal data structures.
-	 * If the host connection succeeds, the client will:
-	 * <p>
-	 * - Add host to the cluster map <br>
-	 * - Request host's list of other nodes in cluster <br>
-	 * - Add these nodes to cluster map <br>
-	 * <p>
-	 * If the connection succeeds, the client is ready to process database requests.
-	 * If the connection fails and the policy's failOnInvalidHosts is true, a connection 
-	 * exception will be thrown. Otherwise, the cluster will remain in a disconnected state
-	 * until the server is activated.
-	 * 
-	 * @param policy				client configuration parameters, pass in null for defaults
-	 * @param hostname				host name
-	 * @param port					host port
-	 * @throws AerospikeException	if host connection fails
-	 */
-	public AsyncClient(AsyncClientPolicy policy, String hostname, int port) throws AerospikeException {
-		this(policy, new Host(hostname, port));	
-	}
+    /**
+     * Asynchronously prepend bin string values to existing record bin values.
+     * This method schedules the prepend command with a channel selector and returns.
+     * Another thread will process the command and send the results to the listener.
+     * <p>
+     * The policy specifies the transaction timeout, record expiration and how the transaction is
+     * handled when the record already exists.
+     * This call works only for string values.
+     *
+     * @param policy				write configuration parameters, pass in null for defaults
+     * @param listener				where to send results, pass in null for fire and forget
+     * @param key					unique record identifier
+     * @param bins					array of bin name/value pairs
+     * @throws com.aerospike.client.AerospikeException	if queue is full
+     */
+    void prepend(WritePolicy policy, WriteListener listener, Key key, Bin... bins) throws AerospikeException;
 
-	/**
-	 * Initialize asynchronous client with suitable hosts to seed the cluster map.
-	 * The client policy is used to set defaults and size internal data structures.
-	 * For each host connection that succeeds, the client will:
-	 * <p>
-	 * - Add host to the cluster map <br>
-	 * - Request host's list of other nodes in cluster <br>
-	 * - Add these nodes to cluster map <br>
-	 * <p>
-	 * In most cases, only one host is necessary to seed the cluster. The remaining hosts 
-	 * are added as future seeds in case of a complete network failure.
-	 * <p>
-	 * If one connection succeeds, the client is ready to process database requests.
-	 * If all connections fail and the policy's failIfNotConnected is true, a connection 
-	 * exception will be thrown. Otherwise, the cluster will remain in a disconnected state
-	 * until the server is activated.
-	 * 
-	 * @param policy				client configuration parameters, pass in null for defaults
-	 * @param hosts					array of potential hosts to seed the cluster
-	 * @throws AerospikeException	if all host connections fail
-	 */
-	public AsyncClient(AsyncClientPolicy policy, Host... hosts) throws AerospikeException {
-		if (policy == null) {
-			policy = new AsyncClientPolicy();
-		}
-		this.cluster = new AsyncCluster(policy, hosts);
-		super.cluster = this.cluster;
-		
-		if (policy.failIfNotConnected && ! this.cluster.isConnected()) {
-			throw new AerospikeException.Connection("Failed to connect to host(s): " + Arrays.toString(hosts));
-		}
-	}
+    /**
+     * Asynchronously add integer bin values to existing record bin values.
+     * This method schedules the add command with a channel selector and returns.
+     * Another thread will process the command and send the results to the listener.
+     * <p>
+     * The policy specifies the transaction timeout, record expiration and how the transaction is
+     * handled when the record already exists.
+     * This call only works for integer values.
+     *
+     * @param policy				write configuration parameters, pass in null for defaults
+     * @param listener				where to send results, pass in null for fire and forget
+     * @param key					unique record identifier
+     * @param bins					array of bin name/value pairs
+     * @throws com.aerospike.client.AerospikeException	if queue is full
+     */
+    void add(WritePolicy policy, WriteListener listener, Key key, Bin... bins) throws AerospikeException;
 
-	//-------------------------------------------------------
-	// Write Record Operations
-	//-------------------------------------------------------
-	
-	/**
-	 * Asynchronously write record bin(s). 
-	 * This method schedules the put command with a channel selector and returns.
-	 * Another thread will process the command and send the results to the listener.
-	 * <p>
-	 * The policy specifies the transaction timeout, record expiration and how the transaction is
-	 * handled when the record already exists.
-	 * 
-	 * @param policy				write configuration parameters, pass in null for defaults
-	 * @param listener				where to send results, pass in null for fire and forget
-	 * @param key					unique record identifier
-	 * @param bins					array of bin name/value pairs
-	 * @throws AerospikeException	if queue is full
-	 */
-	public final void put(WritePolicy policy, WriteListener listener, Key key, Bin... bins) throws AerospikeException {		
-		AsyncWrite command = new AsyncWrite(cluster, policy, listener, key, bins, Operation.Type.WRITE);
-		command.execute();
-	}
+    /**
+     * Asynchronously delete record for specified key.
+     * This method schedules the delete command with a channel selector and returns.
+     * Another thread will process the command and send the results to the listener.
+     * <p>
+     * The policy specifies the transaction timeout.
+     *
+     * @param policy				delete configuration parameters, pass in null for defaults
+     * @param listener				where to send results, pass in null for fire and forget
+     * @param key					unique record identifier
+     * @throws com.aerospike.client.AerospikeException	if queue is full
+     */
+    void delete(WritePolicy policy, DeleteListener listener, Key key) throws AerospikeException;
 
-	//-------------------------------------------------------
-	// String Operations
-	//-------------------------------------------------------
-		
-	/**
-	 * Asynchronously append bin string values to existing record bin values.
-	 * This method schedules the append command with a channel selector and returns.
-	 * Another thread will process the command and send the results to the listener.
-	 * <p>
-	 * The policy specifies the transaction timeout, record expiration and how the transaction is
-	 * handled when the record already exists.
-	 * This call only works for string values. 
-	 * 
-	 * @param policy				write configuration parameters, pass in null for defaults
-	 * @param listener				where to send results, pass in null for fire and forget
-	 * @param key					unique record identifier
-	 * @param bins					array of bin name/value pairs
-	 * @throws AerospikeException	if queue is full
-	 */
-	public final void append(WritePolicy policy, WriteListener listener, Key key, Bin... bins) throws AerospikeException {
-		AsyncWrite command = new AsyncWrite(cluster, policy, listener, key, bins, Operation.Type.APPEND);
-		command.execute();
-	}
-	
-	/**
-	 * Asynchronously prepend bin string values to existing record bin values.
-	 * This method schedules the prepend command with a channel selector and returns.
-	 * Another thread will process the command and send the results to the listener.
-	 * <p>
-	 * The policy specifies the transaction timeout, record expiration and how the transaction is
-	 * handled when the record already exists.
-	 * This call works only for string values. 
-	 * 
-	 * @param policy				write configuration parameters, pass in null for defaults
-	 * @param listener				where to send results, pass in null for fire and forget
-	 * @param key					unique record identifier
-	 * @param bins					array of bin name/value pairs
-	 * @throws AerospikeException	if queue is full
-	 */
-	public final void prepend(WritePolicy policy, WriteListener listener, Key key, Bin... bins) throws AerospikeException {
-		AsyncWrite command = new AsyncWrite(cluster, policy, listener, key, bins, Operation.Type.PREPEND);
-		command.execute();
-	}
+    /**
+     * Asynchronously create record if it does not already exist.  If the record exists, the record's
+     * time to expiration will be reset to the policy's expiration.
+     * <p>
+     * This method schedules the touch command with a channel selector and returns.
+     * Another thread will process the command and send the results to the listener.
+     *
+     * @param policy				write configuration parameters, pass in null for defaults
+     * @param listener				where to send results, pass in null for fire and forget
+     * @param key					unique record identifier
+     * @throws com.aerospike.client.AerospikeException	if queue is full
+     */
+    void touch(WritePolicy policy, WriteListener listener, Key key) throws AerospikeException;
 
-	//-------------------------------------------------------
-	// Arithmetic Operations
-	//-------------------------------------------------------
-	
-	/**
-	 * Asynchronously add integer bin values to existing record bin values.
-	 * This method schedules the add command with a channel selector and returns.
-	 * Another thread will process the command and send the results to the listener.
-	 * <p>
-	 * The policy specifies the transaction timeout, record expiration and how the transaction is
-	 * handled when the record already exists.
-	 * This call only works for integer values. 
-	 * 
-	 * @param policy				write configuration parameters, pass in null for defaults
-	 * @param listener				where to send results, pass in null for fire and forget
-	 * @param key					unique record identifier
-	 * @param bins					array of bin name/value pairs
-	 * @throws AerospikeException	if queue is full
-	 */
-	public final void add(WritePolicy policy, WriteListener listener, Key key, Bin... bins) throws AerospikeException {
-		AsyncWrite command = new AsyncWrite(cluster, policy, listener, key, bins, Operation.Type.ADD);
-		command.execute();
-	}
+    /**
+     * Asynchronously determine if a record key exists.
+     * This method schedules the exists command with a channel selector and returns.
+     * Another thread will process the command and send the results to the listener.
+     * <p>
+     * The policy can be used to specify timeouts.
+     *
+     * @param policy				generic configuration parameters, pass in null for defaults
+     * @param listener				where to send results
+     * @param key					unique record identifier
+     * @throws com.aerospike.client.AerospikeException	if queue is full
+     */
+    void exists(Policy policy, ExistsListener listener, Key key) throws AerospikeException;
 
-	//-------------------------------------------------------
-	// Delete Operations
-	//-------------------------------------------------------
-	
-	/**
-	 * Asynchronously delete record for specified key.
-	 * This method schedules the delete command with a channel selector and returns.
-	 * Another thread will process the command and send the results to the listener.
-	 * <p>
-	 * The policy specifies the transaction timeout.
-	 * 
-	 * @param policy				delete configuration parameters, pass in null for defaults
-	 * @param listener				where to send results, pass in null for fire and forget
-	 * @param key					unique record identifier
-	 * @throws AerospikeException	if queue is full
-	 */
-	public final void delete(WritePolicy policy, DeleteListener listener, Key key) throws AerospikeException {
-		AsyncDelete command = new AsyncDelete(cluster, policy, listener, key);
-		command.execute();
-	}
+    /**
+     * Asynchronously check if multiple record keys exist in one batch call.
+     * This method schedules the exists command with a channel selector and returns.
+     * Another thread will process the command and send the results to the listener in a single call.
+     * <p>
+     * The policy can be used to specify timeouts.
+     *
+     * @param policy				generic configuration parameters, pass in null for defaults
+     * @param listener				where to send results
+     * @param keys					array of unique record identifiers
+     * @throws com.aerospike.client.AerospikeException	if queue is full
+     */
+    void exists(Policy policy, ExistsArrayListener listener, Key[] keys) throws AerospikeException;
 
-	//-------------------------------------------------------
-	// Touch Operations
-	//-------------------------------------------------------
+    /**
+     * Asynchronously check if multiple record keys exist in one batch call.
+     * This method schedules the exists command with a channel selector and returns.
+     * Another thread will process the command and send the results to the listener in multiple unordered calls.
+     * <p>
+     * The policy can be used to specify timeouts.
+     *
+     * @param policy				generic configuration parameters, pass in null for defaults
+     * @param listener				where to send results
+     * @param keys					array of unique record identifiers
+     * @throws com.aerospike.client.AerospikeException	if queue is full
+     */
+    void exists(Policy policy, ExistsSequenceListener listener, Key[] keys) throws AerospikeException;
 
-	/**
-	 * Asynchronously create record if it does not already exist.  If the record exists, the record's 
-	 * time to expiration will be reset to the policy's expiration.
-	 * <p>
-	 * This method schedules the touch command with a channel selector and returns.
-	 * Another thread will process the command and send the results to the listener.
-	 * 
-	 * @param policy				write configuration parameters, pass in null for defaults
-	 * @param listener				where to send results, pass in null for fire and forget
-	 * @param key					unique record identifier
-	 * @throws AerospikeException	if queue is full
-	 */
-	public final void touch(WritePolicy policy, WriteListener listener, Key key) throws AerospikeException {		
-		AsyncTouch command = new AsyncTouch(cluster, policy, listener, key);
-		command.execute();
-	}
+    /**
+     * Asynchronously read entire record for specified key.
+     * This method schedules the get command with a channel selector and returns.
+     * Another thread will process the command and send the results to the listener.
+     * <p>
+     * The policy can be used to specify timeouts.
+     *
+     * @param policy				generic configuration parameters, pass in null for defaults
+     * @param listener				where to send results
+     * @param key					unique record identifier
+     * @throws com.aerospike.client.AerospikeException	if queue is full
+     */
+    void get(Policy policy, RecordListener listener, Key key) throws AerospikeException;
 
-	//-------------------------------------------------------
-	// Existence-Check Operations
-	//-------------------------------------------------------
-	
-	/**
-	 * Asynchronously determine if a record key exists.
-	 * This method schedules the exists command with a channel selector and returns.
-	 * Another thread will process the command and send the results to the listener.
-	 * <p>
-	 * The policy can be used to specify timeouts.
-	 * 
-	 * @param policy				generic configuration parameters, pass in null for defaults
-	 * @param listener				where to send results
-	 * @param key					unique record identifier
-	 * @throws AerospikeException	if queue is full
-	 */
-	public final void exists(Policy policy, ExistsListener listener, Key key) throws AerospikeException {
-		AsyncExists command = new AsyncExists(cluster, policy, listener, key);
-		command.execute();
-	}
+    /**
+     * Asynchronously read record header and bins for specified key.
+     * This method schedules the get command with a channel selector and returns.
+     * Another thread will process the command and send the results to the listener.
+     * <p>
+     * The policy can be used to specify timeouts.
+     *
+     * @param policy				generic configuration parameters, pass in null for defaults
+     * @param listener				where to send results
+     * @param key					unique record identifier
+     * @param binNames				bins to retrieve
+     * @throws com.aerospike.client.AerospikeException	if queue is full
+     */
+    void get(Policy policy, RecordListener listener, Key key, String... binNames) throws AerospikeException;
 
-	/**
-	 * Asynchronously check if multiple record keys exist in one batch call.
-	 * This method schedules the exists command with a channel selector and returns.
-	 * Another thread will process the command and send the results to the listener in a single call.
-	 * <p>
-	 * The policy can be used to specify timeouts.
-	 *  
-	 * @param policy				generic configuration parameters, pass in null for defaults
-	 * @param listener				where to send results
-	 * @param keys					array of unique record identifiers
-	 * @throws AerospikeException	if queue is full
-	 */
-	public final void exists(Policy policy, ExistsArrayListener listener, Key[] keys) throws AerospikeException {
-		new AsyncBatchExistsArrayExecutor(cluster, policy, keys, listener);		
-	}
+    /**
+     * Asynchronously read record generation and expiration only for specified key.  Bins are not read.
+     * This method schedules the get command with a channel selector and returns.
+     * Another thread will process the command and send the results to the listener.
+     * <p>
+     * The policy can be used to specify timeouts.
+     *
+     * @param policy				generic configuration parameters, pass in null for defaults
+     * @param listener				where to send results
+     * @param key					unique record identifier
+     * @throws com.aerospike.client.AerospikeException	if queue is full
+     */
+    void getHeader(Policy policy, RecordListener listener, Key key) throws AerospikeException;
 
-	/**
-	 * Asynchronously check if multiple record keys exist in one batch call.
-	 * This method schedules the exists command with a channel selector and returns.
-	 * Another thread will process the command and send the results to the listener in multiple unordered calls.
-	 * <p>
-	 * The policy can be used to specify timeouts.
-	 *  
-	 * @param policy				generic configuration parameters, pass in null for defaults
-	 * @param listener				where to send results
-	 * @param keys					array of unique record identifiers
-	 * @throws AerospikeException	if queue is full
-	 */
-	public final void exists(Policy policy, ExistsSequenceListener listener, Key[] keys) throws AerospikeException {
-		new AsyncBatchExistsSequenceExecutor(cluster, policy, keys, listener);		
-	}
+    /**
+     * Asynchronously read multiple records for specified keys in one batch call.
+     * This method schedules the get command with a channel selector and returns.
+     * Another thread will process the command and send the results to the listener in a single call.
+     * <p>
+     * If a key is not found, the record will be null.
+     * The policy can be used to specify timeouts.
+     *
+     * @param policy				generic configuration parameters, pass in null for defaults
+     * @param listener				where to send results
+     * @param keys					array of unique record identifiers
+     * @throws com.aerospike.client.AerospikeException	if queue is full
+     */
+    void get(Policy policy, RecordArrayListener listener, Key[] keys) throws AerospikeException;
 
-	//-------------------------------------------------------
-	// Read Record Operations
-	//-------------------------------------------------------
-	
-	/**
-	 * Asynchronously read entire record for specified key.
-	 * This method schedules the get command with a channel selector and returns.
-	 * Another thread will process the command and send the results to the listener.
-	 * <p>
-	 * The policy can be used to specify timeouts.
-	 * 
-	 * @param policy				generic configuration parameters, pass in null for defaults
-	 * @param listener				where to send results
-	 * @param key					unique record identifier
-	 * @throws AerospikeException	if queue is full
-	 */	
-	public final void get(Policy policy, RecordListener listener, Key key) throws AerospikeException {
-		AsyncRead command = new AsyncRead(cluster, policy, listener, key, null);
-		command.execute();
-	}
-	
-	/**
-	 * Asynchronously read record header and bins for specified key.
-	 * This method schedules the get command with a channel selector and returns.
-	 * Another thread will process the command and send the results to the listener.
-	 * <p>
-	 * The policy can be used to specify timeouts.
-	 * 
-	 * @param policy				generic configuration parameters, pass in null for defaults
-	 * @param listener				where to send results
-	 * @param key					unique record identifier
-	 * @param binNames				bins to retrieve
-	 * @throws AerospikeException	if queue is full
-	 */
-	public final void get(Policy policy, RecordListener listener, Key key, String... binNames) throws AerospikeException {	
-		AsyncRead command = new AsyncRead(cluster, policy, listener, key, binNames);
-		command.execute();
-	}
+    /**
+     * Asynchronously read multiple records for specified keys in one batch call.
+     * This method schedules the get command with a channel selector and returns.
+     * Another thread will process the command and send the results to the listener in multiple unordered calls.
+     * <p>
+     * If a key is not found, the record will be null.
+     * The policy can be used to specify timeouts.
+     *
+     * @param policy				generic configuration parameters, pass in null for defaults
+     * @param listener				where to send results
+     * @param keys					array of unique record identifiers
+     * @throws com.aerospike.client.AerospikeException	if queue is full
+     */
+    void get(Policy policy, RecordSequenceListener listener, Key[] keys) throws AerospikeException;
 
-	/**
-	 * Asynchronously read record generation and expiration only for specified key.  Bins are not read.
-	 * This method schedules the get command with a channel selector and returns.
-	 * Another thread will process the command and send the results to the listener.
-	 * <p>
-	 * The policy can be used to specify timeouts.
-	 * 
-	 * @param policy				generic configuration parameters, pass in null for defaults
-	 * @param listener				where to send results
-	 * @param key					unique record identifier
-	 * @throws AerospikeException	if queue is full
-	 */
-	public final void getHeader(Policy policy, RecordListener listener, Key key) throws AerospikeException {
-		AsyncReadHeader command = new AsyncReadHeader(cluster, policy, listener, key);
-		command.execute();
-	}
+    /**
+     * Asynchronously read multiple record headers and bins for specified keys in one batch call.
+     * This method schedules the get command with a channel selector and returns.
+     * Another thread will process the command and send the results to the listener in a single call.
+     * <p>
+     * If a key is not found, the record will be null.
+     * The policy can be used to specify timeouts.
+     *
+     * @param policy				generic configuration parameters, pass in null for defaults
+     * @param listener				where to send results
+     * @param keys					array of unique record identifiers
+     * @param binNames				array of bins to retrieve
+     * @throws com.aerospike.client.AerospikeException	if queue is full
+     */
+    void get(Policy policy, RecordArrayListener listener, Key[] keys, String... binNames)
+        throws AerospikeException;
 
-	//-------------------------------------------------------
-	// Batch Read Operations
-	//-------------------------------------------------------
+    /**
+     * Asynchronously read multiple record headers and bins for specified keys in one batch call.
+     * This method schedules the get command with a channel selector and returns.
+     * Another thread will process the command and send the results to the listener in multiple unordered calls.
+     * <p>
+     * If a key is not found, the record will be null.
+     * The policy can be used to specify timeouts.
+     *
+     * @param policy				generic configuration parameters, pass in null for defaults
+     * @param listener				where to send results
+     * @param keys					array of unique record identifiers
+     * @param binNames				array of bins to retrieve
+     * @throws com.aerospike.client.AerospikeException	if queue is full
+     */
+    void get(Policy policy, RecordSequenceListener listener, Key[] keys, String... binNames)
+        throws AerospikeException;
 
-	/**
-	 * Asynchronously read multiple records for specified keys in one batch call.
-	 * This method schedules the get command with a channel selector and returns.
-	 * Another thread will process the command and send the results to the listener in a single call.
-	 * <p>
-	 * If a key is not found, the record will be null.
-	 * The policy can be used to specify timeouts.
-	 * 
-	 * @param policy				generic configuration parameters, pass in null for defaults
-	 * @param listener				where to send results
-	 * @param keys					array of unique record identifiers
-	 * @throws AerospikeException	if queue is full
-	 */
-	public final void get(Policy policy, RecordArrayListener listener, Key[] keys) throws AerospikeException {
-		new AsyncBatchGetArrayExecutor(cluster, policy, listener, keys, null, Command.INFO1_READ | Command.INFO1_GET_ALL);
-	}
+    /**
+     * Asynchronously read multiple record header data for specified keys in one batch call.
+     * This method schedules the get command with a channel selector and returns.
+     * Another thread will process the command and send the results to the listener in a single call.
+     * <p>
+     * If a key is not found, the record will be null.
+     * The policy can be used to specify timeouts.
+     *
+     * @param policy				generic configuration parameters, pass in null for defaults
+     * @param listener				where to send results
+     * @param keys					array of unique record identifiers
+     * @throws com.aerospike.client.AerospikeException	if queue is full
+     */
+    void getHeader(Policy policy, RecordArrayListener listener, Key[] keys) throws AerospikeException;
 
-	/**
-	 * Asynchronously read multiple records for specified keys in one batch call.
-	 * This method schedules the get command with a channel selector and returns.
-	 * Another thread will process the command and send the results to the listener in multiple unordered calls.
-	 * <p>
-	 * If a key is not found, the record will be null.
-	 * The policy can be used to specify timeouts.
-	 * 
-	 * @param policy				generic configuration parameters, pass in null for defaults
-	 * @param listener				where to send results
-	 * @param keys					array of unique record identifiers
-	 * @throws AerospikeException	if queue is full
-	 */
-	public final void get(Policy policy, RecordSequenceListener listener, Key[] keys) throws AerospikeException {
-		new AsyncBatchGetSequenceExecutor(cluster, policy, listener, keys, null, Command.INFO1_READ | Command.INFO1_GET_ALL);		
-	}
-	
-	/**
-	 * Asynchronously read multiple record headers and bins for specified keys in one batch call.
-	 * This method schedules the get command with a channel selector and returns.
-	 * Another thread will process the command and send the results to the listener in a single call.
-	 * <p>
-	 * If a key is not found, the record will be null.
-	 * The policy can be used to specify timeouts.
-	 * 
-	 * @param policy				generic configuration parameters, pass in null for defaults
-	 * @param listener				where to send results
-	 * @param keys					array of unique record identifiers
-	 * @param binNames				array of bins to retrieve
-	 * @throws AerospikeException	if queue is full
-	 */
-	public final void get(Policy policy, RecordArrayListener listener, Key[] keys, String... binNames) 
-		throws AerospikeException {
-		HashSet<String> names = binNamesToHashSet(binNames);
-		new AsyncBatchGetArrayExecutor(cluster, policy, listener, keys, names, Command.INFO1_READ);
-	}
+    /**
+     * Asynchronously read multiple record header data for specified keys in one batch call.
+     * This method schedules the get command with a channel selector and returns.
+     * Another thread will process the command and send the results to the listener in multiple unordered calls.
+     * <p>
+     * If a key is not found, the record will be null.
+     * The policy can be used to specify timeouts.
+     *
+     * @param policy				generic configuration parameters, pass in null for defaults
+     * @param listener				where to send results
+     * @param keys					array of unique record identifiers
+     * @throws com.aerospike.client.AerospikeException	if queue is full
+     */
+    void getHeader(Policy policy, RecordSequenceListener listener, Key[] keys) throws AerospikeException;
 
-	/**
-	 * Asynchronously read multiple record headers and bins for specified keys in one batch call.
-	 * This method schedules the get command with a channel selector and returns.
-	 * Another thread will process the command and send the results to the listener in multiple unordered calls.
-	 * <p>
-	 * If a key is not found, the record will be null.
-	 * The policy can be used to specify timeouts.
-	 * 
-	 * @param policy				generic configuration parameters, pass in null for defaults
-	 * @param listener				where to send results
-	 * @param keys					array of unique record identifiers
-	 * @param binNames				array of bins to retrieve
-	 * @throws AerospikeException	if queue is full
-	 */
-	public final void get(Policy policy, RecordSequenceListener listener, Key[] keys, String... binNames) 
-		throws AerospikeException {
-		HashSet<String> names = binNamesToHashSet(binNames);
-		new AsyncBatchGetSequenceExecutor(cluster, policy, listener, keys, names, Command.INFO1_READ);
-	}
-	
-	/**
-	 * Asynchronously read multiple record header data for specified keys in one batch call.
-	 * This method schedules the get command with a channel selector and returns.
-	 * Another thread will process the command and send the results to the listener in a single call.
-	 * <p>
-	 * If a key is not found, the record will be null.
-	 * The policy can be used to specify timeouts.
-	 * 
-	 * @param policy				generic configuration parameters, pass in null for defaults
-	 * @param listener				where to send results
-	 * @param keys					array of unique record identifiers
-	 * @throws AerospikeException	if queue is full
-	 */
-	public final void getHeader(Policy policy, RecordArrayListener listener, Key[] keys) throws AerospikeException {
-		new AsyncBatchGetArrayExecutor(cluster, policy, listener, keys, null, Command.INFO1_READ | Command.INFO1_NOBINDATA);
-	}
+    /**
+     * Asynchronously perform multiple read/write operations on a single key in one batch call.
+     * An example would be to add an integer value to an existing record and then
+     * read the result, all in one database call.
+     * <p>
+     * This method schedules the operate command with a channel selector and returns.
+     * Another thread will process the command and send the results to the listener.
+     *
+     * @param policy				write configuration parameters, pass in null for defaults
+     * @param listener				where to send results, pass in null for fire and forget
+     * @param key					unique record identifier
+     * @param operations			database operations to perform
+     * @throws com.aerospike.client.AerospikeException	if queue is full
+     */
+    void operate(WritePolicy policy, RecordListener listener, Key key, Operation... operations)
+        throws AerospikeException;
 
-	/**
-	 * Asynchronously read multiple record header data for specified keys in one batch call.
-	 * This method schedules the get command with a channel selector and returns.
-	 * Another thread will process the command and send the results to the listener in multiple unordered calls.
-	 * <p>
-	 * If a key is not found, the record will be null.
-	 * The policy can be used to specify timeouts.
-	 * 
-	 * @param policy				generic configuration parameters, pass in null for defaults
-	 * @param listener				where to send results
-	 * @param keys					array of unique record identifiers
-	 * @throws AerospikeException	if queue is full
-	 */
-	public final void getHeader(Policy policy, RecordSequenceListener listener, Key[] keys) throws AerospikeException {
-		new AsyncBatchGetSequenceExecutor(cluster, policy, listener, keys, null, Command.INFO1_READ | Command.INFO1_NOBINDATA);
-	}
-
-	//-------------------------------------------------------
-	// Generic Database Operations
-	//-------------------------------------------------------
-	
-	/**
-	 * Asynchronously perform multiple read/write operations on a single key in one batch call.
-	 * An example would be to add an integer value to an existing record and then
-	 * read the result, all in one database call.
-	 * <p>
-	 * This method schedules the operate command with a channel selector and returns.
-	 * Another thread will process the command and send the results to the listener.
-	 * 
-	 * @param policy				write configuration parameters, pass in null for defaults
-	 * @param listener				where to send results, pass in null for fire and forget
-	 * @param key					unique record identifier
-	 * @param operations			database operations to perform
-	 * @throws AerospikeException	if queue is full
-	 */
-	public final void operate(WritePolicy policy, RecordListener listener, Key key, Operation... operations) 
-		throws AerospikeException {		
-		AsyncOperate command = new AsyncOperate(cluster, policy, listener, key, operations);
-		command.execute();
-	}
-
-	//-------------------------------------------------------
-	// Scan Operations
-	//-------------------------------------------------------
-
-	/**
-	 * Asynchronously read all records in specified namespace and set.  If the policy's 
-	 * <code>concurrentNodes</code> is specified, each server node will be read in
-	 * parallel.  Otherwise, server nodes are read in series.
-	 * <p>
-	 * This method schedules the scan command with a channel selector and returns.
-	 * Another thread will process the command and send the results to the listener.
-	 * 
-	 * @param policy				scan configuration parameters, pass in null for defaults
-	 * @param listener				where to send results, pass in null for fire and forget
-	 * @param namespace				namespace - equivalent to database name
-	 * @param setName				optional set name - equivalent to database table
-	 * @param binNames				optional bin to retrieve. All bins will be returned if not specified.
-	 * 								Aerospike 2 servers ignore this parameter.
-	 * @throws AerospikeException	if queue is full
-	 */
-	public final void scanAll(ScanPolicy policy, RecordSequenceListener listener, String namespace, String setName, String... binNames)
-		throws AerospikeException {
-		if (policy == null) {
-			policy = new ScanPolicy();
-		}
-		
-		// Retry policy must be one-shot for scans.
-		policy.maxRetries = 0;
-		new AsyncScanExecutor(cluster, policy, listener, namespace, setName, binNames);
-	}
+    /**
+     * Asynchronously read all records in specified namespace and set.  If the policy's
+     * <code>concurrentNodes</code> is specified, each server node will be read in
+     * parallel.  Otherwise, server nodes are read in series.
+     * <p>
+     * This method schedules the scan command with a channel selector and returns.
+     * Another thread will process the command and send the results to the listener.
+     *
+     * @param policy				scan configuration parameters, pass in null for defaults
+     * @param listener				where to send results, pass in null for fire and forget
+     * @param namespace				namespace - equivalent to database name
+     * @param setName				optional set name - equivalent to database table
+     * @param binNames				optional bin to retrieve. All bins will be returned if not specified.
+     * 								Aerospike 2 servers ignore this parameter.
+     * @throws com.aerospike.client.AerospikeException	if queue is full
+     */
+    void scanAll(ScanPolicy policy, RecordSequenceListener listener, String namespace, String setName, String... binNames)
+        throws AerospikeException;
 }

--- a/client/src/com/aerospike/client/async/DefaultAsyncClient.java
+++ b/client/src/com/aerospike/client/async/DefaultAsyncClient.java
@@ -1,0 +1,305 @@
+/*******************************************************************************
+ * Copyright 2012-2014 by Aerospike.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ ******************************************************************************/
+package com.aerospike.client.async;
+
+import java.util.Arrays;
+import java.util.HashSet;
+
+import com.aerospike.client.*;
+import com.aerospike.client.command.Command;
+import com.aerospike.client.listener.DeleteListener;
+import com.aerospike.client.listener.ExistsArrayListener;
+import com.aerospike.client.listener.ExistsListener;
+import com.aerospike.client.listener.ExistsSequenceListener;
+import com.aerospike.client.listener.RecordArrayListener;
+import com.aerospike.client.listener.RecordListener;
+import com.aerospike.client.listener.RecordSequenceListener;
+import com.aerospike.client.listener.WriteListener;
+import com.aerospike.client.policy.Policy;
+import com.aerospike.client.policy.ScanPolicy;
+import com.aerospike.client.policy.WritePolicy;
+
+/**
+ * Asynchronous Aerospike client.
+ * <p>
+ * Your application uses this class to perform asynchronous database operations 
+ * such as writing and reading records, and selecting sets of records. Write 
+ * operations include specialized functionality such as append/prepend and arithmetic
+ * addition.
+ * <p>
+ * This client is thread-safe. One client instance should be used per cluster.
+ * Multiple threads should share this cluster instance.
+ * <p>
+ * Each record may have multiple bins, unless the Aerospike server nodes are
+ * configured as "single-bin". In "multi-bin" mode, partial records may be
+ * written or read by specifying the relevant subset of bins.
+ */
+public class DefaultAsyncClient extends DefaultAerospikeClient implements AsyncClient {
+	//-------------------------------------------------------
+	// Member variables.
+	//-------------------------------------------------------
+	
+	private final AsyncCluster cluster;
+	
+	//-------------------------------------------------------
+	// Constructors
+	//-------------------------------------------------------
+
+	/**
+	 * Initialize asynchronous client.
+	 * If the host connection succeeds, the client will:
+	 * <p>
+	 * - Add host to the cluster map <br>
+	 * - Request host's list of other nodes in cluster <br>
+	 * - Add these nodes to cluster map <br>
+	 * <p>
+	 * If the connection succeeds, the client is ready to process database requests.
+	 * If the connection fails, the cluster will remain in a disconnected state
+	 * until the server is activated.
+	 * 
+	 * @param hostname				host name
+	 * @param port					host port
+	 * @throws AerospikeException	if host connection fails
+	 */
+	public DefaultAsyncClient(String hostname, int port) throws AerospikeException {
+		this(new AsyncClientPolicy(), new Host(hostname, port));
+	}
+
+	/**
+	 * Initialize asynchronous client.
+	 * The client policy is used to set defaults and size internal data structures.
+	 * If the host connection succeeds, the client will:
+	 * <p>
+	 * - Add host to the cluster map <br>
+	 * - Request host's list of other nodes in cluster <br>
+	 * - Add these nodes to cluster map <br>
+	 * <p>
+	 * If the connection succeeds, the client is ready to process database requests.
+	 * If the connection fails and the policy's failOnInvalidHosts is true, a connection 
+	 * exception will be thrown. Otherwise, the cluster will remain in a disconnected state
+	 * until the server is activated.
+	 * 
+	 * @param policy				client configuration parameters, pass in null for defaults
+	 * @param hostname				host name
+	 * @param port					host port
+	 * @throws AerospikeException	if host connection fails
+	 */
+	public DefaultAsyncClient(AsyncClientPolicy policy, String hostname, int port) throws AerospikeException {
+		this(policy, new Host(hostname, port));	
+	}
+
+	/**
+	 * Initialize asynchronous client with suitable hosts to seed the cluster map.
+	 * The client policy is used to set defaults and size internal data structures.
+	 * For each host connection that succeeds, the client will:
+	 * <p>
+	 * - Add host to the cluster map <br>
+	 * - Request host's list of other nodes in cluster <br>
+	 * - Add these nodes to cluster map <br>
+	 * <p>
+	 * In most cases, only one host is necessary to seed the cluster. The remaining hosts 
+	 * are added as future seeds in case of a complete network failure.
+	 * <p>
+	 * If one connection succeeds, the client is ready to process database requests.
+	 * If all connections fail and the policy's failIfNotConnected is true, a connection 
+	 * exception will be thrown. Otherwise, the cluster will remain in a disconnected state
+	 * until the server is activated.
+	 * 
+	 * @param policy				client configuration parameters, pass in null for defaults
+	 * @param hosts					array of potential hosts to seed the cluster
+	 * @throws AerospikeException	if all host connections fail
+	 */
+	public DefaultAsyncClient(AsyncClientPolicy policy, Host... hosts) throws AerospikeException {
+		if (policy == null) {
+			policy = new AsyncClientPolicy();
+		}
+		this.cluster = new AsyncCluster(policy, hosts);
+		super.cluster = this.cluster;
+		
+		if (policy.failIfNotConnected && ! this.cluster.isConnected()) {
+			throw new AerospikeException.Connection("Failed to connect to host(s): " + Arrays.toString(hosts));
+		}
+	}
+
+	//-------------------------------------------------------
+	// Write Record Operations
+	//-------------------------------------------------------
+	
+	@Override
+    public final void put(WritePolicy policy, WriteListener listener, Key key, Bin... bins) throws AerospikeException {
+		AsyncWrite command = new AsyncWrite(cluster, policy, listener, key, bins, Operation.Type.WRITE);
+		command.execute();
+	}
+
+	//-------------------------------------------------------
+	// String Operations
+	//-------------------------------------------------------
+		
+	@Override
+    public final void append(WritePolicy policy, WriteListener listener, Key key, Bin... bins) throws AerospikeException {
+		AsyncWrite command = new AsyncWrite(cluster, policy, listener, key, bins, Operation.Type.APPEND);
+		command.execute();
+	}
+	
+	@Override
+    public final void prepend(WritePolicy policy, WriteListener listener, Key key, Bin... bins) throws AerospikeException {
+		AsyncWrite command = new AsyncWrite(cluster, policy, listener, key, bins, Operation.Type.PREPEND);
+		command.execute();
+	}
+
+	//-------------------------------------------------------
+	// Arithmetic Operations
+	//-------------------------------------------------------
+	
+	@Override
+    public final void add(WritePolicy policy, WriteListener listener, Key key, Bin... bins) throws AerospikeException {
+		AsyncWrite command = new AsyncWrite(cluster, policy, listener, key, bins, Operation.Type.ADD);
+		command.execute();
+	}
+
+	//-------------------------------------------------------
+	// Delete Operations
+	//-------------------------------------------------------
+	
+	@Override
+    public final void delete(WritePolicy policy, DeleteListener listener, Key key) throws AerospikeException {
+		AsyncDelete command = new AsyncDelete(cluster, policy, listener, key);
+		command.execute();
+	}
+
+	//-------------------------------------------------------
+	// Touch Operations
+	//-------------------------------------------------------
+
+	@Override
+    public final void touch(WritePolicy policy, WriteListener listener, Key key) throws AerospikeException {
+		AsyncTouch command = new AsyncTouch(cluster, policy, listener, key);
+		command.execute();
+	}
+
+	//-------------------------------------------------------
+	// Existence-Check Operations
+	//-------------------------------------------------------
+	
+	@Override
+    public final void exists(Policy policy, ExistsListener listener, Key key) throws AerospikeException {
+		AsyncExists command = new AsyncExists(cluster, policy, listener, key);
+		command.execute();
+	}
+
+	@Override
+    public final void exists(Policy policy, ExistsArrayListener listener, Key[] keys) throws AerospikeException {
+		new AsyncBatchExistsArrayExecutor(cluster, policy, keys, listener);		
+	}
+
+	@Override
+    public final void exists(Policy policy, ExistsSequenceListener listener, Key[] keys) throws AerospikeException {
+		new AsyncBatchExistsSequenceExecutor(cluster, policy, keys, listener);		
+	}
+
+	//-------------------------------------------------------
+	// Read Record Operations
+	//-------------------------------------------------------
+	
+	@Override
+    public final void get(Policy policy, RecordListener listener, Key key) throws AerospikeException {
+		AsyncRead command = new AsyncRead(cluster, policy, listener, key, null);
+		command.execute();
+	}
+	
+	@Override
+    public final void get(Policy policy, RecordListener listener, Key key, String... binNames) throws AerospikeException {
+		AsyncRead command = new AsyncRead(cluster, policy, listener, key, binNames);
+		command.execute();
+	}
+
+	@Override
+    public final void getHeader(Policy policy, RecordListener listener, Key key) throws AerospikeException {
+		AsyncReadHeader command = new AsyncReadHeader(cluster, policy, listener, key);
+		command.execute();
+	}
+
+	//-------------------------------------------------------
+	// Batch Read Operations
+	//-------------------------------------------------------
+
+	@Override
+    public final void get(Policy policy, RecordArrayListener listener, Key[] keys) throws AerospikeException {
+		new AsyncBatchGetArrayExecutor(cluster, policy, listener, keys, null, Command.INFO1_READ | Command.INFO1_GET_ALL);
+	}
+
+	@Override
+    public final void get(Policy policy, RecordSequenceListener listener, Key[] keys) throws AerospikeException {
+		new AsyncBatchGetSequenceExecutor(cluster, policy, listener, keys, null, Command.INFO1_READ | Command.INFO1_GET_ALL);		
+	}
+	
+	@Override
+    public final void get(Policy policy, RecordArrayListener listener, Key[] keys, String... binNames)
+		throws AerospikeException {
+		HashSet<String> names = binNamesToHashSet(binNames);
+		new AsyncBatchGetArrayExecutor(cluster, policy, listener, keys, names, Command.INFO1_READ);
+	}
+
+	@Override
+    public final void get(Policy policy, RecordSequenceListener listener, Key[] keys, String... binNames)
+		throws AerospikeException {
+		HashSet<String> names = binNamesToHashSet(binNames);
+		new AsyncBatchGetSequenceExecutor(cluster, policy, listener, keys, names, Command.INFO1_READ);
+	}
+	
+	@Override
+    public final void getHeader(Policy policy, RecordArrayListener listener, Key[] keys) throws AerospikeException {
+		new AsyncBatchGetArrayExecutor(cluster, policy, listener, keys, null, Command.INFO1_READ | Command.INFO1_NOBINDATA);
+	}
+
+	@Override
+    public final void getHeader(Policy policy, RecordSequenceListener listener, Key[] keys) throws AerospikeException {
+		new AsyncBatchGetSequenceExecutor(cluster, policy, listener, keys, null, Command.INFO1_READ | Command.INFO1_NOBINDATA);
+	}
+
+	//-------------------------------------------------------
+	// Generic Database Operations
+	//-------------------------------------------------------
+	
+	@Override
+    public final void operate(WritePolicy policy, RecordListener listener, Key key, Operation... operations)
+		throws AerospikeException {		
+		AsyncOperate command = new AsyncOperate(cluster, policy, listener, key, operations);
+		command.execute();
+	}
+
+	//-------------------------------------------------------
+	// Scan Operations
+	//-------------------------------------------------------
+
+	@Override
+    public final void scanAll(ScanPolicy policy, RecordSequenceListener listener, String namespace, String setName, String... binNames)
+		throws AerospikeException {
+		if (policy == null) {
+			policy = new ScanPolicy();
+		}
+		
+		// Retry policy must be one-shot for scans.
+		policy.maxRetries = 0;
+		new AsyncScanExecutor(cluster, policy, listener, namespace, setName, binNames);
+	}
+}

--- a/examples/src/com/aerospike/examples/AsyncExample.java
+++ b/examples/src/com/aerospike/examples/AsyncExample.java
@@ -26,6 +26,7 @@ import java.util.List;
 
 import com.aerospike.client.async.AsyncClient;
 import com.aerospike.client.async.AsyncClientPolicy;
+import com.aerospike.client.async.DefaultAsyncClient;
 
 public abstract class AsyncExample {
 	/**
@@ -37,7 +38,7 @@ public abstract class AsyncExample {
 		policy.asyncSelectorThreads = 1;
 		policy.asyncSelectorTimeout = 10;
 		
-		AsyncClient client = new AsyncClient(policy, params.host, params.port);
+		AsyncClient client = new DefaultAsyncClient(policy, params.host, params.port);
 
 		try {
 			for (String exampleName : examples) {

--- a/examples/src/com/aerospike/examples/Example.java
+++ b/examples/src/com/aerospike/examples/Example.java
@@ -25,6 +25,7 @@ import java.lang.reflect.Constructor;
 import java.util.List;
 
 import com.aerospike.client.AerospikeClient;
+import com.aerospike.client.DefaultAerospikeClient;
 import com.aerospike.client.policy.ClientPolicy;
 
 public abstract class Example {
@@ -36,7 +37,7 @@ public abstract class Example {
 	 */
 	public static void runExamples(Console console, Parameters params, List<String> examples) throws Exception {
 		ClientPolicy policy = new ClientPolicy();		
-		AerospikeClient client = new AerospikeClient(policy, params.host, params.port);
+		AerospikeClient client = new DefaultAerospikeClient(policy, params.host, params.port);
 
 		try {
 			for (String exampleName : examples) {

--- a/servlets/src/com/aerospike/servlets/AerospikeServlet.java
+++ b/servlets/src/com/aerospike/servlets/AerospikeServlet.java
@@ -32,11 +32,7 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import com.aerospike.client.AerospikeClient;
-import com.aerospike.client.AerospikeException;
-import com.aerospike.client.Bin;
-import com.aerospike.client.Key;
-import com.aerospike.client.Record;
+import com.aerospike.client.*;
 import com.aerospike.client.policy.Policy;
 import com.aerospike.client.policy.RecordExistsAction;
 import com.aerospike.client.policy.WritePolicy;
@@ -112,7 +108,7 @@ public class AerospikeServlet extends HttpServlet {
 		}
 		
 		try {
-			client = new AerospikeClient(host, port);						
+			client = new DefaultAerospikeClient(host, port);
 			
 			if (client.isConnected())
 				return true;


### PR DESCRIPTION
This change is motivated by the fact that it is hard to write unit tests  for functionality that uses client classes ie. DAO. Because of the fact that most API methods are marked as final it is not possible to 'mock' them for unit testing purposes. Introducing interfaces solves that issue and does not force developer to write wrapper/proxies

The change includes the following refactorings:
1) AerospikeClient renamed to DefaultAerospikeClient
2) AsyncClient renamed to DefaultAsyncClient
3) interface AerospikeClient extracted (with java docs pulled up)
4) interface AsyncClient extracted (with java docs pulled up)
