### PR TITLE
fix: prevent integer overflow in getInt

### DIFF
--- a/client/src/com/aerospike/client/Record.java
+++ b/client/src/com/aerospike/client/Record.java
@@ -95,7 +95,7 @@ public final class Record {
 		// The server always returns numbers as longs if bin found.
 		// If bin not found, the result will be null.  Convert null to zero.
 		Object result = getValue(name);
-		return (result != null)? (Long)result : 0;
+		return (result != null) ? (long) result : 0;
 	}
 
 	/**
@@ -103,7 +103,7 @@ public final class Record {
 	 */
 	public int getInt(String name) {
 		// The server always returns numbers as longs, so get long and cast.
-		return (int)getLong(name);
+		return Math.toIntExact(getLong(name));
 	}
 
 	/**

--- a/test/src/com/aerospike/test/sync/basic/TestPutGet.java
+++ b/test/src/com/aerospike/test/sync/basic/TestPutGet.java
@@ -16,7 +16,9 @@
  */
 package com.aerospike.test.sync.basic;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -82,5 +84,21 @@ public class TestPutGet extends TestSync {
 		assertFalse(b);
 		b = record.getBoolean(bin4.name);
 		assertTrue(b);
+	}
+
+	@Test
+	public void putGetNums() {
+		Key key = new Key(args.namespace, args.set, "pgi");
+		Bin bin1 = new Bin("bin1", 1);
+		Bin bin2 = new Bin("bin2", 2L);
+		Bin bin3 = new Bin("bin3", Long.MAX_VALUE);
+
+		client.put(null, key, bin1, bin2);
+
+		Record record = client.get(null, key);
+		assertEquals(1, record.getInt(bin1.name));
+		assertEquals(2, record.getInt(bin2.name));
+		assertEquals(2L, record.getLong(bin2.name));
+		assertThrows(ArithmeticException.class, () -> record.getInt(bin3.name));
 	}
 }


### PR DESCRIPTION
It is possible for the raw cast in getInt to return something completely incorrect due to a long value overflowing the int. Adding some defense to prevent this.

Also remove the unnecessary boxing and unboxing of longs in getLong.

Related issue running a local aerospike container:
![image](https://user-images.githubusercontent.com/9076759/201384944-66baede1-37d0-401a-98d7-d9aab9b4ce6b.png)
