### PR TITLE
add an increment to be sure to not be out of bounds

### DIFF
--- a/client/src/com/aerospike/client/command/Command.java
+++ b/client/src/com/aerospike/client/command/Command.java
@@ -67,7 +67,7 @@ public abstract class Command {
 		int fieldCount = estimateKeySize(key);
 		
 		if (policy.sendKey) {
-			dataOffset += key.userKey.estimateSize() + FIELD_HEADER_SIZE;
+			dataOffset += key.userKey.estimateSize() + FIELD_HEADER_SIZE +1;
 			fieldCount++;
 		}
 		


### PR DESCRIPTION
Hi,

I need to do scanAll on my sets. So i've to send user key at the server on write.
When i do so with little bin value (1024 bytes), all is fine.
But with a bin value of 10KB, i've java.lang.ArrayIndexOutOfBoundsException.

So i add an increment to be sure to not be out of bounds when sendKey is enabled and the size is near of 8192 bytes.

Hope it helps.