### PR TITLE
Added null check for exceptions in Cluster::seedNodes()

### DIFF
--- a/client/src/com/aerospike/client/cluster/Cluster.java
+++ b/client/src/com/aerospike/client/cluster/Cluster.java
@@ -432,7 +432,7 @@ public class Cluster implements Runnable, Closeable {
 				sb.append(seedArray[i]);
 				sb.append(' ');
 
-				Exception ex = exceptions[i];
+				Exception ex = exceptions == null ? null : exceptions[i];
 
 				if (ex != null)
 				{


### PR DESCRIPTION
I was having trouble with the new async library and got the following error:

```
Caused by: java.lang.NullPointerException
        at com.aerospike.client.cluster.Cluster.seedNodes(Cluster.java:435)
        at com.aerospike.client.cluster.Cluster.tend(Cluster.java:336)
        at com.aerospike.client.cluster.Cluster.waitTillStabilized(Cluster.java:301)
        at com.aerospike.client.cluster.Cluster.initTendThread(Cluster.java:211)
        at com.aerospike.client.AerospikeClient.<init>(AerospikeClient.java:233)
```

It seems like it fails to connect, but doesn't populate the exceptions in some cases.