### PR TITLE
allow buffers to be managed by descendants of Command

### DIFF
--- a/client/src/com/aerospike/client/async/AsyncCommand.java
+++ b/client/src/com/aerospike/client/async/AsyncCommand.java
@@ -82,11 +82,11 @@ public abstract class AsyncCommand extends Command {
 	}
 
 	@Override
-	protected final void sizeBuffer() {
+	protected void sizeBuffer() {
 		sizeBuffer(dataOffset);
 	}
 
-	final void sizeBuffer(int size) {
+	void sizeBuffer(int size) {
 		if (dataBuffer == null) {
 			dataBuffer = getBuffer(size);
 		}
@@ -97,14 +97,14 @@ public abstract class AsyncCommand extends Command {
 		}
 	}
 
-	final void putBuffer() {
+	void putBuffer() {
 		if (dataBuffer != null) {
 			putBuffer(dataBuffer);
 			dataBuffer = null;
 		}
 	}
 
-	private final byte[] getBuffer(int size) {
+	protected byte[] getBuffer(int size) {
 		if (size > MAX_BUFFER_SIZE) {
 			// Allocate huge buffer, but do not put back in pool.
 			return new byte[size];

--- a/client/src/com/aerospike/client/async/AsyncCommand.java
+++ b/client/src/com/aerospike/client/async/AsyncCommand.java
@@ -130,7 +130,7 @@ public abstract class AsyncCommand extends Command {
 		return new byte[(size + 8191) & ~8191];
 	}
 
-	private final void putBuffer(byte[] buffer) {
+	protected void putBuffer(byte[] buffer) {
 		if (buffer.length <= MAX_BUFFER_SIZE) {
 			bufferQueue.addLast(buffer);
 		}

--- a/client/src/com/aerospike/client/command/SyncCommand.java
+++ b/client/src/com/aerospike/client/command/SyncCommand.java
@@ -246,7 +246,7 @@ public abstract class SyncCommand extends Command {
 	}
 
 	@Override
-	protected final void sizeBuffer() {
+	protected void sizeBuffer() {
 		dataBuffer = ThreadLocalData.getBuffer();
 
 		if (dataOffset > dataBuffer.length) {
@@ -254,7 +254,7 @@ public abstract class SyncCommand extends Command {
 		}
 	}
 
-	protected final void sizeBuffer(int size) {
+	protected void sizeBuffer(int size) {
 		if (size > dataBuffer.length) {
 			dataBuffer = ThreadLocalData.resizeBuffer(size);
 		}


### PR DESCRIPTION
Make methods non-final and overridable to allow byte buffers (used to send and
receive data with Aerospike server) to be custom managed by descendants
of Command.