### PR TITLE
Add a  check for put operation with minimum one bin

### DIFF
--- a/client/src/com/aerospike/client/AerospikeClient.java
+++ b/client/src/com/aerospike/client/AerospikeClient.java
@@ -366,7 +366,7 @@ public class AerospikeClient implements IAerospikeClient, Closeable {
 		if (policy == null) {
 			policy = writePolicyDefault;
 		}
-		if(bins.length < 1){
+		if(bins.length < 1) {
 			throw new AerospikeException("Require at least a single bin");
 		}
 		WriteCommand command = new WriteCommand(policy, key, bins, Operation.Type.WRITE);

--- a/client/src/com/aerospike/client/AerospikeClient.java
+++ b/client/src/com/aerospike/client/AerospikeClient.java
@@ -366,6 +366,9 @@ public class AerospikeClient implements IAerospikeClient, Closeable {
 		if (policy == null) {
 			policy = writePolicyDefault;
 		}
+		if(bins.length < 1){
+			throw new AerospikeException("Require at least a single bin");
+		}
 		WriteCommand command = new WriteCommand(policy, key, bins, Operation.Type.WRITE);
 		command.execute(cluster, policy, key, null, false);
 	}

--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,7 @@
     <module>examples</module>
     <module>benchmarks</module>
     <module>servlets</module>
+    <module>test</module>
   </modules>
 
 </project>


### PR DESCRIPTION
The pull request is for the interface to the `put` operation 
`void put(WritePolicy policy, Key key, Bin... bins) throws AerospikeException`
The problem is the `bins` argument is a vararg and it's very easy to miss the argument and still pass the compilation phase.
What I would like is 
`void put(WritePolicy policy, Key key, firstBin Bin, Bin... bins) throws AerospikeException`
Which gives me type safety. When I tried to refactor it's a big change and thought, for now, the exception will still be helpful rather than get an error like `AerospikeException: Error Code 4: Parameter error` Which doesn't help at all.

I am not sure if there is a particular case where the `Bin` can be optional like in cases of overriding, but then again I realized what's  the point of having a put operation without a data sent across