### PR TITLE
Add query.PredExp implement java.io.Serializable interface

### DIFF
--- a/client/src/com/aerospike/client/query/PredExp.java
+++ b/client/src/com/aerospike/client/query/PredExp.java
@@ -16,6 +16,7 @@
  */
 package com.aerospike.client.query;
 
+import java.io.Serializable;
 import java.util.Calendar;
 
 import com.aerospike.client.command.Buffer;
@@ -25,7 +26,7 @@ import com.aerospike.client.command.Buffer;
  * Predicate expression filters are applied on the query results on the server.
  * Predicate expression filters may occur on any bin in the record.
  */
-public abstract class PredExp {
+public abstract class PredExp implements Serializable {
 	/**
 	 * Create "and" expression.
 	 * 


### PR DESCRIPTION
Given that it doesn't make sense to have AerospikeClient implement Serializable interface, adding the components that can allow rebuilding the client on another hosts, should implement Serializable interface. The first step is to make query.PredExp implement Serializable interface.