### PR TITLE
Fix deadlock in Cluster.getStats()

### DIFF
--- a/client/src/com/aerospike/client/cluster/Cluster.java
+++ b/client/src/com/aerospike/client/cluster/Cluster.java
@@ -1056,7 +1056,7 @@ public class Cluster implements Runnable, Closeable {
 			count = 0;
 
 			for (EventLoop eventLoop : eventLoopArray) {
-				eventLoop.execute(new Runnable() {
+				Runnable fetch = new Runnable() {
 					public void run() {
 						int index = eventLoop.getIndex();
 						loopStats[index] = new EventLoopStats(eventLoop);
@@ -1071,7 +1071,12 @@ public class Cluster implements Runnable, Closeable {
 							monitor.notifyComplete();
 						}
 					}
-				});
+				};
+				if (eventLoop.inEventLoop()) {
+					fetch.run();
+				} else {
+					eventLoop.execute(fetch);
+				}
 			}
 			monitor.waitTillComplete();
 			eventLoopStats = loopStats;


### PR DESCRIPTION
Calling getStats from an event loop causes this method to hang, since the monitor is waiting for this event loop's stats task to run, yet the monitor is preventing the caller from completing which holds up the event loops stats task from running. Solution: run the stats Runnable in the current thread if we detect we are in that specific event loop.