### PR TITLE
fixing concurrent access bug for BatchExecutor

### DIFF
--- a/client/src/com/aerospike/client/command/BatchExecutor.java
+++ b/client/src/com/aerospike/client/command/BatchExecutor.java
@@ -138,7 +138,7 @@ public final class BatchExecutor {
 	private final class BatchThread implements Runnable {
 		private MultiCommand command;
 		private Thread thread;
-		private boolean complete;
+		private volatile boolean complete;
 
 		public BatchThread(MultiCommand command) {
 			this.command = command;


### PR DESCRIPTION
Hi Brian,

We discovered an issues in our system when that our business threads are hanging forever, waiting for waitTillComplete() forever. Thread and Heap dumps have shown that all BatchThread instances has complete flag True, but BatchExecutor (owner class) has it set to False.

After some tests we discovered that there is concurrent access issue in threadCompleted() method, when traversing BatchThread instances without any protection.

This fix adds volatile flag for BatchThread.complete flag, which is checked in the cycle. Initial 2 hours test has shown 0 hanged threads, we started long stability test, however I think this fix should be enough to correct the problem.
