### PR TITLE
#142 NioEventLoop prevents main thread completion

### DIFF
--- a/client/src/com/aerospike/client/async/NioEventLoop.java
+++ b/client/src/com/aerospike/client/async/NioEventLoop.java
@@ -49,7 +49,8 @@ public final class NioEventLoop extends EventLoopBase implements Runnable {
     /**
      * Construct Aerospike event loop wrapper from NIO Selector.
      */
-	public NioEventLoop(EventPolicy policy, SelectorProvider provider, int index) throws IOException {
+	public NioEventLoop(EventPolicy policy, SelectorProvider provider, int index, boolean daemon, String poolName)
+			throws IOException {
 		super(policy, index);
 
 		commandQueue = new ConcurrentLinkedDeque<Runnable>();
@@ -58,8 +59,8 @@ public final class NioEventLoop extends EventLoopBase implements Runnable {
 		selectorTimeout = policy.minTimeout;
 		selector = provider.openSelector();
 
-		thread = new Thread(this, "event" + index);
-		thread.setDaemon(false);
+		thread = new Thread(this, poolName + '-' + index);
+		thread.setDaemon(daemon);
 	}
 
 	/**

--- a/client/src/com/aerospike/client/async/NioEventLoops.java
+++ b/client/src/com/aerospike/client/async/NioEventLoops.java
@@ -54,6 +54,18 @@ public final class NioEventLoops implements EventLoops {
 	 * @param size		number of event loops to create
 	 */
 	public NioEventLoops(EventPolicy policy, int size) throws AerospikeException {
+		this(policy, size, false, "aerospike-nio-event-loop");
+	}
+
+	/**
+	 * Create direct NIO event loops.
+	 *
+	 * @param policy	event loop policy
+	 * @param size		number of event loops to create
+	 * @param daemon	true if the associated threads should run as a daemons
+	 * @param poolName	event loop thread pool name
+	 */
+	public NioEventLoops(EventPolicy policy, int size, boolean daemon, String poolName) throws AerospikeException {
 		if (policy.minTimeout < 5) {
 			throw new AerospikeException("Invalid minTimeout " + policy.minTimeout + ". Must be at least 5ms.");
 		}
@@ -72,7 +84,7 @@ public final class NioEventLoops implements EventLoops {
 
 		for (int i = 0; i < eventLoops.length; i++) {
 			try {
-				eventLoops[i] = new NioEventLoop(policy, provider, i);
+				eventLoops[i] = new NioEventLoop(policy, provider, i, daemon, poolName);
 			}
 			catch (IOException ioe) {
                 for (int j = 0; j < i; j++) {


### PR DESCRIPTION
Exposed `daemon` and `poolName` parameters in `NioEventLoops` constructor. No behavioral changes. 