### PR TITLE
HasMap is replaced by LinkedHashMap

### DIFF
--- a/client/src/com/aerospike/client/async/AsyncMultiCommand.java
+++ b/client/src/com/aerospike/client/async/AsyncMultiCommand.java
@@ -16,7 +16,7 @@
  */
 package com.aerospike.client.async;
 
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import com.aerospike.client.AerospikeException;
@@ -158,7 +158,7 @@ public abstract class AsyncMultiCommand extends AsyncCommand {
 	}
 
 	protected final Record parseRecord() {
-		Map<String,Object> bins = null;
+		Map<String,Object> bins = opCount == 0 ? null : new LinkedHashMap<>();
 
 		for (int i = 0 ; i < opCount; i++) {
 			int opSize = Buffer.bytesToInt(dataBuffer, dataOffset);
@@ -170,10 +170,6 @@ public abstract class AsyncMultiCommand extends AsyncCommand {
 			int particleBytesSize = (int) (opSize - (4 + nameSize));
 	        Object value = Buffer.bytesToParticle(particleType, dataBuffer, dataOffset, particleBytesSize);
 			dataOffset += particleBytesSize;
-
-			if (bins == null) {
-				bins = new HashMap<String,Object>();
-			}
 			bins.put(name, value);
 	    }
 	    return new Record(bins, generation, expiration);

--- a/client/src/com/aerospike/client/async/AsyncRead.java
+++ b/client/src/com/aerospike/client/async/AsyncRead.java
@@ -16,7 +16,7 @@
  */
 package com.aerospike.client.async;
 
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import com.aerospike.client.AerospikeException;
@@ -155,7 +155,7 @@ public class AsyncRead extends AsyncCommand {
 			}
 		}
 
-		Map<String,Object> bins = null;
+		Map<String,Object> bins = opCount == 0 ? null : new LinkedHashMap<>();
 
 		for (int i = 0 ; i < opCount; i++) {
 			int opSize = Buffer.bytesToInt(dataBuffer, dataOffset);
@@ -170,9 +170,6 @@ public class AsyncRead extends AsyncCommand {
 			value = Buffer.bytesToParticle(particleType, dataBuffer, dataOffset, particleBytesSize);
 			dataOffset += particleBytesSize;
 
-			if (bins == null) {
-				bins = new HashMap<String,Object>();
-			}
 			addBin(bins, name, value);
 	    }
 	    return new Record(bins, generation, expiration);

--- a/client/src/com/aerospike/client/command/MultiCommand.java
+++ b/client/src/com/aerospike/client/command/MultiCommand.java
@@ -17,7 +17,7 @@
 package com.aerospike.client.command;
 
 import java.io.IOException;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.zip.DataFormatException;
 import java.util.zip.Inflater;
@@ -266,7 +266,7 @@ public abstract class MultiCommand extends SyncCommand {
 	}
 
 	protected final Record parseRecord() {
-		Map<String,Object> bins = null;
+		Map<String,Object> bins = opCount == 0 ? null : new LinkedHashMap<>();
 
 		for (int i = 0 ; i < opCount; i++) {
 			int opSize = Buffer.bytesToInt(dataBuffer, dataOffset);
@@ -278,10 +278,6 @@ public abstract class MultiCommand extends SyncCommand {
 			int particleBytesSize = (int) (opSize - (4 + nameSize));
 	        Object value = Buffer.bytesToParticle(particleType, dataBuffer, dataOffset, particleBytesSize);
 			dataOffset += particleBytesSize;
-
-			if (bins == null) {
-				bins = new HashMap<String,Object>();
-			}
 			bins.put(name, value);
 	    }
 	    return new Record(bins, generation, expiration);

--- a/client/src/com/aerospike/client/command/ReadCommand.java
+++ b/client/src/com/aerospike/client/command/ReadCommand.java
@@ -17,7 +17,7 @@
 package com.aerospike.client.command;
 
 import java.io.IOException;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.zip.DataFormatException;
 import java.util.zip.Inflater;
@@ -218,8 +218,6 @@ public class ReadCommand extends SyncCommand {
 		int generation,
 		int expiration
 	)  {
-		Map<String,Object> bins = new HashMap<String,Object>();
-
 		// There can be fields in the response (setname etc).
 		// But for now, ignore them. Expose them to the API if needed in the future.
 		if (fieldCount > 0) {
@@ -229,6 +227,8 @@ public class ReadCommand extends SyncCommand {
 				dataOffset += 4 + fieldSize;
 			}
 		}
+
+		Map<String,Object> bins = new LinkedHashMap<>();
 
 		for (int i = 0 ; i < opCount; i++) {
 			int opSize = Buffer.bytesToInt(dataBuffer, dataOffset);


### PR DESCRIPTION
This is done in order to preserve bins order on read, so client returns bins in the same order as they have been written.

The problem is that bins read from the database are stored in `HashMap` that is in turn passed to constructor of `Record`. `HashMap` does not preserve order of keys, so the bins retrieved from the record in "random" order. This does not happen in case of clients written in other languages (e.g. python) where map stores keys in order  the same order they have been passed. `LinkedHashMap` behaves like `HashMap` when retrieving values by key, but returns keys in the same order as they were inserted.  