### PR TITLE
updated connection and login timeout arguments

### DIFF
--- a/benchmarks/src/com/aerospike/benchmarks/Main.java
+++ b/benchmarks/src/com/aerospike/benchmarks/Main.java
@@ -121,8 +121,11 @@ public class Main implements Log.Callback {
 		options.addOption("P", "password", true, "Password");
 		options.addOption("n", "namespace", true, "Set the Aerospike namespace. Default: test");
 		options.addOption("bns","batchNamespaces", true, "Set batch namespaces. Default is regular namespace.");
-        options.addOption("s", "set", true, "Set the Aerospike set name. Default: testset");
-        options.addOption("c", "clusterName", true, "Set expected cluster name.");
+        	options.addOption("s", "set", true, "Set the Aerospike set name. Default: testset");
+        	options.addOption("c", "clusterName", true, "Set expected cluster name.");
+		options.addOption("lt", "loginTimeout", true, "Set expected loginTimeout in millisecond.The timeout is used when user authentication is enabled and a node login is being performed. Default would be 5000 millisecond");
+        	options.addOption("ct", "connectTimeout", true, "Set expected connect timeout in millisecond. Initial host connection timeout in milliseconds. Default would be 1000 millisecond");
+
 
         options.addOption("k", "keys", true,
 			"Set the number of keys the client is dealing with. " +
@@ -341,6 +344,13 @@ public class Main implements Log.Callback {
 		else {
 			this.hosts = new Host[1];
 			this.hosts[0] = new Host("127.0.0.1", this.port);
+		}
+	if (line.hasOption("loginTimeout")) {
+			clientPolicy.loginTimeout = Integer.parseInt(line.getOptionValue("loginTimeout"));
+		}
+		
+	if (line.hasOption("connectTimeout")) {
+			clientPolicy.timeout = Integer.parseInt(line.getOptionValue("connectTimeout"));
 		}
 
         if (line.hasOption("tls")) {


### PR DESCRIPTION
Arguments for Connection timeout and Login timeout variable can be set as command line parameters.

Very crucial when running a benchmark against a high latency network.

This parameter helps to specify timeout values if there is latency between client to aerospike cluster and if there is latency between establishing a connection and external authentication system.

Both timeout variables are part of client.policy class.