### PR TITLE
equals() method should cast to BoolIntValue instead of BooleanValue

### DIFF
--- a/client/src/com/aerospike/client/Value.java
+++ b/client/src/com/aerospike/client/Value.java
@@ -1110,7 +1110,7 @@ public abstract class Value {
 		public boolean equals(Object other) {
 			return (other != null &&
 				this.getClass().equals(other.getClass()) &&
-				this.value == ((BooleanValue)other).value);
+				this.value == ((BoolIntValue)other).value);
 		}
 
 		@Override


### PR DESCRIPTION
fix: equals() method should cast to BoolIntValue instead of BooleanValue.