### PR TITLE
Support netty kqueue native transport 

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -31,6 +31,14 @@
 
     <dependency>
       <groupId>io.netty</groupId>
+      <artifactId>netty-transport-native-kqueue</artifactId>
+      <classifier>osx-x86_64</classifier>
+      <scope>provided</scope>
+      <optional>true</optional>
+    </dependency>
+
+    <dependency>
+      <groupId>io.netty</groupId>
       <artifactId>netty-handler</artifactId>
       <scope>provided</scope>
       <optional>true</optional>
@@ -42,17 +50,17 @@
       <version>2.0.1</version>
     </dependency>
 
-    <dependency> 
+    <dependency>
       <groupId>org.luaj</groupId>
       <artifactId>luaj-jse</artifactId>
     </dependency>
 
-    <dependency> 
+    <dependency>
       <groupId>org.mindrot</groupId>
       <artifactId>jbcrypt</artifactId>
     </dependency>
   </dependencies>
-    
+
   <build>
     <sourceDirectory>${project.basedir}/src</sourceDirectory>
     <resources>
@@ -147,7 +155,7 @@
           </sourceFileIncludes>
         </configuration>
       </plugin>
-    </plugins>      
+    </plugins>
 
   </build>
 

--- a/client/src/com/aerospike/client/async/NettyCommand.java
+++ b/client/src/com/aerospike/client/async/NettyCommand.java
@@ -46,6 +46,7 @@ import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.epoll.EpollSocketChannel;
+import io.netty.channel.kqueue.KQueueSocketChannel;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.channel.socket.nio.NioSocketChannel;
 import io.netty.handler.ssl.SslHandler;
@@ -287,6 +288,8 @@ public final class NettyCommand implements Runnable, TimerTask {
 
 			if (eventLoop.parent.isEpoll) {
 				b.channel(EpollSocketChannel.class);
+			} else if(eventLoop.parent.isKqueue) {
+				b.channel(KQueueSocketChannel.class);
 			}
 			else {
 				b.channel(NioSocketChannel.class);

--- a/client/src/com/aerospike/client/async/NettyConnector.java
+++ b/client/src/com/aerospike/client/async/NettyConnector.java
@@ -42,6 +42,7 @@ import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.epoll.EpollSocketChannel;
+import io.netty.channel.kqueue.KQueueSocketChannel;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.channel.socket.nio.NioSocketChannel;
 import io.netty.handler.ssl.SslHandler;
@@ -75,6 +76,8 @@ public final class NettyConnector extends AsyncConnector {
 
 		if (eventLoop.parent.isEpoll) {
 			b.channel(EpollSocketChannel.class);
+		} else if(eventLoop.parent.isKqueue) {
+			b.channel(KQueueSocketChannel.class);
 		}
 		else {
 			b.channel(NioSocketChannel.class);

--- a/client/src/com/aerospike/client/async/NettyEventLoops.java
+++ b/client/src/com/aerospike/client/async/NettyEventLoops.java
@@ -34,6 +34,7 @@ import com.aerospike.client.util.Util;
 
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.epoll.EpollEventLoopGroup;
+import io.netty.channel.kqueue.KQueueEventLoopGroup;
 import io.netty.handler.ssl.CipherSuiteFilter;
 import io.netty.handler.ssl.ClientAuth;
 import io.netty.handler.ssl.JdkSslContext;
@@ -54,6 +55,7 @@ public final class NettyEventLoops implements EventLoops, CipherSuiteFilter {
 	SslContext sslContext;
 	private int eventIter;
 	final boolean isEpoll;
+	final boolean isKqueue;
 
 	/**
 	 * Create Aerospike event loop wrappers from given netty event loops.
@@ -71,6 +73,7 @@ public final class NettyEventLoops implements EventLoops, CipherSuiteFilter {
 		}
 		this.group = group;
 		this.isEpoll = (group instanceof EpollEventLoopGroup);
+		this.isKqueue = (group instanceof KQueueEventLoopGroup);
 
 		ArrayList<NettyEventLoop> list = new ArrayList<NettyEventLoop>();
 		Iterator<EventExecutor> iter = group.iterator();

--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,13 @@
 
       <dependency>
         <groupId>io.netty</groupId>
+        <artifactId>netty-transport-native-kqueue</artifactId>
+        <classifier>osx-x86_64</classifier>
+        <version>${netty.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.netty</groupId>
         <artifactId>netty-handler</artifactId>
         <version>${netty.version}</version>
       </dependency>


### PR DESCRIPTION
Fixes: https://github.com/aerospike/aerospike-client-java/issues/175

By providing KQueue with equivalent support to EPoll.