### PR TITLE
Reverting Unpacker 0xd1 change made in Release 3.0.35

### DIFF
--- a/client/src/com/aerospike/client/util/Unpacker.java
+++ b/client/src/com/aerospike/client/util/Unpacker.java
@@ -185,10 +185,10 @@ public abstract class Unpacker<T> {
 			case 0xcc: { // unsigned 8 bit integer
 				return getLong(buffer[offset++] & 0xff);
 			}
-				
-			case 0xd1: { // signed 16 bit integer
-				short val = Buffer.bigSigned16ToShort(buffer, offset);
-				offset += 2;			
+
+			case 0xd1: {
+				int val = Buffer.bytesToShort(buffer, offset);
+				offset += 2;
 				return getLong(val);
 			}
 


### PR DESCRIPTION
This change in Release 3.0.35 is causing the AerospikeClient.register to fail.   I am undoing it so that it works again.