### PR TITLE
Add support for io_uring with Netty

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -38,6 +38,14 @@
     </dependency>
 
     <dependency>
+      <groupId>io.netty.incubator</groupId>
+      <artifactId>netty-incubator-transport-native-io_uring</artifactId>
+      <version>0.0.8.Final</version>
+      <scope>provided</scope>
+      <optional>true</optional>
+    </dependency>
+
+    <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-handler</artifactId>
       <scope>provided</scope>

--- a/client/src/com/aerospike/client/async/EventLoopType.java
+++ b/client/src/com/aerospike/client/async/EventLoopType.java
@@ -43,5 +43,5 @@ public enum EventLoopType {
 	/**
 	 * Netty io_uring. Available on Linux.
 	 */
-	NETTY_IO_URING
+	NETTY_IOURING
 }

--- a/client/src/com/aerospike/client/async/EventLoopType.java
+++ b/client/src/com/aerospike/client/async/EventLoopType.java
@@ -38,5 +38,10 @@ public enum EventLoopType {
 	/**
 	 * Netty kqueue. Available on MacOS, FreeBSD.
 	 */
-	NETTY_KQUEUE
+	NETTY_KQUEUE,
+
+	/**
+	 * Netty io_uring. Available on Linux.
+	 */
+	NETTY_IO_URING
 }

--- a/client/src/com/aerospike/client/async/NettyCommand.java
+++ b/client/src/com/aerospike/client/async/NettyCommand.java
@@ -362,7 +362,7 @@ public final class NettyCommand implements Runnable, TimerTask {
 			b.channel(KQueueSocketChannel.class);
 			break;
 
-		case NETTY_IO_URING:
+		case NETTY_IOURING:
 			b.channel(IOUringSocketChannel.class);
 			break;
 		}

--- a/client/src/com/aerospike/client/async/NettyCommand.java
+++ b/client/src/com/aerospike/client/async/NettyCommand.java
@@ -54,6 +54,7 @@ import io.netty.channel.socket.SocketChannel;
 import io.netty.channel.socket.nio.NioSocketChannel;
 import io.netty.handler.ssl.SslHandler;
 import io.netty.handler.ssl.SslHandshakeCompletionEvent;
+import io.netty.incubator.channel.uring.IOUringSocketChannel;
 
 /**
  * Asynchronous command handler using netty.
@@ -359,6 +360,10 @@ public final class NettyCommand implements Runnable, TimerTask {
 
 		case NETTY_KQUEUE:
 			b.channel(KQueueSocketChannel.class);
+			break;
+
+		case NETTY_IO_URING:
+			b.channel(IOUringSocketChannel.class);
 			break;
 		}
 

--- a/client/src/com/aerospike/client/async/NettyEventLoops.java
+++ b/client/src/com/aerospike/client/async/NettyEventLoops.java
@@ -43,6 +43,7 @@ import io.netty.handler.ssl.IdentityCipherSuiteFilter;
 import io.netty.handler.ssl.JdkSslContext;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
+import io.netty.incubator.channel.uring.IOUringEventLoopGroup;
 import io.netty.util.concurrent.EventExecutor;
 
 /**
@@ -83,6 +84,9 @@ public final class NettyEventLoops implements EventLoops, CipherSuiteFilter {
 		}
 		else if (group instanceof KQueueEventLoopGroup) {
 			this.eventLoopType = EventLoopType.NETTY_KQUEUE;
+		}
+		else if (group instanceof IOUringEventLoopGroup) {
+			this.eventLoopType = EventLoopType.NETTY_IO_URING;
 		}
 		else {
 			throw new AerospikeException("Unexpected EventLoopGroup");

--- a/client/src/com/aerospike/client/async/NettyEventLoops.java
+++ b/client/src/com/aerospike/client/async/NettyEventLoops.java
@@ -40,7 +40,6 @@ import io.netty.handler.ssl.IdentityCipherSuiteFilter;
 import io.netty.handler.ssl.JdkSslContext;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
-import io.netty.incubator.channel.uring.IOUringEventLoopGroup;
 import io.netty.util.concurrent.EventExecutor;
 
 /**
@@ -85,7 +84,7 @@ public final class NettyEventLoops implements EventLoops, CipherSuiteFilter {
 			break;
 		case "IOUringEventLoopGroup":
 			this.eventLoopType = EventLoopType.NETTY_IOURING;
-			break
+			break;
 		default:
 			throw new AerospikeException("Unexpected EventLoopGroup");
 		}

--- a/client/src/com/aerospike/client/async/NettyEventLoops.java
+++ b/client/src/com/aerospike/client/async/NettyEventLoops.java
@@ -34,9 +34,6 @@ import com.aerospike.client.policy.TlsPolicy;
 import com.aerospike.client.util.Util;
 
 import io.netty.channel.EventLoopGroup;
-import io.netty.channel.epoll.EpollEventLoopGroup;
-import io.netty.channel.kqueue.KQueueEventLoopGroup;
-import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.handler.ssl.CipherSuiteFilter;
 import io.netty.handler.ssl.ClientAuth;
 import io.netty.handler.ssl.IdentityCipherSuiteFilter;
@@ -76,19 +73,20 @@ public final class NettyEventLoops implements EventLoops, CipherSuiteFilter {
 		}
 		this.group = group;
 
-		if (group instanceof NioEventLoopGroup) {
+		switch (group.getClass().getSimpleName()) {
+		case "NioEventLoopGroup":
 			this.eventLoopType = EventLoopType.NETTY_NIO;
-		}
-		else if (group instanceof EpollEventLoopGroup) {
+			break;
+		case "EpollEventLoopGroup":
 			this.eventLoopType = EventLoopType.NETTY_EPOLL;
-		}
-		else if (group instanceof KQueueEventLoopGroup) {
+			break;
+		case "KQueueEventLoopGroup":
 			this.eventLoopType = EventLoopType.NETTY_KQUEUE;
-		}
-		else if (group instanceof IOUringEventLoopGroup) {
-			this.eventLoopType = EventLoopType.NETTY_IO_URING;
-		}
-		else {
+			break;
+		case "IOUringEventLoopGroup":
+			this.eventLoopType = EventLoopType.NETTY_IOURING;
+			break
+		default:
 			throw new AerospikeException("Unexpected EventLoopGroup");
 		}
 


### PR DESCRIPTION
Netty has recently added support for an experimental new type of transport which used Linux's io_uring facility. This PR allows users to pass in a IOUringEventLoopGroup to the NettyEventLoops constructor. This is an optional dependency like the other native transports. The EventLoopType determination is currently done sequentially, so I changed it to use a switch statement. I believe if the optional dependency was not provided the instanceof would fail with an ClassNotFoundException instead of falling down to the "Unexpected EventLoopGroup" exception. Using the class names prevents that.