### PR TITLE
Lua cache problems

### DIFF
--- a/client/src/com/aerospike/client/AerospikeClient.java
+++ b/client/src/com/aerospike/client/AerospikeClient.java
@@ -16,13 +16,6 @@
  */
 package com.aerospike.client;
 
-import java.io.Closeable;
-import java.io.File;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-
 import com.aerospike.client.admin.AdminCommand;
 import com.aerospike.client.admin.Privilege;
 import com.aerospike.client.admin.Role;
@@ -51,6 +44,7 @@ import com.aerospike.client.large.LargeList;
 import com.aerospike.client.large.LargeMap;
 import com.aerospike.client.large.LargeSet;
 import com.aerospike.client.large.LargeStack;
+import com.aerospike.client.lua.LuaCache;
 import com.aerospike.client.policy.AdminPolicy;
 import com.aerospike.client.policy.BatchPolicy;
 import com.aerospike.client.policy.ClientPolicy;
@@ -72,6 +66,13 @@ import com.aerospike.client.task.IndexTask;
 import com.aerospike.client.task.RegisterTask;
 import com.aerospike.client.util.RandomShift;
 import com.aerospike.client.util.Util;
+
+import java.io.Closeable;
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Instantiate an <code>AerospikeClient</code> object to access an Aerospike
@@ -955,6 +956,8 @@ public class AerospikeClient implements IAerospikeClient, Closeable {
 		String response = Info.request(policy, node, command);
 		
 		if (response.equalsIgnoreCase("ok")) {
+			// Clear LuaCache as it still references the old UDF.
+			LuaCache.clearPackageFromCache(serverPath);
 			return;
 		}
 		

--- a/client/src/com/aerospike/client/lua/LuaInstance.java
+++ b/client/src/com/aerospike/client/lua/LuaInstance.java
@@ -16,11 +16,11 @@
  */
 package com.aerospike.client.lua;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
+import com.aerospike.client.AerospikeException;
+import com.aerospike.client.Value;
+import com.aerospike.client.command.Buffer;
+import com.aerospike.client.command.ParticleType;
+import com.aerospike.client.query.Statement;
 import org.luaj.vm2.Globals;
 import org.luaj.vm2.LoadState;
 import org.luaj.vm2.LuaBoolean;
@@ -44,11 +44,10 @@ import org.luaj.vm2.lib.jse.JseMathLib;
 import org.luaj.vm2.lib.jse.JseOsLib;
 import org.luaj.vm2.lib.jse.LuajavaLib;
 
-import com.aerospike.client.AerospikeException;
-import com.aerospike.client.Value;
-import com.aerospike.client.command.Buffer;
-import com.aerospike.client.command.ParticleType;
-import com.aerospike.client.query.Statement;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 public final class LuaInstance {
 	
@@ -120,6 +119,10 @@ public final class LuaInstance {
 		LuaClosure function = new LuaClosure(prototype, globals);
 		function.invoke();
 		loadedTable.set(packageName, LuaValue.TRUE);
+	}
+
+	public void unloadPackage(String packageName) {
+		loadedTable.set(packageName, LuaValue.FALSE);
 	}
 
 	public void load(LibFunction function) {


### PR DESCRIPTION
I have several integration tests in which I register a lua file, let's call it "mylua", but sometimes I need to re-register it with extra functions in different tests (as it is generated dynamically), or simply remove it.

However, LuaCache contains pre-cached `Prototype`(s) and `LuaInstance`(s) for performance reasons I presume, but when `removeUdf` is called in `AerospikeClient `or a new `register` operation happens, the actual references inside all the `LuaInstance`(s) are still pointing to the previously compiled "mylua" and therefore trying to call new functions from the new "mylua" file will fail with "function not found".

I have seen a `LuaCache.clearPackages()` method in `LuaCache`, and I thought would fix my problem. But even though we clear the `Prototype`(s) map, the previously created `LuaInstance`(s) are still cached, and every time a `QueryAggregateExecutor `calls `lua.loadPackage(statement)` it will not reload the new file as this code snippet checks if it was already loaded or not and the response is always **true**:

``		if (loadedTable.get(statement.getPackageName()).toboolean()) {
			return;
		}
``

Therefore I extended the classes **AerospikeClient.java**, **LuaCache.java** and **LuaInstance.java,** so the `removeUdf `method clears the package from `LuaCache `and also sets the load value to false for each package in each `LuaInstance `object. I also extended **clearPackages** to clear the `LuaInstance `queue as well, as any instance in the queue will be "corrupted" and still referencing old non-existent lua files.

It definitely helps testing, and I believe this is also the way `removeUdf `method should really work.



