### PR TITLE
Remove initialisation condition for data parse in read command

### DIFF
--- a/client/src/com/aerospike/client/command/ReadCommand.java
+++ b/client/src/com/aerospike/client/command/ReadCommand.java
@@ -187,7 +187,6 @@ public class ReadCommand extends SyncCommand {
 
     /*
      * The function represents mutability on the Record.
-     * {@link #setCallback(Callback callback) setCallback()}
      * The function is overridden in other commands to change
      * the behaviour of adding/modifying key to the map
      * @see com.aerospike.client.command.OperateCommand

--- a/client/src/com/aerospike/client/command/ReadCommand.java
+++ b/client/src/com/aerospike/client/command/ReadCommand.java
@@ -180,10 +180,21 @@ public class ReadCommand extends SyncCommand {
 			int particleBytesSize = (int) (opSize - (4 + nameSize));
 	        Object value = Buffer.bytesToParticle(particleType, dataBuffer, receiveOffset, particleBytesSize);
 			receiveOffset += particleBytesSize;
-			bins.put(name, value);
+			addBin(bins, name, value);
 	    }	
 	    return new Record(bins, generation, expiration);
 	}
+
+    /*
+     * The function represents mutability on the Record.
+     * {@link #setCallback(Callback callback) setCallback()}
+     * The function is overridden in other commands to change
+     * the behaviour of adding/modifying key to the map
+     * @see com.aerospike.client.command.OperateCommand
+     */
+    protected void addBin(Map<String, Object> bins, String name, Object value) {
+        bins.put(name, value);
+    }
 
 	public Record getRecord() {
 		return record;

--- a/client/src/com/aerospike/client/command/ReadCommand.java
+++ b/client/src/com/aerospike/client/command/ReadCommand.java
@@ -157,7 +157,7 @@ public class ReadCommand extends SyncCommand {
 		int generation,
 		int expiration
 	) throws AerospikeException {
-		Map<String,Object> bins = null;
+		Map<String,Object> bins = new HashMap();
 	    int receiveOffset = 0;
 	
 		// There can be fields in the response (setname etc).
@@ -180,19 +180,11 @@ public class ReadCommand extends SyncCommand {
 			int particleBytesSize = (int) (opSize - (4 + nameSize));
 	        Object value = Buffer.bytesToParticle(particleType, dataBuffer, receiveOffset, particleBytesSize);
 			receiveOffset += particleBytesSize;
-	
-			if (bins == null) {
-				bins = new HashMap<String,Object>();
-			}
-			addBin(bins, name, value);
+			bins.put(name, value);
 	    }	
 	    return new Record(bins, generation, expiration);
 	}
-	
-	protected void addBin(Map<String,Object> bins, String name, Object value) {
-		bins.put(name, value);	
-	}
-	
+
 	public Record getRecord() {
 		return record;
 	}


### PR DESCRIPTION
The PR intends to remove the local function variable check for initializations which happens for all the data bytes  coming from the server

1. Initialize the variable locally
2. Avoid a function call for put and remove the chance of map mutability


