### PR TITLE
Making IAerospikeClient extend java.io.Serializable

### DIFF
--- a/client/src/com/aerospike/client/BatchRead.java
+++ b/client/src/com/aerospike/client/BatchRead.java
@@ -16,12 +16,13 @@
  */
 package com.aerospike.client;
 
+import java.io.Serializable;
 import java.util.Arrays;
 
 /**
  * Key and bin names used in batch read commands where variables bins are needed for each key.
  */
-public final class BatchRead {
+public final class BatchRead implements Serializable {
 	/**
 	 * Key.
 	 */

--- a/client/src/com/aerospike/client/Bin.java
+++ b/client/src/com/aerospike/client/Bin.java
@@ -16,6 +16,7 @@
  */
 package com.aerospike.client;
 
+import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
 
@@ -23,7 +24,7 @@ import java.util.Map;
 /**
  * Column name/value pair. 
  */
-public final class Bin {
+public final class Bin implements Serializable {
 	/**
 	 * Bin name. Current limit is 14 characters.
 	 */

--- a/client/src/com/aerospike/client/Host.java
+++ b/client/src/com/aerospike/client/Host.java
@@ -16,12 +16,13 @@
  */
 package com.aerospike.client;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 
 /**
  * Host name/port of database server. 
  */
-public final class Host {
+public final class Host implements Serializable {
 	/**
 	 * Host name or IP address of database server.
 	 */

--- a/client/src/com/aerospike/client/IAerospikeClient.java
+++ b/client/src/com/aerospike/client/IAerospikeClient.java
@@ -17,37 +17,38 @@
 package com.aerospike.client;
 
 import java.io.Closeable;
+import java.io.Serializable;
 import java.util.Calendar;
 import java.util.List;
 
-import com.aerospike.client.admin.Privilege;
-import com.aerospike.client.admin.Role;
+import com.aerospike.client.admin.Privilege; 
+import com.aerospike.client.admin.Role; 
 import com.aerospike.client.admin.User;
-import com.aerospike.client.async.EventLoop;
-import com.aerospike.client.cluster.Node;
-import com.aerospike.client.listener.BatchListListener;
-import com.aerospike.client.listener.BatchSequenceListener;
-import com.aerospike.client.listener.DeleteListener;
-import com.aerospike.client.listener.ExecuteListener;
-import com.aerospike.client.listener.ExistsArrayListener;
-import com.aerospike.client.listener.ExistsListener;
-import com.aerospike.client.listener.ExistsSequenceListener;
-import com.aerospike.client.listener.RecordArrayListener;
-import com.aerospike.client.listener.RecordListener;
-import com.aerospike.client.listener.RecordSequenceListener;
-import com.aerospike.client.listener.WriteListener;
-import com.aerospike.client.policy.AdminPolicy;
+import com.aerospike.client.async.EventLoop; 
+import com.aerospike.client.cluster.Node; 
+import com.aerospike.client.listener.BatchListListener; 
+import com.aerospike.client.listener.BatchSequenceListener; 
+import com.aerospike.client.listener.DeleteListener; 
+import com.aerospike.client.listener.ExecuteListener; 
+import com.aerospike.client.listener.ExistsArrayListener; 
+import com.aerospike.client.listener.ExistsListener; 
+import com.aerospike.client.listener.ExistsSequenceListener; 
+import com.aerospike.client.listener.RecordArrayListener; 
+import com.aerospike.client.listener.RecordListener; 
+import com.aerospike.client.listener.RecordSequenceListener; 
+import com.aerospike.client.listener.WriteListener; 
+import com.aerospike.client.policy.AdminPolicy; 
 import com.aerospike.client.policy.BatchPolicy;
-import com.aerospike.client.policy.InfoPolicy;
-import com.aerospike.client.policy.Policy;
+import com.aerospike.client.policy.InfoPolicy; 
+import com.aerospike.client.policy.Policy; 
 import com.aerospike.client.policy.QueryPolicy;
 import com.aerospike.client.policy.ScanPolicy;
 import com.aerospike.client.policy.WritePolicy;
 import com.aerospike.client.query.IndexCollectionType;
 import com.aerospike.client.query.IndexType;
-import com.aerospike.client.query.RecordSet;
-import com.aerospike.client.query.ResultSet;
-import com.aerospike.client.query.Statement;
+import com.aerospike.client.query.RecordSet; 
+import com.aerospike.client.query.ResultSet; 
+import com.aerospike.client.query.Statement; 
 import com.aerospike.client.task.ExecuteTask;
 import com.aerospike.client.task.IndexTask;
 import com.aerospike.client.task.RegisterTask;
@@ -56,7 +57,7 @@ import com.aerospike.client.task.RegisterTask;
  * This interface's sole purpose is to allow mock frameworks to operate on
  * AerospikeClient without being constrained by final methods.
  */
-public interface IAerospikeClient extends Closeable {
+public interface IAerospikeClient extends Closeable, Serializable {
 	//-------------------------------------------------------
 	// Default Policies
 	//-------------------------------------------------------

--- a/client/src/com/aerospike/client/Info.java
+++ b/client/src/com/aerospike/client/Info.java
@@ -19,6 +19,7 @@ package com.aerospike.client;
 import gnu.crypto.util.Base64;
 
 import java.io.IOException;
+import java.io.Serializable;
 import java.net.InetSocketAddress;
 import java.util.HashMap;
 import java.util.Map;
@@ -40,7 +41,7 @@ import com.aerospike.client.util.ThreadLocalData;
  * <p>
  * 
  */
-public final class Info {	
+public final class Info implements Serializable {
 	//-------------------------------------------------------
 	// Static variables.
 	//-------------------------------------------------------

--- a/client/src/com/aerospike/client/Key.java
+++ b/client/src/com/aerospike/client/Key.java
@@ -18,6 +18,7 @@ package com.aerospike.client;
 
 import gnu.crypto.hash.RipeMD160;
 
+import java.io.Serializable;
 import java.util.Arrays;
 
 import com.aerospike.client.command.Buffer;
@@ -29,7 +30,7 @@ import com.aerospike.client.util.ThreadLocalData;
  * Records can also be identified by namespace/digest which is the combination used 
  * on the server.
  */
-public final class Key {
+public final class Key implements Serializable {
 	/**
 	 * Namespace. Equivalent to database name.
 	 */

--- a/client/src/com/aerospike/client/Log.java
+++ b/client/src/com/aerospike/client/Log.java
@@ -16,11 +16,13 @@
  */
 package com.aerospike.client;
 
+import java.io.Serializable;
+
 /**
  * Aerospike client logging facility. Logs can be filtered and message callbacks 
  * can be defined to control how log messages are written.
  */
-public final class Log {
+public final class Log implements Serializable {
 	/**
 	 * Log escalation level.
 	 */

--- a/client/src/com/aerospike/client/Operation.java
+++ b/client/src/com/aerospike/client/Operation.java
@@ -16,10 +16,12 @@
  */
 package com.aerospike.client;
 
+import java.io.Serializable;
+
 /**
  * Database operation definition.  The class is used in client's operate() method. 
  */
-public final class Operation {	
+public final class Operation implements Serializable {
 	/**
 	 * Create read bin database operation.
 	 */

--- a/client/src/com/aerospike/client/Record.java
+++ b/client/src/com/aerospike/client/Record.java
@@ -16,6 +16,7 @@
  */
 package com.aerospike.client;
 
+import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -25,7 +26,7 @@ import com.aerospike.client.Value.GeoJSONValue;
 /**
  * Container object for records.  Records are equivalent to rows.
  */
-public final class Record {
+public final class Record implements Serializable {
 	/**
 	 * Map of requested name/value bins.
 	 */

--- a/client/src/com/aerospike/client/ResultCode.java
+++ b/client/src/com/aerospike/client/ResultCode.java
@@ -16,11 +16,13 @@
  */
 package com.aerospike.client;
 
+import java.io.Serializable;
+
 /**
  * Database operation error codes.  The positive numbers align with the server
  * side file proto.h.
  */
-public final class ResultCode {
+public final class ResultCode implements Serializable {
 	/**
 	 * Server is not accepting requests.
 	 */

--- a/client/src/com/aerospike/client/ScanCallback.java
+++ b/client/src/com/aerospike/client/ScanCallback.java
@@ -16,11 +16,13 @@
  */
 package com.aerospike.client;
 
+import java.io.Serializable;
+
 /**
  * An object implementing this interface is passed in <code>scan()</code> calls, so the caller can
  * be notified with scan results.
  */
-public interface ScanCallback {
+public interface ScanCallback extends Serializable {
 	/**
 	 * This method will be called for each record returned from a scan. The user may throw a 
 	 * {@link com.aerospike.client.AerospikeException.ScanTerminated AerospikeException.ScanTerminated} 

--- a/client/src/com/aerospike/client/Value.java
+++ b/client/src/com/aerospike/client/Value.java
@@ -18,6 +18,7 @@ package com.aerospike.client;
 
 import java.io.ByteArrayOutputStream;
 import java.io.ObjectOutputStream;
+import java.io.Serializable;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -38,7 +39,7 @@ import com.aerospike.client.util.Packer;
 /**
  * Polymorphic value classes used to efficiently serialize objects into the wire protocol.
  */
-public abstract class Value {
+public abstract class Value implements Serializable {
 	/**
 	 * Should the client use the new double floating point particle type supported by Aerospike
 	 * server versions >= 3.6.0.  It's important that all server nodes and XDR be upgraded before

--- a/client/src/com/aerospike/client/admin/Privilege.java
+++ b/client/src/com/aerospike/client/admin/Privilege.java
@@ -16,10 +16,12 @@
  */
 package com.aerospike.client.admin;
 
+import java.io.Serializable;
+
 /**
  * User privilege.
  */
-public final class Privilege {
+public final class Privilege implements Serializable {
 	/**
 	 * Privilege code.
 	 */

--- a/client/src/com/aerospike/client/admin/Role.java
+++ b/client/src/com/aerospike/client/admin/Role.java
@@ -16,12 +16,13 @@
  */
 package com.aerospike.client.admin;
 
+import java.io.Serializable;
 import java.util.List;
 
 /**
  * Role definition.
  */
-public final class Role {
+public final class Role implements Serializable {
 	/**
 	 * Manage users their roles.
 	 */

--- a/client/src/com/aerospike/client/admin/User.java
+++ b/client/src/com/aerospike/client/admin/User.java
@@ -16,12 +16,13 @@
  */
 package com.aerospike.client.admin;
 
+import java.io.Serializable;
 import java.util.List;
 
 /**
  * User and assigned roles.
  */
-public final class User {
+public final class User implements Serializable {
 	/**
 	 * User name.
 	 */

--- a/client/src/com/aerospike/client/async/EventLoop.java
+++ b/client/src/com/aerospike/client/async/EventLoop.java
@@ -16,6 +16,7 @@
  */
 package com.aerospike.client.async;
 
+import java.io.Serializable;
 import java.util.concurrent.TimeUnit;
 
 import com.aerospike.client.cluster.Cluster;
@@ -23,7 +24,7 @@ import com.aerospike.client.cluster.Cluster;
 /**
  * Aerospike event loop interface.
  */
-public interface EventLoop {	
+public interface EventLoop extends Serializable {
 	/**
 	 * Execute async command.  Execute immediately if in event loop.
 	 * Otherwise, place command on event loop queue.

--- a/client/src/com/aerospike/client/cluster/Node.java
+++ b/client/src/com/aerospike/client/cluster/Node.java
@@ -17,6 +17,7 @@
 package com.aerospike.client.cluster;
 
 import java.io.Closeable;
+import java.io.Serializable;
 import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
 import java.util.ArrayDeque;
@@ -39,7 +40,7 @@ import com.aerospike.client.util.Util;
 /**
  * Server node representation.  This class manages server node connections and health status.
  */
-public class Node implements Closeable {
+public class Node implements Closeable, Serializable {
 	/**
 	 * Number of partitions for each namespace.
 	 */

--- a/client/src/com/aerospike/client/command/Buffer.java
+++ b/client/src/com/aerospike/client/command/Buffer.java
@@ -18,6 +18,7 @@ package com.aerospike.client.command;
 
 import java.io.ByteArrayInputStream;
 import java.io.ObjectInputStream;
+import java.io.Serializable;
 import java.io.UnsupportedEncodingException;
 import java.math.BigInteger;
 import java.util.Arrays;
@@ -26,7 +27,7 @@ import com.aerospike.client.AerospikeException;
 import com.aerospike.client.Value;
 import com.aerospike.client.util.Unpacker;
 
-public final class Buffer {
+public final class Buffer implements Serializable {
 
 	public static Value bytesToKeyValue(int type, byte[] buf, int offset, int len)
 		throws AerospikeException {

--- a/client/src/com/aerospike/client/command/ParticleType.java
+++ b/client/src/com/aerospike/client/command/ParticleType.java
@@ -16,7 +16,9 @@
  */
 package com.aerospike.client.command;
 
-public final class ParticleType {
+import java.io.Serializable;
+
+public final class ParticleType implements Serializable {
 	// Server particle types. Unsupported types are commented out.
 	public static final int NULL = 0;
 	public static final int INTEGER = 1;

--- a/client/src/com/aerospike/client/listener/BatchListListener.java
+++ b/client/src/com/aerospike/client/listener/BatchListListener.java
@@ -16,6 +16,7 @@
  */
 package com.aerospike.client.listener;
 
+import java.io.Serializable;
 import java.util.List;
 
 import com.aerospike.client.AerospikeException;
@@ -25,7 +26,7 @@ import com.aerospike.client.BatchRead;
  * Asynchronous result notifications for batch get commands with variable bins per key.
  * The result is sent in a single list.
  */
-public interface BatchListListener {
+public interface BatchListListener extends Serializable {
 	/**
 	 * This method is called when an asynchronous batch get command completes successfully.
 	 * 

--- a/client/src/com/aerospike/client/listener/BatchSequenceListener.java
+++ b/client/src/com/aerospike/client/listener/BatchSequenceListener.java
@@ -19,11 +19,13 @@ package com.aerospike.client.listener;
 import com.aerospike.client.AerospikeException;
 import com.aerospike.client.BatchRead;
 
+import java.io.Serializable;
+
 /**
  * Asynchronous result notifications for batch get commands with variable bins per key.
  * The results are sent one batch record at a time.
  */
-public interface BatchSequenceListener {
+public interface BatchSequenceListener extends Serializable {
 	/**
 	 * This method is called when an asynchronous batch record is received from the server.
 	 * The receive sequence is not ordered.

--- a/client/src/com/aerospike/client/listener/DeleteListener.java
+++ b/client/src/com/aerospike/client/listener/DeleteListener.java
@@ -19,10 +19,12 @@ package com.aerospike.client.listener;
 import com.aerospike.client.AerospikeException;
 import com.aerospike.client.Key;
 
+import java.io.Serializable;
+
 /**
  * Asynchronous result notifications for delete commands.
  */
-public interface DeleteListener {
+public interface DeleteListener extends Serializable {
 	/**
 	 * This method is called when an asynchronous delete command completes successfully.
 	 * 

--- a/client/src/com/aerospike/client/listener/ExecuteListener.java
+++ b/client/src/com/aerospike/client/listener/ExecuteListener.java
@@ -19,10 +19,12 @@ package com.aerospike.client.listener;
 import com.aerospike.client.AerospikeException;
 import com.aerospike.client.Key;
 
+import java.io.Serializable;
+
 /**
  * Asynchronous result notifications for execute commands.
  */
-public interface ExecuteListener {
+public interface ExecuteListener extends Serializable {
 	/**
 	 * This method is called when an asynchronous execute command completes successfully.
 	 * 

--- a/client/src/com/aerospike/client/listener/ExistsArrayListener.java
+++ b/client/src/com/aerospike/client/listener/ExistsArrayListener.java
@@ -19,11 +19,13 @@ package com.aerospike.client.listener;
 import com.aerospike.client.AerospikeException;
 import com.aerospike.client.Key;
 
+import java.io.Serializable;
+
 /**
  * Asynchronous result notifications for batch exists commands.
  * The result is sent in a single array.
  */
-public interface ExistsArrayListener {
+public interface ExistsArrayListener extends Serializable {
 	/**
 	 * This method is called when an asynchronous batch exists command completes successfully.
 	 * The returned boolean array is in positional order with the original key array order.

--- a/client/src/com/aerospike/client/listener/ExistsListener.java
+++ b/client/src/com/aerospike/client/listener/ExistsListener.java
@@ -19,10 +19,12 @@ package com.aerospike.client.listener;
 import com.aerospike.client.AerospikeException;
 import com.aerospike.client.Key;
 
+import java.io.Serializable;
+
 /**
  * Asynchronous result notifications for exists commands.
  */
-public interface ExistsListener {
+public interface ExistsListener extends Serializable {
 	/**
 	 * This method is called when an asynchronous exists command completes successfully.
 	 * 

--- a/client/src/com/aerospike/client/listener/ExistsSequenceListener.java
+++ b/client/src/com/aerospike/client/listener/ExistsSequenceListener.java
@@ -19,11 +19,13 @@ package com.aerospike.client.listener;
 import com.aerospike.client.AerospikeException;
 import com.aerospike.client.Key;
 
+import java.io.Serializable;
+
 /**
  * Asynchronous result notifications for batch exists commands.
  * The results are sent one record at a time.
  */
-public interface ExistsSequenceListener {
+public interface ExistsSequenceListener extends Serializable {
 	/**
 	 * This method is called when an asynchronous batch exists result is received from the server.
 	 * The receive sequence is not ordered.

--- a/client/src/com/aerospike/client/listener/RecordArrayListener.java
+++ b/client/src/com/aerospike/client/listener/RecordArrayListener.java
@@ -20,11 +20,13 @@ import com.aerospike.client.AerospikeException;
 import com.aerospike.client.Key;
 import com.aerospike.client.Record;
 
+import java.io.Serializable;
+
 /**
  * Asynchronous result notifications for batch get commands.
  * The result is sent in a single array.
  */
-public interface RecordArrayListener {
+public interface RecordArrayListener extends Serializable {
 	/**
 	 * This method is called when an asynchronous batch get command completes successfully.
 	 * The returned record array is in positional order with the original key array order.

--- a/client/src/com/aerospike/client/listener/RecordListener.java
+++ b/client/src/com/aerospike/client/listener/RecordListener.java
@@ -20,10 +20,12 @@ import com.aerospike.client.AerospikeException;
 import com.aerospike.client.Key;
 import com.aerospike.client.Record;
 
+import java.io.Serializable;
+
 /**
  * Asynchronous result notifications for get or operate commands.
  */
-public interface RecordListener {
+public interface RecordListener extends Serializable {
 	/**
 	 * This method is called when an asynchronous get or operate command completes successfully.
 	 * 

--- a/client/src/com/aerospike/client/listener/RecordSequenceListener.java
+++ b/client/src/com/aerospike/client/listener/RecordSequenceListener.java
@@ -20,11 +20,13 @@ import com.aerospike.client.AerospikeException;
 import com.aerospike.client.Key;
 import com.aerospike.client.Record;
 
+import java.io.Serializable;
+
 /**
  * Asynchronous result notifications for batch get and scan commands.
  * The results are sent one record at a time.
  */
-public interface RecordSequenceListener {
+public interface RecordSequenceListener extends Serializable {
 	/**
 	 * This method is called when an asynchronous record is received from the server.
 	 * The receive sequence is not ordered.

--- a/client/src/com/aerospike/client/listener/WriteListener.java
+++ b/client/src/com/aerospike/client/listener/WriteListener.java
@@ -19,10 +19,12 @@ package com.aerospike.client.listener;
 import com.aerospike.client.AerospikeException;
 import com.aerospike.client.Key;
 
+import java.io.Serializable;
+
 /**
  * Asynchronous result notifications for put, append, prepend, add, delete and touch commands.
  */
-public interface WriteListener {
+public interface WriteListener extends Serializable {
 	/**
 	 * This method is called when an asynchronous write command completes successfully.
 	 * 

--- a/client/src/com/aerospike/client/lua/LuaBytes.java
+++ b/client/src/com/aerospike/client/lua/LuaBytes.java
@@ -20,7 +20,9 @@ import org.luaj.vm2.LuaUserdata;
 
 import com.aerospike.client.command.Buffer;
 
-public final class LuaBytes extends LuaUserdata implements LuaData {
+import java.io.Serializable;
+
+public final class LuaBytes extends LuaUserdata implements LuaData, Serializable {
 
 	private LuaInstance instance;
 	private byte[] bytes;

--- a/client/src/com/aerospike/client/lua/LuaInstance.java
+++ b/client/src/com/aerospike/client/lua/LuaInstance.java
@@ -16,6 +16,7 @@
  */
 package com.aerospike.client.lua;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -50,7 +51,7 @@ import com.aerospike.client.command.Buffer;
 import com.aerospike.client.command.ParticleType;
 import com.aerospike.client.query.Statement;
 
-public final class LuaInstance {
+public final class LuaInstance implements Serializable {
 	
 	private final Globals globals = new Globals();
 	private final LuaTable loadedTable;

--- a/client/src/com/aerospike/client/policy/AdminPolicy.java
+++ b/client/src/com/aerospike/client/policy/AdminPolicy.java
@@ -16,10 +16,12 @@
  */
 package com.aerospike.client.policy;
 
+import java.io.Serializable;
+
 /**
  * Policy attributes used for user administration commands.
  */
-public final class AdminPolicy {
+public final class AdminPolicy implements Serializable {
 
 	/**
 	 * User administration command socket timeout in milliseconds.

--- a/client/src/com/aerospike/client/policy/InfoPolicy.java
+++ b/client/src/com/aerospike/client/policy/InfoPolicy.java
@@ -16,10 +16,12 @@
  */
 package com.aerospike.client.policy;
 
+import java.io.Serializable;
+
 /**
  * Policy attributes used for info commands.
  */
-public final class InfoPolicy {
+public final class InfoPolicy implements Serializable {
 	/**
 	 * Info command socket timeout in milliseconds.
 	 * Default is one second timeout.

--- a/client/src/com/aerospike/client/policy/Policy.java
+++ b/client/src/com/aerospike/client/policy/Policy.java
@@ -16,10 +16,12 @@
  */
 package com.aerospike.client.policy;
 
+import java.io.Serializable;
+
 /**
  * Transaction policy attributes used in all database commands.
  */
-public class Policy {
+public class Policy implements Serializable {
 	/**
 	 * Priority of request relative to other transactions.
 	 * Currently, only used for scans.

--- a/client/src/com/aerospike/client/query/RecordSet.java
+++ b/client/src/com/aerospike/client/query/RecordSet.java
@@ -17,6 +17,7 @@
 package com.aerospike.client.query;
 
 import java.io.Closeable;
+import java.io.Serializable;
 import java.util.Iterator;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
@@ -31,7 +32,7 @@ import com.aerospike.client.Record;
  * Multiple threads will retrieve records from the server nodes and put these records on the queue.
  * The single user thread consumes these records from the queue.
  */
-public final class RecordSet implements Iterable<KeyRecord>, Closeable {
+public final class RecordSet implements Iterable<KeyRecord>, Closeable, Serializable {
 	public static final KeyRecord END = new KeyRecord(null, null);
 	
 	private final QueryExecutor executor;

--- a/client/src/com/aerospike/client/query/ResultSet.java
+++ b/client/src/com/aerospike/client/query/ResultSet.java
@@ -17,6 +17,7 @@
 package com.aerospike.client.query;
 
 import java.io.Closeable;
+import java.io.Serializable;
 import java.util.Iterator;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
@@ -29,7 +30,7 @@ import com.aerospike.client.Log;
  * Multiple threads will retrieve results from the server nodes and put these results on the queue.
  * The single user thread consumes these results from the queue.
  */
-public final class ResultSet implements Iterable<Object>, Closeable {
+public final class ResultSet implements Iterable<Object>, Closeable, Serializable {
 	public static final Integer END = new Integer(-1);
 	
 	private final QueryAggregateExecutor executor;

--- a/client/src/com/aerospike/client/query/Statement.java
+++ b/client/src/com/aerospike/client/query/Statement.java
@@ -21,10 +21,12 @@ import com.aerospike.client.ResultCode;
 import com.aerospike.client.Value;
 import com.aerospike.client.util.RandomShift;
 
+import java.io.Serializable;
+
 /**
  * Query statement parameters.
  */
-public final class Statement {	
+public final class Statement implements Serializable {
 	String namespace;
 	String setName;
 	String indexName;

--- a/client/src/com/aerospike/client/task/Task.java
+++ b/client/src/com/aerospike/client/task/Task.java
@@ -16,6 +16,7 @@
  */
 package com.aerospike.client.task;
 
+import java.io.Serializable;
 import java.util.concurrent.TimeUnit;
 
 import com.aerospike.client.AerospikeException;
@@ -27,7 +28,7 @@ import com.aerospike.client.util.Util;
 /**
  * Task used to poll for server task completion.
  */
-public abstract class Task {
+public abstract class Task implements Serializable {
 	public static final int NOT_FOUND = 0;
 	public static final int IN_PROGRESS = 1;
 	public static final int COMPLETE = 2;

--- a/client/src/com/aerospike/client/util/Packer.java
+++ b/client/src/com/aerospike/client/util/Packer.java
@@ -19,6 +19,7 @@ package com.aerospike.client.util;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.ObjectOutputStream;
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -34,7 +35,7 @@ import com.aerospike.client.command.ParticleType;
  * 
  * https://github.com/msgpack/msgpack/blob/master/spec.md
  */
-public final class Packer {
+public final class Packer implements Serializable {
 	
 	public static byte[] pack(Value[] val) throws AerospikeException {
 		try {

--- a/client/src/com/aerospike/client/util/ThreadLocalData.java
+++ b/client/src/com/aerospike/client/util/ThreadLocalData.java
@@ -18,10 +18,12 @@ package com.aerospike.client.util;
 
 import com.aerospike.client.Log;
 
+import java.io.Serializable;
+
 /**
  * Thread local buffer storage.
  */
-public final class ThreadLocalData {
+public final class ThreadLocalData implements Serializable {
 	/**
 	 * Initial buffer size on first use of thread local buffer.
 	 */


### PR DESCRIPTION
Made IAerospikeClient extend java.io.Serializable with extending also all dependencies (only supertypes) that have been used by the interface.

The goal was to enable serialization of the IAerospikeClient in order to send it over the network to multiple worker machines while using Apache Beam. 

Serialization was tested in a real environment using Google Dataflow / Apache Beam machines but also with an easy but good enough example of saving the client to a file and reading it back using serialization.

```
    val client: IAerospikeClient = { ... }
    val fos = new FileOutputStream("client")
    val oos = new ObjectOutputStream(fos)

    oos.writeObject(client)

    val fis = new FileInputStream("client")
    val ois = new ObjectInputStream(fis)

    val deserializedClient = ois.readObject().asInstanceOf[IAerospikeClient]
```

To solve https://github.com/aerospike/aerospike-client-java/issues/90

