### PR TITLE
Fixed a bug with com.aerospike.client.Value#equals

### DIFF
--- a/client/src/com/aerospike/client/Value.java
+++ b/client/src/com/aerospike/client/Value.java
@@ -985,7 +985,7 @@ public abstract class Value {
 	@Override
 	public boolean equals(Object otherValue) {
 		return (otherValue != null
-				&& otherValue.getClass().isAssignableFrom(Value.class)
+				&& this.getClass().equals(otherValue.getClass())
 				&& ((Value)otherValue).toString().equals(this.toString()));
 	}
 }


### PR DESCRIPTION
It seems there's a bug with the `com.aerospike.client.Value#equals` method. The following is the simplest demonstration:

```java
package com.aerospike.client;
public class ValueTest {
	public static void main(String[] args) {
		System.out.println(Value.get(100).equals(Value.get(100)));
		System.out.println(Value.get("hello").equals(Value.get("hello")));

		// Different value types should not be equal
		System.out.println(Value.get("100").equals(Value.get(100)));
		System.out.println(Value.get("true").equals(Value.get(true)));
	}
}
```

I expected to see:

```
true
true
false
false
```

instead, I see that everything returns false. The problem is the order of the objects in the `#isAssignableFrom` call. However, when you switch them around, you run into another problem where different value types could then match (due to the `#toString` equals check), leading to the above example showing all true.

The following 1 line change should address those issues.