### PR TITLE
NullValue is now cached to avoid unnecessary object instantiations and improve performance

### DIFF
--- a/client/src/com/aerospike/client/Value.java
+++ b/client/src/com/aerospike/client/Value.java
@@ -52,21 +52,21 @@ public abstract class Value {
 	 * Get string or null value instance.
 	 */
 	public static Value get(String value) {
-		return (value == null)? new NullValue() : new StringValue(value);
+		return (value == null)? NullValue.INSTANCE : new StringValue(value);
 	}
 
 	/**
 	 * Get byte array or null value instance.
 	 */
 	public static Value get(byte[] value) {
-		return (value == null)? new NullValue() : new BytesValue(value);
+		return (value == null)? NullValue.INSTANCE : new BytesValue(value);
 	}
 	
 	/**
 	 * Get byte segment or null value instance.
 	 */
 	public static Value get(byte[] value, int offset, int length) {
-		return (value == null)? new NullValue() : new ByteSegmentValue(value, offset, length);
+		return (value == null)? NullValue.INSTANCE : new ByteSegmentValue(value, offset, length);
 	}
 
 	/**
@@ -109,7 +109,7 @@ public abstract class Value {
 	 * Supported by Aerospike 3 servers only.
 	 */
 	public static Value get(List<?> value) {
-		return (value == null)? new NullValue() : new ListValue(value);
+		return (value == null)? NullValue.INSTANCE : new ListValue(value);
 	}
 
 	/**
@@ -117,35 +117,35 @@ public abstract class Value {
 	 * Supported by Aerospike 3 servers only.
 	 */
 	public static Value get(Map<?,?> value) {
-		return (value == null)? new NullValue() : new MapValue(value);
+		return (value == null)? NullValue.INSTANCE : new MapValue(value);
 	}
 
 	/**
 	 * Get value array instance.
 	 */
 	public static Value get(Value[] value) {
-		return (value == null)? new NullValue() : new ValueArray(value);
+		return (value == null)? NullValue.INSTANCE : new ValueArray(value);
 	}
 
 	/**
 	 * Get blob or null value instance.
 	 */
 	public static Value getAsBlob(Object value) {
-		return (value == null)? new NullValue() : new BlobValue(value);
+		return (value == null)? NullValue.INSTANCE : new BlobValue(value);
 	}
 
 	/**
 	 * Get GeoJSON or null value instance.
 	 */
 	public static Value getAsGeoJSON(String value) {
-		return (value == null)? new NullValue() : new GeoJSONValue(value);
+		return (value == null)? NullValue.INSTANCE : new GeoJSONValue(value);
 	}
 
 	/**
 	 * Get null value instance.
 	 */
 	public static Value getAsNull() {
-		return new NullValue();
+		return NullValue.INSTANCE;
 	}
 	
 	/**
@@ -157,7 +157,7 @@ public abstract class Value {
 	 */
 	public static Value get(Object value) {
 		if (value == null) {
-			return new NullValue();
+			return NullValue.INSTANCE;
 		}
 		
 		if (value instanceof Value) {
@@ -267,6 +267,8 @@ public abstract class Value {
 	 * Empty value.
 	 */
 	public static final class NullValue extends Value {
+		public static final NullValue INSTANCE = new NullValue();
+		
 		@Override
 		public int estimateSize() {
 			return 0;


### PR DESCRIPTION
I heavily use NullValues and I believe this pull request will help improving the overall performance of NullValue creation inside Value.java, as the logic of a NullValue object is always the same and allows us to cache it in a single instance. Less object allocation should also reduce garbage collection pressure.

This strategy is well known and is used in the Java ecosystem very frequently (e.g Collections.emptyList() or BigDecimal.ZERO), so this is not a novel or untested approach.