### PR TITLE
Note that EventLoops.next() is not thread-safe

### DIFF
--- a/client/src/com/aerospike/client/async/EventLoops.java
+++ b/client/src/com/aerospike/client/async/EventLoops.java
@@ -41,6 +41,7 @@ public interface EventLoops extends Closeable {
 
 	/**
 	 * Return next Aerospike event loop in round-robin fashion.
+	 * Implementations may not be thread-safe.
 	 */
 	public EventLoop next();
 

--- a/client/src/com/aerospike/client/async/NettyEventLoops.java
+++ b/client/src/com/aerospike/client/async/NettyEventLoops.java
@@ -58,6 +58,7 @@ public final class NettyEventLoops implements EventLoops, CipherSuiteFilter {
 	TlsPolicy tlsPolicy;
 	SslContext sslContext;
 	final EventLoopType eventLoopType;
+	private int eventIter;
 
 	/**
 	 * Create Aerospike event loop wrappers from given netty event loops.
@@ -254,7 +255,7 @@ public final class NettyEventLoops implements EventLoops, CipherSuiteFilter {
 	}
 
 	/**
-	 * Return Aerospike event loop given array index.
+	 * Return Aerospike event loop given array index..
 	 */
 	@Override
 	public NettyEventLoop get(int index) {
@@ -262,11 +263,18 @@ public final class NettyEventLoops implements EventLoops, CipherSuiteFilter {
 	}
 
 	/**
-	 * Return next Aerospike event loop as determined by {@link io.netty.channel.EventLoopGroup#next()}.
+	 * Return next Aerospike event loop in round-robin fashion.
+	 * This implementation is not thread-safe.
 	 */
 	@Override
 	public NettyEventLoop next() {
-		return eventLoopMap.get(group.next());
+		int iter = eventIter++; // Not atomic by design
+		iter = iter % eventLoopArray.length;
+
+		if (iter < 0) {
+			iter += eventLoopArray.length;
+		}
+		return eventLoopArray[iter];
 	}
 
 	@Override


### PR DESCRIPTION
This patch makes the EventLoops.next() thread-safe. I did both implementations. In the NettyEventLoops case, we can lean on the `EventLoopGroup#next()` which is thread-safe. I mimicked [how Netty does this round robin](https://github.com/netty/netty/blob/netty-4.1.69.Final/common/src/main/java/io/netty/util/concurrent/DefaultEventExecutorChooserFactory.java#L60) in the NioEventLoops.

Can you explain the rationale for "Not atomic by design". If that behavior is still wanted in one or both of these implementations, I can remove my work and I'll change this PR to just have Javadoc giving a warning about the lack of thread-safety.