### PR TITLE
Index key now contains index type

### DIFF
--- a/extensions/query-engine/src/main/java/com/aerospike/helper/query/cache/IndexedField.java
+++ b/extensions/query-engine/src/main/java/com/aerospike/helper/query/cache/IndexedField.java
@@ -1,21 +1,17 @@
 package com.aerospike.helper.query.cache;
 
-import com.aerospike.client.query.IndexType;
-
 import java.util.Objects;
 
-public class IndexKey {
+public class IndexedField {
 
     private final String namespace;
     private final String set;
     private final String field;
-    private final IndexType type;
 
-    public IndexKey(String namespace, String set, String field, IndexType type) {
+    public IndexedField(String namespace, String set, String field) {
         this.namespace = namespace;
         this.set = set;
         this.field = field;
-        this.type = type;
     }
 
     public String getNamespace() {
@@ -30,23 +26,18 @@ public class IndexKey {
         return field;
     }
 
-    public IndexType getType() {
-        return type;
-    }
-
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-        IndexKey indexKey = (IndexKey) o;
-        return Objects.equals(namespace, indexKey.namespace) &&
-                Objects.equals(set, indexKey.set) &&
-                Objects.equals(field, indexKey.field) &&
-                type == indexKey.type;
+        IndexedField that = (IndexedField) o;
+        return Objects.equals(namespace, that.namespace) &&
+                Objects.equals(set, that.set) &&
+                Objects.equals(field, that.field);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(namespace, set, field, type);
+        return Objects.hash(namespace, set, field);
     }
 }

--- a/extensions/query-engine/src/main/java/com/aerospike/helper/query/cache/InternalIndexOperations.java
+++ b/extensions/query-engine/src/main/java/com/aerospike/helper/query/cache/InternalIndexOperations.java
@@ -1,0 +1,68 @@
+package com.aerospike.helper.query.cache;
+
+import com.aerospike.helper.model.Index;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static java.util.stream.Collectors.collectingAndThen;
+import static java.util.stream.Collectors.toMap;
+
+/**
+ * Internal index related operations used by ReactorIndexCache and IndexCache.
+ */
+public class InternalIndexOperations {
+
+    private static final String SINDEX = "sindex";
+
+    private final IndexInfoParser indexInfoParser;
+
+    public InternalIndexOperations(IndexInfoParser indexInfoParser) {
+        this.indexInfoParser = indexInfoParser;
+    }
+
+    public Cache parseIndexesInfo(String infoResponse) {
+        if (infoResponse.isEmpty()) {
+            return Cache.empty();
+        }
+        return Cache.of(Arrays.stream(infoResponse.split(";"))
+                .map(indexInfoParser::parse)
+                .collect(collectingAndThen(
+                        toMap(InternalIndexOperations::getIndexKey, index -> index),
+                        Collections::unmodifiableMap)));
+    }
+
+    public String buildGetIndexesCommand() {
+        return SINDEX;
+    }
+
+    private static IndexKey getIndexKey(Index index) {
+        return new IndexKey(index.getNamespace(), index.getSet(), index.getBin(), index.getType());
+    }
+
+    public static class Cache {
+
+        private static final Cache EMPTY = new Cache(Collections.emptyMap());
+
+        public final Map<IndexKey, Index> indexes;
+        public final Set<IndexedField> indexedFields;
+
+        private Cache(Map<IndexKey, Index> indexes) {
+            this.indexes = Collections.unmodifiableMap(indexes);
+            this.indexedFields = indexes.keySet().stream()
+                    .map(key -> new IndexedField(key.getNamespace(), key.getSet(), key.getField()))
+                    .collect(Collectors.collectingAndThen(Collectors.toSet(), Collections::unmodifiableSet));
+        }
+
+        public static Cache empty() {
+            return EMPTY;
+        }
+
+        public static Cache of(Map<IndexKey, Index> cache) {
+            return new Cache(cache);
+        }
+    }
+}

--- a/extensions/query-engine/src/test/java/com/aerospike/helper/query/AerospikeAwareTests.java
+++ b/extensions/query-engine/src/test/java/com/aerospike/helper/query/AerospikeAwareTests.java
@@ -21,7 +21,7 @@ public abstract class AerospikeAwareTests {
 
     }
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         queryEngine = new QueryEngine(client);
     }
 

--- a/extensions/query-engine/src/test/java/com/aerospike/helper/query/HelperTests.java
+++ b/extensions/query-engine/src/test/java/com/aerospike/helper/query/HelperTests.java
@@ -38,7 +38,7 @@ public abstract class HelperTests extends AerospikeAwareTests {
 	protected Map<Long, Long> recordsModTenCounts;
 
 	@Before
-	public void setUp() throws Exception {
+	public void setUp() {
 		super.setUp();
 		int i = 0;
 		Key key = new Key(TestQueryEngine.NAMESPACE, TestQueryEngine.SET_NAME, "selector-test:"+ 10);

--- a/extensions/query-engine/src/test/java/com/aerospike/helper/query/IndexTests.java
+++ b/extensions/query-engine/src/test/java/com/aerospike/helper/query/IndexTests.java
@@ -3,8 +3,10 @@ package com.aerospike.helper.query;
 import com.aerospike.client.AerospikeException;
 import com.aerospike.client.Info;
 import com.aerospike.client.ResultCode;
+import com.aerospike.client.Value;
 import com.aerospike.client.cluster.Node;
 import com.aerospike.client.query.IndexType;
+import com.aerospike.client.query.Statement;
 import com.aerospike.client.task.IndexTask;
 import com.aerospike.helper.model.Index;
 import com.aerospike.helper.query.cache.IndexKey;
@@ -27,9 +29,10 @@ public class IndexTests extends AerospikeAwareTests {
 
     @Override
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         dropIndexIfExists(INDEX_NAME, TestQueryEngine.NAMESPACE, SET);
         dropIndexIfExists(INDEX_NAME_2, TestQueryEngine.NAMESPACE, null);
+        dropIndexIfExists(INDEX_NAME_2, TestQueryEngine.NAMESPACE, SET);
         dropIndexIfExists(INDEX_NAME_3, TestQueryEngine.NAMESPACE, SET);
         super.setUp();
     }
@@ -42,14 +45,14 @@ public class IndexTests extends AerospikeAwareTests {
 
     @Test
     public void refreshIndexes_findsNewlyCreatedIndex() {
-        Optional<Index> index = queryEngine.getIndex(new IndexKey(TestQueryEngine.NAMESPACE, SET, BIN_1));
+        Optional<Index> index = queryEngine.getIndex(new IndexKey(TestQueryEngine.NAMESPACE, SET, BIN_1, IndexType.NUMERIC));
         assertThat(index).isEmpty();
 
         wait(client.createIndex(null, TestQueryEngine.NAMESPACE, SET, INDEX_NAME, BIN_1, IndexType.NUMERIC));
 
         queryEngine.refreshIndexes();
 
-        index = queryEngine.getIndex(new IndexKey(TestQueryEngine.NAMESPACE, SET, BIN_1));
+        index = queryEngine.getIndex(new IndexKey(TestQueryEngine.NAMESPACE, SET, BIN_1, IndexType.NUMERIC));
         assertThat(index).isPresent()
                 .hasValueSatisfying(value -> {
                     assertThat(value.getName()).isEqualTo(INDEX_NAME);
@@ -66,13 +69,13 @@ public class IndexTests extends AerospikeAwareTests {
 
         queryEngine.refreshIndexes();
 
-        assertThat(queryEngine.getIndex(new IndexKey(TestQueryEngine.NAMESPACE, SET, BIN_1))).isPresent();
+        assertThat(queryEngine.getIndex(new IndexKey(TestQueryEngine.NAMESPACE, SET, BIN_1, IndexType.NUMERIC))).isPresent();
 
         wait(client.dropIndex(null, TestQueryEngine.NAMESPACE, SET, INDEX_NAME));
 
         queryEngine.refreshIndexes();
 
-        assertThat(queryEngine.getIndex(new IndexKey(TestQueryEngine.NAMESPACE, SET, BIN_1))).isEmpty();
+        assertThat(queryEngine.getIndex(new IndexKey(TestQueryEngine.NAMESPACE, SET, BIN_1, IndexType.NUMERIC))).isEmpty();
     }
 
     @Test
@@ -81,7 +84,7 @@ public class IndexTests extends AerospikeAwareTests {
 
         queryEngine.refreshIndexes();
 
-        Optional<Index> index = queryEngine.getIndex(new IndexKey(TestQueryEngine.NAMESPACE, null, BIN_2));
+        Optional<Index> index = queryEngine.getIndex(new IndexKey(TestQueryEngine.NAMESPACE, null, BIN_2, IndexType.STRING));
         assertThat(index).isPresent()
                 .hasValueSatisfying(value -> {
                     assertThat(value.getName()).isEqualTo(INDEX_NAME_2);
@@ -98,7 +101,7 @@ public class IndexTests extends AerospikeAwareTests {
 
         queryEngine.refreshIndexes();
 
-        Optional<Index> index = queryEngine.getIndex(new IndexKey(TestQueryEngine.NAMESPACE, SET, BIN_3));
+        Optional<Index> index = queryEngine.getIndex(new IndexKey(TestQueryEngine.NAMESPACE, SET, BIN_3, IndexType.GEO2DSPHERE));
         assertThat(index).isPresent()
                 .hasValueSatisfying(value -> {
                     assertThat(value.getName()).isEqualTo(INDEX_NAME_3);
@@ -117,15 +120,61 @@ public class IndexTests extends AerospikeAwareTests {
 
         queryEngine.refreshIndexes();
 
-        assertThat(queryEngine.getIndex(new IndexKey(TestQueryEngine.NAMESPACE, SET, BIN_1))).isPresent();
-        assertThat(queryEngine.getIndex(new IndexKey(TestQueryEngine.NAMESPACE, null, BIN_2))).isPresent();
-        assertThat(queryEngine.getIndex(new IndexKey(TestQueryEngine.NAMESPACE, SET, BIN_3))).isPresent();
-        assertThat(queryEngine.getIndex(new IndexKey("unknown", null, "unknown"))).isEmpty();
+        assertThat(queryEngine.getIndex(new IndexKey(TestQueryEngine.NAMESPACE, SET, BIN_1, IndexType.NUMERIC))).isPresent();
+        assertThat(queryEngine.getIndex(new IndexKey(TestQueryEngine.NAMESPACE, null, BIN_2, IndexType.STRING))).isPresent();
+        assertThat(queryEngine.getIndex(new IndexKey(TestQueryEngine.NAMESPACE, SET, BIN_3, IndexType.GEO2DSPHERE))).isPresent();
+        assertThat(queryEngine.getIndex(new IndexKey("unknown", null, "unknown", IndexType.NUMERIC))).isEmpty();
+    }
+
+    @Test
+    public void refreshIndexes_indexesForTheSameBinCanBeParsed() {
+        wait(client.createIndex(null, TestQueryEngine.NAMESPACE, SET, INDEX_NAME, BIN_1, IndexType.NUMERIC));
+        wait(client.createIndex(null, TestQueryEngine.NAMESPACE, SET, INDEX_NAME_2, BIN_1, IndexType.STRING));
+
+        queryEngine.refreshIndexes();
+
+        assertThat(queryEngine.getIndex(new IndexKey(TestQueryEngine.NAMESPACE, SET, BIN_1, IndexType.NUMERIC))).hasValueSatisfying(value -> {
+            assertThat(value.getName()).isEqualTo(INDEX_NAME);
+            assertThat(value.getNamespace()).isEqualTo(TestQueryEngine.NAMESPACE);
+            assertThat(value.getSet()).isEqualTo(SET);
+            assertThat(value.getBin()).isEqualTo(BIN_1);
+            assertThat(value.getType()).isEqualTo(IndexType.NUMERIC);
+        });
+        assertThat(queryEngine.getIndex(new IndexKey(TestQueryEngine.NAMESPACE, SET, BIN_1, IndexType.STRING))).hasValueSatisfying(value -> {
+            assertThat(value.getName()).isEqualTo(INDEX_NAME_2);
+            assertThat(value.getNamespace()).isEqualTo(TestQueryEngine.NAMESPACE);
+            assertThat(value.getSet()).isEqualTo(SET);
+            assertThat(value.getBin()).isEqualTo(BIN_1);
+            assertThat(value.getType()).isEqualTo(IndexType.STRING);
+        });
+
+    }
+
+    @Test
+    public void isIndexedBin_returnsTrueForIndexedField() {
+        wait(client.createIndex(null, TestQueryEngine.NAMESPACE, SET, INDEX_NAME, BIN_1, IndexType.NUMERIC));
+        wait(client.createIndex(null, TestQueryEngine.NAMESPACE, SET, INDEX_NAME_2, BIN_2, IndexType.NUMERIC));
+        queryEngine.refreshIndexes();
+
+        assertThat(queryEngine.getIndex(new IndexKey(TestQueryEngine.NAMESPACE, SET, BIN_1, IndexType.NUMERIC))).isPresent();
+        assertThat(queryEngine.getIndex(new IndexKey(TestQueryEngine.NAMESPACE, SET, BIN_2, IndexType.NUMERIC))).isPresent();
+    }
+
+    @Test
+    public void isIndexedBin_returnsFalseForNonIndexedField() {
+        Statement stmt = new Statement();
+        stmt.setNamespace(TestQueryEngine.NAMESPACE);
+        stmt.setSetName(SET);
+        Qualifier qualifier = new Qualifier(BIN_2, Qualifier.FilterOperation.EQ, Value.get(10));
+
+        assertThat(queryEngine.getIndex(new IndexKey(TestQueryEngine.NAMESPACE, SET, BIN_2, IndexType.NUMERIC))).isEmpty();
+        assertThat(queryEngine.getIndex(new IndexKey(TestQueryEngine.NAMESPACE, SET, BIN_2, IndexType.STRING))).isEmpty();
+        assertThat(queryEngine.getIndex(new IndexKey(TestQueryEngine.NAMESPACE, SET, BIN_2, IndexType.GEO2DSPHERE))).isEmpty();
     }
 
     @Test
     public void getIndex_returnsEmptyForNonExistingIndex() {
-        Optional<Index> index = queryEngine.getIndex(new IndexKey(TestQueryEngine.NAMESPACE, SET, BIN_1));
+        Optional<Index> index = queryEngine.getIndex(new IndexKey(TestQueryEngine.NAMESPACE, SET, BIN_1, IndexType.NUMERIC));
         assertThat(index).isEmpty();
     }
 

--- a/extensions/query-engine/src/test/java/com/aerospike/helper/query/InserterTests.java
+++ b/extensions/query-engine/src/test/java/com/aerospike/helper/query/InserterTests.java
@@ -23,7 +23,7 @@ public class InserterTests extends HelperTests{
 		super();
 	}
 	@Before
-	public void setUp() throws Exception {
+	public void setUp() {
 //		if (this.useAuth){
 //			clientPolicy = new ClientPolicy();
 //			clientPolicy.failIfNotConnected = true;

--- a/extensions/query-engine/src/test/java/com/aerospike/helper/query/UsersTests.java
+++ b/extensions/query-engine/src/test/java/com/aerospike/helper/query/UsersTests.java
@@ -23,7 +23,7 @@ public class UsersTests extends HelperTests{
 
 
 	@Before
-	public void setUp() throws Exception {
+	public void setUp() {
 		createUsers();
 		super.setUp();
 

--- a/extensions/reactor-query-engine/src/main/java/com/aerospike/helper/query/ReactorQueryEngine.java
+++ b/extensions/reactor-query-engine/src/main/java/com/aerospike/helper/query/ReactorQueryEngine.java
@@ -23,6 +23,7 @@ import com.aerospike.client.query.KeyRecord;
 import com.aerospike.client.query.Statement;
 import com.aerospike.client.reactor.IAerospikeReactorClient;
 import com.aerospike.helper.query.cache.IndexInfoParser;
+import com.aerospike.helper.query.cache.InternalIndexOperations;
 import com.aerospike.helper.query.cache.ReactorIndexCache;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -53,7 +54,7 @@ public class ReactorQueryEngine implements Closeable {
 	 */
 	public ReactorQueryEngine(IAerospikeReactorClient client) {
 		this(client, client.getQueryPolicyDefault(),
-				new ReactorIndexCache(client, client.getInfoPolicyDefault(), new IndexInfoParser()));
+				new ReactorIndexCache(client, client.getInfoPolicyDefault(), new InternalIndexOperations(new IndexInfoParser())));
 	}
 
 	public ReactorQueryEngine(IAerospikeReactorClient client,
@@ -134,7 +135,7 @@ public class ReactorQueryEngine implements Closeable {
 		/*
 		 *  query with filters
 		 */
-		updateStatement(stmt, qualifiers, indexCache::getIndex);
+		updateStatement(stmt, qualifiers, indexCache::hasIndexFor);
 
 		return client.query(queryPolicy, stmt);
 	}


### PR DESCRIPTION
It is possible to create index for the same bin, but with different type; such indexes will prevent QueryIndex from loading indexes cache.