### PR TITLE
Support for UUID values

### DIFF
--- a/client/src/com/aerospike/client/Value.java
+++ b/client/src/com/aerospike/client/Value.java
@@ -23,6 +23,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.UUID;
 
 import org.luaj.vm2.LuaBoolean;
 import org.luaj.vm2.LuaDouble;
@@ -142,6 +143,13 @@ public abstract class Value {
 	}
 
 	/**
+	 * Get UUID value string instance.
+	 */
+	public static Value get(UUID value) {
+		return new StringValue(value.toString());
+	}
+
+	/**
 	 * Get list or null value instance.
 	 */
 	public static Value get(List<?> value) {
@@ -244,7 +252,11 @@ public abstract class Value {
 		}
 
 		if (value instanceof Enum) {
-        	return new StringValue(((Enum<?>)value).toString());
+        	return new StringValue(value.toString());
+		}
+
+		if (value instanceof UUID) {
+			return new StringValue(value.toString());
 		}
 
 		if (value instanceof List<?>) {


### PR DESCRIPTION
# Summary
* Add support to store java UUIDs as Strings in Aerospike
* This will allow libraries like https://github.com/aerospike-community/spring-data-aerospike to create repository functions that query by UUID - it uses this client's Value.java class to generate the query statement
   * example:
   ```
   public interface PersonRepository extends CrudRepository<Person, UUID> {

      List<Person> findByIdAndMembershipStatus(UUID id, MembershipStatus status );
   }
   ```