### PR TITLE
Opened up required method, fixed masked exception

### DIFF
--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.aerospike</groupId>
     <artifactId>aerospike-parent</artifactId>
-    <version>6.1.6</version>
+    <version>6.1.6-0.9.0-proxy-SNAPSHOT</version>
   </parent>
   <artifactId>aerospike-benchmarks</artifactId>
   <packaging>jar</packaging>

--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.aerospike</groupId>
     <artifactId>aerospike-parent</artifactId>
-    <version>6.1.7</version>
+    <version>6.1.7-SNAPSHOT</version>
   </parent>
   <artifactId>aerospike-benchmarks</artifactId>
   <packaging>jar</packaging>
@@ -58,7 +58,7 @@
     </dependency>
   </dependencies>
 
- <build>
+  <build>
     <sourceDirectory>${project.basedir}/src</sourceDirectory>
     <plugins>
       <plugin>
@@ -91,5 +91,5 @@
       </plugin>
     </plugins>
   </build>
-    
+
 </project>

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.aerospike</groupId>
     <artifactId>aerospike-parent</artifactId>
-    <version>6.1.7</version>
+    <version>6.1.7-SNAPSHOT</version>
   </parent>
   <artifactId>aerospike-client</artifactId>
   <packaging>jar</packaging>
@@ -98,10 +98,10 @@
         <executions>
           <execution>
             <id>make-my-jar-with-dependencies</id>
-              <phase>package</phase>
-              <goals>
-                <goal>single</goal>
-              </goals>
+            <phase>package</phase>
+            <goals>
+              <goal>single</goal>
+            </goals>
           </execution>
         </executions>
       </plugin>

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.aerospike</groupId>
     <artifactId>aerospike-parent</artifactId>
-    <version>6.1.6</version>
+    <version>6.1.6-0.9.0-proxy-SNAPSHOT</version>
   </parent>
   <artifactId>aerospike-client</artifactId>
   <packaging>jar</packaging>

--- a/client/src/com/aerospike/client/async/AsyncCommand.java
+++ b/client/src/com/aerospike/client/async/AsyncCommand.java
@@ -119,7 +119,7 @@ public abstract class AsyncCommand extends Command {
 		return buffer;
 	}
 
-	private final byte[] resizeBuffer(byte[] buffer, int size) {
+	private byte[] resizeBuffer(byte[] buffer, int size) {
 		if (size > MAX_BUFFER_SIZE) {
 			// Put original buffer back in pool.
 			putBuffer(buffer);
@@ -142,7 +142,7 @@ public abstract class AsyncCommand extends Command {
 		}
 	}
 
-	final boolean parseCommandResult() {
+	boolean parseCommandResult() {
 		if (compressed) {
 			int usize = (int)Buffer.bytesToLong(dataBuffer, 0);
 			byte[] buf = new byte[usize];
@@ -190,9 +190,14 @@ public abstract class AsyncCommand extends Command {
 	}
 
 	abstract Node getNode(Cluster cluster);
+
 	abstract void writeBuffer();
+
 	abstract boolean parseResult();
+
 	abstract boolean prepareRetry(boolean timeout);
+
 	abstract void onSuccess();
+
 	abstract void onFailure(AerospikeException ae);
 }

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.aerospike</groupId>
     <artifactId>aerospike-parent</artifactId>
-    <version>6.1.7</version>
+    <version>6.1.7-SNAPSHOT</version>
   </parent>
   <artifactId>aerospike-examples</artifactId>
   <packaging>jar</packaging>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.aerospike</groupId>
     <artifactId>aerospike-parent</artifactId>
-    <version>6.1.6</version>
+    <version>6.1.6-0.9.0-proxy-SNAPSHOT</version>
   </parent>
   <artifactId>aerospike-examples</artifactId>
   <packaging>jar</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -5,15 +5,15 @@
   <groupId>com.aerospike</groupId>
   <artifactId>aerospike-parent</artifactId>
   <name>aerospike-parent</name>
-  <version>6.1.7</version>
+  <version>6.1.7-SNAPSHOT</version>
   <packaging>pom</packaging>
   <url>https://github.com/aerospike/aerospike-client-java</url>
-  
+
   <organization>
     <name>Aerospike Inc.</name>
     <url>https://www.aerospike.com</url>
   </organization>
-  
+
   <licenses>
     <license>
       <name>The Apache License, Version 2.0</name>

--- a/pom.xml
+++ b/pom.xml
@@ -5,15 +5,15 @@
   <groupId>com.aerospike</groupId>
   <artifactId>aerospike-parent</artifactId>
   <name>aerospike-parent</name>
-  <version>6.1.6</version>
+  <version>6.1.6-0.9.0-proxy-SNAPSHOT</version>
   <packaging>pom</packaging>
   <url>https://github.com/aerospike/aerospike-client-java</url>
-  
+
   <organization>
     <name>Aerospike Inc.</name>
     <url>https://www.aerospike.com</url>
   </organization>
-  
+
   <licenses>
     <license>
       <name>The Apache License, Version 2.0</name>
@@ -173,13 +173,6 @@
       </plugins>
     </pluginManagement>
   </build>
-
-  <repositories>
-    <repository>
-      <id>oss-sonatype</id>
-      <url>${oss.sonatype.url}</url>
-    </repository>
-  </repositories>
 
   <distributionManagement>
     <!-- For now releases are in github packages -->

--- a/proxy/pom.xml
+++ b/proxy/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.aerospike</groupId>
     <artifactId>aerospike-parent</artifactId>
-    <version>6.1.6</version>
+    <version>6.1.6-0.9.0-proxy-SNAPSHOT</version>
   </parent>
   <artifactId>aerospike-proxy-client</artifactId>
   <packaging>jar</packaging>

--- a/proxy/pom.xml
+++ b/proxy/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.aerospike</groupId>
     <artifactId>aerospike-parent</artifactId>
-    <version>6.1.7</version>
+    <version>6.1.7-SNAPSHOT</version>
   </parent>
   <artifactId>aerospike-proxy-client</artifactId>
   <packaging>jar</packaging>
@@ -90,10 +90,10 @@
         <executions>
           <execution>
             <id>make-my-jar-with-dependencies</id>
-              <phase>package</phase>
-              <goals>
-                <goal>single</goal>
-              </goals>
+            <phase>package</phase>
+            <goals>
+              <goal>single</goal>
+            </goals>
           </execution>
         </executions>
       </plugin>

--- a/proxy/src/com/aerospike/client/proxy/AerospikeClientProxy.java
+++ b/proxy/src/com/aerospike/client/proxy/AerospikeClientProxy.java
@@ -94,7 +94,6 @@ import com.aerospike.client.task.ExecuteTask;
 import com.aerospike.client.task.IndexTask;
 import com.aerospike.client.task.RegisterTask;
 import com.aerospike.client.util.Util;
-
 import io.netty.channel.Channel;
 
 /**
@@ -112,17 +111,17 @@ public class AerospikeClientProxy implements IAerospikeClient, Closeable {
 	 */
 	public static String Version = getVersion();
 
-    /**
-     * Lower limit of proxy server connection.
-     */
-    private static final int MIN_CONNECTIONS = 1;
+	/**
+	 * Lower limit of proxy server connection.
+	 */
+	private static final int MIN_CONNECTIONS = 1;
 
-    /**
-     * Upper limit of proxy server connection.
-     */
-    private static final int MAX_CONNECTIONS = 8;
+	/**
+	 * Upper limit of proxy server connection.
+	 */
+	private static final int MAX_CONNECTIONS = 8;
 
-    private static String NotSupported = "Method not supported in proxy client: ";
+	private static final String NotSupported = "Method not supported in proxy client: ";
 
 	//-------------------------------------------------------
 	// Member variables.
@@ -214,8 +213,8 @@ public class AerospikeClientProxy implements IAerospikeClient, Closeable {
 		authTokenManager = new AuthTokenManager(policy, channelProvider);
 
 		try {
-            // The gRPC client policy transformed from the client policy.
-            GrpcClientPolicy grpcClientPolicy = toGrpcClientPolicy(policy);
+			// The gRPC client policy transformed from the client policy.
+			GrpcClientPolicy grpcClientPolicy = toGrpcClientPolicy(policy);
 			executor = new GrpcCallExecutor(grpcClientPolicy, authTokenManager, hosts);
 			channelProvider.setCallExecutor(executor);
 		}
@@ -340,7 +339,7 @@ public class AerospikeClientProxy implements IAerospikeClient, Closeable {
 
 	@Override
 	public void put(WritePolicy policy, Key key, Bin... bins) {
-		CompletableFuture<Void> future = new CompletableFuture<Void>();
+		CompletableFuture<Void> future = new CompletableFuture<>();
 		WriteListener listener = prepareWriteListener(future);
 		put(null, listener, policy, key, bins);
 		getFuture(future);
@@ -361,7 +360,7 @@ public class AerospikeClientProxy implements IAerospikeClient, Closeable {
 
 	@Override
 	public void append(WritePolicy policy, Key key, Bin... bins) {
-		CompletableFuture<Void> future = new CompletableFuture<Void>();
+		CompletableFuture<Void> future = new CompletableFuture<>();
 		WriteListener listener = prepareWriteListener(future);
 		append(null, listener, policy, key, bins);
 		getFuture(future);
@@ -378,7 +377,7 @@ public class AerospikeClientProxy implements IAerospikeClient, Closeable {
 
 	@Override
 	public void prepend(WritePolicy policy, Key key, Bin... bins) {
-		CompletableFuture<Void> future = new CompletableFuture<Void>();
+		CompletableFuture<Void> future = new CompletableFuture<>();
 		WriteListener listener = prepareWriteListener(future);
 		prepend(null, listener, policy, key, bins);
 		getFuture(future);
@@ -399,7 +398,7 @@ public class AerospikeClientProxy implements IAerospikeClient, Closeable {
 
 	@Override
 	public void add(WritePolicy policy, Key key, Bin... bins) {
-		CompletableFuture<Void> future = new CompletableFuture<Void>();
+		CompletableFuture<Void> future = new CompletableFuture<>();
 		WriteListener listener = prepareWriteListener(future);
 		add(null, listener, policy, key, bins);
 		getFuture(future);
@@ -420,7 +419,7 @@ public class AerospikeClientProxy implements IAerospikeClient, Closeable {
 
 	@Override
 	public boolean delete(WritePolicy policy, Key key) {
-		CompletableFuture<Boolean> future = new CompletableFuture<Boolean>();
+		CompletableFuture<Boolean> future = new CompletableFuture<>();
 		DeleteListener listener = prepareDeleteListener(future);
 		delete(null, listener, policy, key);
 		return getFuture(future);
@@ -442,22 +441,22 @@ public class AerospikeClientProxy implements IAerospikeClient, Closeable {
 
 	@Override
 	public void delete(
-		EventLoop eventLoop,
-		BatchRecordArrayListener listener,
-		BatchPolicy batchPolicy,
-		BatchDeletePolicy deletePolicy,
-		Key[] keys
+			EventLoop eventLoop,
+			BatchRecordArrayListener listener,
+			BatchPolicy batchPolicy,
+			BatchDeletePolicy deletePolicy,
+			Key[] keys
 	) {
 		throw new AerospikeException(NotSupported + "batch delete");
 	}
 
 	@Override
 	public void delete(
-		EventLoop eventLoop,
-		BatchRecordSequenceListener listener,
-		BatchPolicy batchPolicy,
-		BatchDeletePolicy deletePolicy,
-		Key[] keys
+			EventLoop eventLoop,
+			BatchRecordSequenceListener listener,
+			BatchPolicy batchPolicy,
+			BatchDeletePolicy deletePolicy,
+			Key[] keys
 	) {
 		throw new AerospikeException(NotSupported + "batch delete");
 	}
@@ -473,7 +472,7 @@ public class AerospikeClientProxy implements IAerospikeClient, Closeable {
 
 	@Override
 	public void touch(WritePolicy policy, Key key) {
-		CompletableFuture<Void> future = new CompletableFuture<Void>();
+		CompletableFuture<Void> future = new CompletableFuture<>();
 		WriteListener listener = prepareWriteListener(future);
 		touch(null, listener, policy, key);
 		getFuture(future);
@@ -494,7 +493,7 @@ public class AerospikeClientProxy implements IAerospikeClient, Closeable {
 
 	@Override
 	public boolean exists(Policy policy, Key key) {
-		CompletableFuture<Boolean> future = new CompletableFuture<Boolean>();
+		CompletableFuture<Boolean> future = new CompletableFuture<>();
 		ExistsListener listener = prepareExistsListener(future);
 		exists(null, listener, policy, key);
 		return getFuture(future);
@@ -530,12 +529,12 @@ public class AerospikeClientProxy implements IAerospikeClient, Closeable {
 
 	@Override
 	public Record get(Policy policy, Key key) {
-		return get(policy, key, (String[]) null);
+		return get(policy, key, (String[])null);
 	}
 
 	@Override
 	public void get(EventLoop eventLoop, RecordListener listener, Policy policy, Key key) {
-		get(eventLoop, listener, policy, key, (String[]) null);
+		get(eventLoop, listener, policy, key, (String[])null);
 	}
 
 	@Override
@@ -681,54 +680,54 @@ public class AerospikeClientProxy implements IAerospikeClient, Closeable {
 
 	@Override
 	public void operate(
-		EventLoop eventLoop,
-		BatchOperateListListener listener,
-		BatchPolicy policy,
-		List<BatchRecord> records
+			EventLoop eventLoop,
+			BatchOperateListListener listener,
+			BatchPolicy policy,
+			List<BatchRecord> records
 	) {
 		throw new AerospikeException(NotSupported + "batch operate");
 	}
 
 	@Override
 	public void operate(
-		EventLoop eventLoop,
-		BatchRecordSequenceListener listener,
-		BatchPolicy policy,
-		List<BatchRecord> records
+			EventLoop eventLoop,
+			BatchRecordSequenceListener listener,
+			BatchPolicy policy,
+			List<BatchRecord> records
 	) {
 		throw new AerospikeException(NotSupported + "batch operate");
 	}
 
 	@Override
 	public BatchResults operate(
-		BatchPolicy batchPolicy,
-		BatchWritePolicy writePolicy,
-		Key[] keys,
-		Operation... ops
+			BatchPolicy batchPolicy,
+			BatchWritePolicy writePolicy,
+			Key[] keys,
+			Operation... ops
 	) {
 		throw new AerospikeException(NotSupported + "batch operate");
 	}
 
 	@Override
 	public void operate(
-		EventLoop eventLoop,
-		BatchRecordArrayListener listener,
-		BatchPolicy batchPolicy,
-		BatchWritePolicy writePolicy,
-		Key[] keys,
-		Operation... ops
+			EventLoop eventLoop,
+			BatchRecordArrayListener listener,
+			BatchPolicy batchPolicy,
+			BatchWritePolicy writePolicy,
+			Key[] keys,
+			Operation... ops
 	) {
 		throw new AerospikeException(NotSupported + "batch operate");
 	}
 
 	@Override
 	public void operate(
-		EventLoop eventLoop,
-		BatchRecordSequenceListener listener,
-		BatchPolicy batchPolicy,
-		BatchWritePolicy writePolicy,
-		Key[] keys,
-		Operation... ops
+			EventLoop eventLoop,
+			BatchRecordSequenceListener listener,
+			BatchPolicy batchPolicy,
+			BatchWritePolicy writePolicy,
+			Key[] keys,
+			Operation... ops
 	) {
 		throw new AerospikeException(NotSupported + "batch operate");
 	}
@@ -739,67 +738,67 @@ public class AerospikeClientProxy implements IAerospikeClient, Closeable {
 
 	@Override
 	public void scanAll(
-		ScanPolicy policy,
-		String namespace,
-		String setName,
-		ScanCallback callback,
-		String... binNames
+			ScanPolicy policy,
+			String namespace,
+			String setName,
+			ScanCallback callback,
+			String... binNames
 	) {
 	}
 
 	@Override
 	public void scanAll(
-		EventLoop eventLoop,
-		RecordSequenceListener listener,
-		ScanPolicy policy,
-		String namespace,
-		String setName,
-		String... binNames
+			EventLoop eventLoop,
+			RecordSequenceListener listener,
+			ScanPolicy policy,
+			String namespace,
+			String setName,
+			String... binNames
 	) {
 	}
 
 	@Override
 	public void scanNode(
-		ScanPolicy policy,
-		String nodeName,
-		String namespace,
-		String setName,
-		ScanCallback callback,
-		String... binNames
+			ScanPolicy policy,
+			String nodeName,
+			String namespace,
+			String setName,
+			ScanCallback callback,
+			String... binNames
 	) {
 	}
 
 	@Override
 	public void scanNode(
-		ScanPolicy policy,
-		Node node,
-		String namespace,
-		String setName,
-		ScanCallback callback,
-		String... binNames
+			ScanPolicy policy,
+			Node node,
+			String namespace,
+			String setName,
+			ScanCallback callback,
+			String... binNames
 	) {
 	}
 
 	@Override
 	public void scanPartitions(
-		ScanPolicy policy,
-		PartitionFilter partitionFilter,
-		String namespace,
-		String setName,
-		ScanCallback callback,
-		String... binNames
+			ScanPolicy policy,
+			PartitionFilter partitionFilter,
+			String namespace,
+			String setName,
+			ScanCallback callback,
+			String... binNames
 	) {
 	}
 
 	@Override
 	public void scanPartitions(
-		EventLoop eventLoop,
-		RecordSequenceListener listener,
-		ScanPolicy policy,
-		PartitionFilter partitionFilter,
-		String namespace,
-		String setName,
-		String... binNames
+			EventLoop eventLoop,
+			RecordSequenceListener listener,
+			ScanPolicy policy,
+			PartitionFilter partitionFilter,
+			String namespace,
+			String setName,
+			String... binNames
 	) {
 	}
 
@@ -814,11 +813,11 @@ public class AerospikeClientProxy implements IAerospikeClient, Closeable {
 
 	@Override
 	public RegisterTask register(
-		Policy policy,
-		ClassLoader resourceLoader,
-		String resourcePath,
-		String serverPath,
-		Language language
+			Policy policy,
+			ClassLoader resourceLoader,
+			String resourcePath,
+			String serverPath,
+			Language language
 	) {
 		throw new AerospikeException(NotSupported + "register");
 	}
@@ -843,58 +842,58 @@ public class AerospikeClientProxy implements IAerospikeClient, Closeable {
 
 	@Override
 	public void execute(
-		EventLoop eventLoop,
-		ExecuteListener listener,
-		WritePolicy policy,
-		Key key,
-		String packageName,
-		String functionName,
-		Value... functionArgs
+			EventLoop eventLoop,
+			ExecuteListener listener,
+			WritePolicy policy,
+			Key key,
+			String packageName,
+			String functionName,
+			Value... functionArgs
 	) {
 		if (policy == null) {
 			policy = writePolicyDefault;
 		}
 		ExecuteCommandProxy command = new ExecuteCommandProxy(executor, listener, policy, key,
-			packageName, functionName, functionArgs);
+				packageName, functionName, functionArgs);
 		command.execute();
 	}
 
 	@Override
 	public BatchResults execute(
-		BatchPolicy batchPolicy,
-		BatchUDFPolicy udfPolicy,
-		Key[] keys,
-		String packageName,
-		String functionName,
-		Value... functionArgs
+			BatchPolicy batchPolicy,
+			BatchUDFPolicy udfPolicy,
+			Key[] keys,
+			String packageName,
+			String functionName,
+			Value... functionArgs
 	) {
 		throw new AerospikeException(NotSupported + "batch execute");
 	}
 
 	@Override
 	public void execute(
-		EventLoop eventLoop,
-		BatchRecordArrayListener listener,
-		BatchPolicy batchPolicy,
-		BatchUDFPolicy udfPolicy,
-		Key[] keys,
-		String packageName,
-		String functionName,
-		Value... functionArgs
+			EventLoop eventLoop,
+			BatchRecordArrayListener listener,
+			BatchPolicy batchPolicy,
+			BatchUDFPolicy udfPolicy,
+			Key[] keys,
+			String packageName,
+			String functionName,
+			Value... functionArgs
 	) {
 		throw new AerospikeException(NotSupported + "batch execute");
 	}
 
 	@Override
 	public void execute(
-		EventLoop eventLoop,
-		BatchRecordSequenceListener listener,
-		BatchPolicy batchPolicy,
-		BatchUDFPolicy udfPolicy,
-		Key[] keys,
-		String packageName,
-		String functionName,
-		Value... functionArgs
+			EventLoop eventLoop,
+			BatchRecordSequenceListener listener,
+			BatchPolicy batchPolicy,
+			BatchUDFPolicy udfPolicy,
+			Key[] keys,
+			String packageName,
+			String functionName,
+			Value... functionArgs
 	) {
 		throw new AerospikeException(NotSupported + "batch execute");
 	}
@@ -905,11 +904,11 @@ public class AerospikeClientProxy implements IAerospikeClient, Closeable {
 
 	@Override
 	public ExecuteTask execute(
-		WritePolicy policy,
-		Statement statement,
-		String packageName,
-		String functionName,
-		Value... functionArgs
+			WritePolicy policy,
+			Statement statement,
+			String packageName,
+			String functionName,
+			Value... functionArgs
 	) {
 		return null;
 	}
@@ -952,21 +951,21 @@ public class AerospikeClientProxy implements IAerospikeClient, Closeable {
 
 	@Override
 	public void queryPartitions(
-		EventLoop eventLoop,
-		RecordSequenceListener listener,
-		QueryPolicy policy,
-		Statement statement,
-		PartitionFilter partitionFilter
+			EventLoop eventLoop,
+			RecordSequenceListener listener,
+			QueryPolicy policy,
+			Statement statement,
+			PartitionFilter partitionFilter
 	) {
 	}
 
 	@Override
 	public ResultSet queryAggregate(
-		QueryPolicy policy,
-		Statement statement,
-		String packageName,
-		String functionName,
-		Value... functionArgs
+			QueryPolicy policy,
+			Statement statement,
+			String packageName,
+			String functionName,
+			Value... functionArgs
 	) {
 		return null;
 	}
@@ -987,42 +986,42 @@ public class AerospikeClientProxy implements IAerospikeClient, Closeable {
 
 	@Override
 	public IndexTask createIndex(
-		Policy policy,
-		String namespace,
-		String setName,
-		String indexName,
-		String binName,
-		IndexType indexType
+			Policy policy,
+			String namespace,
+			String setName,
+			String indexName,
+			String binName,
+			IndexType indexType
 	) {
 		return null;
 	}
 
 	@Override
 	public IndexTask createIndex(
-		Policy policy,
-		String namespace,
-		String setName,
-		String indexName,
-		String binName,
-		IndexType indexType,
-		IndexCollectionType indexCollectionType,
-		CTX... ctx
+			Policy policy,
+			String namespace,
+			String setName,
+			String indexName,
+			String binName,
+			IndexType indexType,
+			IndexCollectionType indexCollectionType,
+			CTX... ctx
 	) {
 		return null;
 	}
 
 	@Override
 	public void createIndex(
-		EventLoop eventLoop,
-		IndexListener listener,
-		Policy policy,
-		String namespace,
-		String setName,
-		String indexName,
-		String binName,
-		IndexType indexType,
-		IndexCollectionType indexCollectionType,
-		CTX... ctx
+			EventLoop eventLoop,
+			IndexListener listener,
+			Policy policy,
+			String namespace,
+			String setName,
+			String indexName,
+			String binName,
+			IndexType indexType,
+			IndexCollectionType indexCollectionType,
+			CTX... ctx
 	) {
 	}
 
@@ -1033,12 +1032,12 @@ public class AerospikeClientProxy implements IAerospikeClient, Closeable {
 
 	@Override
 	public void dropIndex(
-		EventLoop eventLoop,
-		IndexListener listener,
-		Policy policy,
-		String namespace,
-		String setName,
-		String indexName
+			EventLoop eventLoop,
+			IndexListener listener,
+			Policy policy,
+			String namespace,
+			String setName,
+			String indexName
 	) {
 	}
 
@@ -1094,12 +1093,12 @@ public class AerospikeClientProxy implements IAerospikeClient, Closeable {
 
 	@Override
 	public void createRole(
-		AdminPolicy policy,
-		String roleName,
-		List<Privilege> privileges,
-		List<String> whitelist,
-		int readQuota,
-		int writeQuota
+			AdminPolicy policy,
+			String roleName,
+			List<Privilege> privileges,
+			List<String> whitelist,
+			int readQuota,
+			int writeQuota
 	) {
 	}
 
@@ -1153,14 +1152,14 @@ public class AerospikeClientProxy implements IAerospikeClient, Closeable {
 		Class<? extends Channel> channelType = null;
 
 		if (policy.eventLoops != null) {
-			if (! (policy.eventLoops instanceof NettyEventLoops)) {
+			if (!(policy.eventLoops instanceof NettyEventLoops)) {
 				throw new AerospikeException(ResultCode.PARAMETER_ERROR,
-					"Netty event loops are required in proxy client");
+						"Netty event loops are required in proxy client");
 			}
 
 			NettyEventLoops nettyLoops = (NettyEventLoops)policy.eventLoops;
 			NettyEventLoop[] array = nettyLoops.getArray();
-			eventLoops = new ArrayList<io.netty.channel.EventLoop>(array.length);
+			eventLoops = new ArrayList<>(array.length);
 
 			for (NettyEventLoop loop : array) {
 				eventLoops.add(loop.get());
@@ -1170,15 +1169,15 @@ public class AerospikeClientProxy implements IAerospikeClient, Closeable {
 		}
 
 		int maxConnections =
-		        Math.min(MAX_CONNECTIONS,
-		                Math.max(MIN_CONNECTIONS, Math.max(policy.asyncMaxConnsPerNode,
-		                        policy.maxConnsPerNode)));
+				Math.min(MAX_CONNECTIONS,
+						Math.max(MIN_CONNECTIONS, Math.max(policy.asyncMaxConnsPerNode,
+								policy.maxConnsPerNode)));
 
 		return GrpcClientPolicy.newBuilder(eventLoops, channelType)
-		        .maxChannels(maxConnections)
-		        .connectTimeoutMillis(policy.timeout)
-		        .tlsPolicy(policy.tlsPolicy)
-		        .build();
+				.maxChannels(maxConnections)
+				.connectTimeoutMillis(policy.timeout)
+				.tlsPolicy(policy.tlsPolicy)
+				.build();
 	}
 
 	private static WriteListener prepareWriteListener(final CompletableFuture<Void> future) {
@@ -1256,6 +1255,9 @@ public class AerospikeClientProxy implements IAerospikeClient, Closeable {
 			return future.get();
 		}
 		catch (ExecutionException e) {
+			if (e.getCause() instanceof AerospikeException) {
+				throw (AerospikeException)e.getCause();
+			}
 			throw new AerospikeException(e);
 		}
 		catch (InterruptedException e) {

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.aerospike</groupId>
     <artifactId>aerospike-parent</artifactId>
-    <version>6.1.7</version>
+    <version>6.1.7-SNAPSHOT</version>
   </parent>
   <artifactId>aerospike-client-test</artifactId>
   <packaging>jar</packaging>
@@ -57,13 +57,13 @@
       <artifactId>commons-cli</artifactId>
     </dependency>
 
-    <dependency> 
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>
-    
+
   <build>
     <testSourceDirectory>${project.basedir}/src</testSourceDirectory>
     <testResources>
@@ -86,10 +86,10 @@
         <executions>
           <execution>
             <id>make-my-jar-with-dependencies</id>
-              <phase>package</phase>
-              <goals>
-                <goal>single</goal>
-              </goals>
+            <phase>package</phase>
+            <goals>
+              <goal>single</goal>
+            </goals>
           </execution>
         </executions>
       </plugin>
@@ -103,7 +103,7 @@
           </includes>
         </configuration>
       </plugin>
-    </plugins>      
+    </plugins>
   </build>
 
 </project>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.aerospike</groupId>
     <artifactId>aerospike-parent</artifactId>
-    <version>6.1.6</version>
+    <version>6.1.6-0.9.0-proxy-SNAPSHOT</version>
   </parent>
   <artifactId>aerospike-client-test</artifactId>
   <packaging>jar</packaging>


### PR DESCRIPTION
 - Opened up the final method required by proxy server to provide pass-through results
 - Changed version to snapshot, so that the proxy server can use the client artifacts
 - Fixed Aerospike exception being nested in getFuture(), masking the resultcode returned by the proxy 