### PR TITLE
[CONNECTOR-615] Ensured the correct streaming call is used for each command

### DIFF
--- a/benchmarks/run_benchmarks
+++ b/benchmarks/run_benchmarks
@@ -4,4 +4,6 @@
 # Build with maven before running this script.
 # mvn package
 
-java -jar target/aerospike-benchmarks-*-jar-with-dependencies.jar $*
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+java -jar $SCRIPT_DIR/target/aerospike-benchmarks-*-jar-with-dependencies.jar $*
+

--- a/benchmarks/src/com/aerospike/benchmarks/Main.java
+++ b/benchmarks/src/com/aerospike/benchmarks/Main.java
@@ -26,13 +26,6 @@ import java.util.Properties;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
-import org.apache.commons.cli.CommandLine;
-import org.apache.commons.cli.CommandLineParser;
-import org.apache.commons.cli.DefaultParser;
-import org.apache.commons.cli.HelpFormatter;
-import org.apache.commons.cli.Options;
-import org.apache.commons.cli.ParseException;
-
 import com.aerospike.client.AerospikeClient;
 import com.aerospike.client.Host;
 import com.aerospike.client.IAerospikeClient;
@@ -60,12 +53,17 @@ import com.aerospike.client.policy.TlsPolicy;
 import com.aerospike.client.policy.WritePolicy;
 import com.aerospike.client.proxy.AerospikeClientProxy;
 import com.aerospike.client.util.Util;
-
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.epoll.EpollEventLoopGroup;
 import io.netty.channel.kqueue.KQueueEventLoopGroup;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.incubator.channel.uring.IOUringEventLoopGroup;
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.CommandLineParser;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.HelpFormatter;
+import org.apache.commons.cli.Options;
+import org.apache.commons.cli.ParseException;
 
 public class Main implements Log.Callback {
 
@@ -80,6 +78,7 @@ public class Main implements Log.Callback {
 			program.runBenchmarks();
 		}
 		catch (UsageException ue) {
+			// Ignored
 		}
 		catch (ParseException pe) {
 			System.out.println(pe.getMessage());
@@ -115,119 +114,119 @@ public class Main implements Log.Callback {
 
 		Options options = new Options();
 		options.addOption("h", "hosts", true,
-			"List of seed hosts in format: " +
-			"hostname1[:tlsname][:port1],...\n" +
-			"The tlsname is only used when connecting with a secure TLS enabled server. " +
-			"If the port is not specified, the default port is used. " +
-			"IPv6 addresses must be enclosed in square brackets.\n" +
-			"Default: localhost\n" +
-			"Examples:\n" +
-			"host1\n" +
-			"host1:3000,host2:3000\n" +
-			"192.168.1.10:cert1:3000,[2001::1111]:cert2:3000\n"
-			);
+				"List of seed hosts in format: " +
+						"hostname1[:tlsname][:port1],...\n" +
+						"The tlsname is only used when connecting with a secure TLS enabled server. " +
+						"If the port is not specified, the default port is used. " +
+						"IPv6 addresses must be enclosed in square brackets.\n" +
+						"Default: localhost\n" +
+						"Examples:\n" +
+						"host1\n" +
+						"host1:3000,host2:3000\n" +
+						"192.168.1.10:cert1:3000,[2001::1111]:cert2:3000\n"
+		);
 		options.addOption("p", "port", true, "Set the default port on which to connect to Aerospike.");
 		options.addOption("U", "user", true, "User name");
 		options.addOption("P", "password", true, "Password");
 		options.addOption("n", "namespace", true, "Set the Aerospike namespace. Default: test");
-		options.addOption("bns","batchNamespaces", true, "Set batch namespaces. Default is regular namespace.");
+		options.addOption("bns", "batchNamespaces", true, "Set batch namespaces. Default is regular namespace.");
 		options.addOption("s", "set", true, "Set the Aerospike set name. Default: testset");
 		options.addOption("c", "clusterName", true, "Set expected cluster name.");
 		options.addOption("servicesAlternate", false, "Set to enable use of services-alternate instead of services in info request during cluster tending");
 
 		options.addOption("lt", "loginTimeout", true,
-			"Set expected loginTimeout in milliseconds. The timeout is used when user " +
-			"authentication is enabled and a node login is being performed. Default: 5000"
-			);
+				"Set expected loginTimeout in milliseconds. The timeout is used when user " +
+						"authentication is enabled and a node login is being performed. Default: 5000"
+		);
 		options.addOption("tt", "tendTimeout", true,
-			"Set cluster tend info call timeout in milliseconds. Default: 1000"
-			);
+				"Set cluster tend info call timeout in milliseconds. Default: 1000"
+		);
 		options.addOption("ti", "tendInterval", true,
-			"Interval between cluster tends in milliseconds. Default: 1000"
-			);
+				"Interval between cluster tends in milliseconds. Default: 1000"
+		);
 		options.addOption("maxSocketIdle", true,
-			"Maximum socket idle in connection pool in seconds. Default: 0"
-			);
+				"Maximum socket idle in connection pool in seconds. Default: 0"
+		);
 		options.addOption("maxErrorRate", true,
-			"Maximum number of errors allowed per node per tend iteration. Default: 100"
-			);
+				"Maximum number of errors allowed per node per tend iteration. Default: 100"
+		);
 		options.addOption("errorRateWindow", true,
-			"Number of cluster tend iterations that defines the window for maxErrorRate. Default: 1"
-			);
+				"Number of cluster tend iterations that defines the window for maxErrorRate. Default: 1"
+		);
 		options.addOption("minConnsPerNode", true,
-			"Minimum number of sync connections pre-allocated per server node. Default: 0"
-			);
+				"Minimum number of sync connections pre-allocated per server node. Default: 0"
+		);
 		options.addOption("maxConnsPerNode", true,
-			"Maximum number of sync connections allowed per server node. Default: 100"
-			);
+				"Maximum number of sync connections allowed per server node. Default: 100"
+		);
 		options.addOption("asyncMinConnsPerNode", true,
-			"Minimum number of async connections pre-allocated per server node. Default: 0"
-			);
+				"Minimum number of async connections pre-allocated per server node. Default: 0"
+		);
 		options.addOption("asyncMaxConnsPerNode", true,
-			"Maximum number of async connections allowed per server node. Default: 100"
-			);
+				"Maximum number of async connections allowed per server node. Default: 100"
+		);
 		options.addOption("k", "keys", true,
-			"Set the number of keys the client is dealing with. " +
-			"If using an 'insert' workload (detailed below), the client will write this " +
-			"number of keys, starting from value = startkey. Otherwise, the client " +
-			"will read and update randomly across the values between startkey and " +
-			"startkey + num_keys.  startkey can be set using '-S' or '-startkey'."
-			);
+				"Set the number of keys the client is dealing with. " +
+						"If using an 'insert' workload (detailed below), the client will write this " +
+						"number of keys, starting from value = startkey. Otherwise, the client " +
+						"will read and update randomly across the values between startkey and " +
+						"startkey + num_keys.  startkey can be set using '-S' or '-startkey'."
+		);
 		options.addOption("b", "bins", true,
-			"Set the number of Aerospike bins. " +
-			"Each bin will contain an object defined with -o. The default is single bin (-b 1)."
-			);
+				"Set the number of Aerospike bins. " +
+						"Each bin will contain an object defined with -o. The default is single bin (-b 1)."
+		);
 		options.addOption("o", "objectSpec", true,
-			"I | S:<size> | B:<size> | R:<size>:<rand_pct>\n" +
-			"Set the type of object(s) to use in Aerospike transactions. Type can be 'I' " +
-			"for integer, 'S' for string, or 'B' for Java blob. If type is 'I' (integer), " +
-			"do not set a size (integers are always 8 bytes). If object_type is 'S' " +
-			"(string), this value represents the length of the string."
-			);
+				"I | S:<size> | B:<size> | R:<size>:<rand_pct>\n" +
+						"Set the type of object(s) to use in Aerospike transactions. Type can be 'I' " +
+						"for integer, 'S' for string, or 'B' for Java blob. If type is 'I' (integer), " +
+						"do not set a size (integers are always 8 bytes). If object_type is 'S' " +
+						"(string), this value represents the length of the string."
+		);
 		options.addOption("R", "random", false,
-			"Use dynamically generated random bin values instead of default static fixed bin values."
-			);
+				"Use dynamically generated random bin values instead of default static fixed bin values."
+		);
 		options.addOption("S", "startkey", true,
-			"Set the starting value of the working set of keys. " +
-			"If using an 'insert' workload, the start_value indicates the first value to write. " +
-			"Otherwise, the start_value indicates the smallest value in the working set of keys."
-			);
+				"Set the starting value of the working set of keys. " +
+						"If using an 'insert' workload, the start_value indicates the first value to write. " +
+						"Otherwise, the start_value indicates the smallest value in the working set of keys."
+		);
 		options.addOption("w", "workload", true,
-			"I | RU,<percent>[,<percent2>][,<percent3>] | RR,<percent>[,<percent2>][,<percent3>], RMU | RMI | RMD\n" +
-			"Set the desired workload.\n\n" +
-			"   -w I sets a linear 'insert' workload.\n\n" +
-			"   -w RU,80 sets a random read-update workload with 80% reads and 20% writes.\n\n" +
-			"      100% of reads will read all bins.\n\n" +
-			"      100% of writes will write all bins.\n\n" +
-			"   -w RU,80,60,30 sets a random multi-bin read-update workload with 80% reads and 20% writes.\n\n" +
-			"      60% of reads will read all bins. 40% of reads will read a single bin.\n\n" +
-			"      30% of writes will write all bins. 70% of writes will write a single bin.\n\n" +
-			"   -w RR,20 sets a random read-replace workload with 20% reads and 80% replace all bin(s) writes.\n\n" +
-			"      100% of reads will read all bins.\n\n" +
-			"      100% of writes will replace all bins.\n\n" +
-			"   -w RMU sets a random read all bins-update one bin workload with 50% reads.\n\n" +
-			"   -w RMI sets a random read all bins-increment one integer bin workload with 50% reads.\n\n" +
-			"   -w RMD sets a random read all bins-decrement one integer bin workload with 50% reads.\n\n" +
-			"   -w TXN,r:1000,w:200,v:20%\n\n" +
-			"      form business transactions with 1000 reads, 200 writes with a variation (+/-) of 20%\n\n"
-			);
+				"I | RU,<percent>[,<percent2>][,<percent3>] | RR,<percent>[,<percent2>][,<percent3>], RMU | RMI | RMD\n" +
+						"Set the desired workload.\n\n" +
+						"   -w I sets a linear 'insert' workload.\n\n" +
+						"   -w RU,80 sets a random read-update workload with 80% reads and 20% writes.\n\n" +
+						"      100% of reads will read all bins.\n\n" +
+						"      100% of writes will write all bins.\n\n" +
+						"   -w RU,80,60,30 sets a random multi-bin read-update workload with 80% reads and 20% writes.\n\n" +
+						"      60% of reads will read all bins. 40% of reads will read a single bin.\n\n" +
+						"      30% of writes will write all bins. 70% of writes will write a single bin.\n\n" +
+						"   -w RR,20 sets a random read-replace workload with 20% reads and 80% replace all bin(s) writes.\n\n" +
+						"      100% of reads will read all bins.\n\n" +
+						"      100% of writes will replace all bins.\n\n" +
+						"   -w RMU sets a random read all bins-update one bin workload with 50% reads.\n\n" +
+						"   -w RMI sets a random read all bins-increment one integer bin workload with 50% reads.\n\n" +
+						"   -w RMD sets a random read all bins-decrement one integer bin workload with 50% reads.\n\n" +
+						"   -w TXN,r:1000,w:200,v:20%\n\n" +
+						"      form business transactions with 1000 reads, 200 writes with a variation (+/-) of 20%\n\n"
+		);
 		options.addOption("e", "expirationTime", true,
-			"Set expiration time of each record in seconds.\n" +
-			" -1: Never expire\n" +
-			"  0: Default to namespace expiration time\n" +
-			" >0: Actual given expiration time"
-			);
+				"Set expiration time of each record in seconds.\n" +
+						" -1: Never expire\n" +
+						"  0: Default to namespace expiration time\n" +
+						" >0: Actual given expiration time"
+		);
 		options.addOption("g", "throughput", true,
-			"Set a target transactions per second for the client. The client should not exceed this " +
-			"average throughput."
-			);
+				"Set a target transactions per second for the client. The client should not exceed this " +
+						"average throughput."
+		);
 		options.addOption("t", "transactions", true,
-			"Number of transactions to perform in read/write mode before shutting down. " +
-			"The default is to run indefinitely."
-			);
+				"Number of transactions to perform in read/write mode before shutting down. " +
+						"The default is to run indefinitely."
+		);
 		options.addOption("ct", "connectTimeout", true,
-			"Set socket connection timeout in milliseconds. Default: 0"
-			);
+				"Set socket connection timeout in milliseconds. Default: 0"
+		);
 
 		options.addOption("T", "timeout", true, "Set read and write socketTimeout and totalTimeout to the same timeout in milliseconds.");
 		options.addOption("socketTimeout", true, "Set read and write socketTimeout in milliseconds.");
@@ -241,53 +240,53 @@ public class Main implements Log.Callback {
 		options.addOption("rackId", true, "Set Rack where this benchmark instance resides.  Default: 0");
 		options.addOption("maxRetries", true, "Maximum number of retries before aborting the current transaction.");
 		options.addOption("sleepBetweenRetries", true,
-			"Milliseconds to sleep between retries if a transaction fails and the timeout was not exceeded. " +
-			"Enter zero to skip sleep."
-			);
+				"Milliseconds to sleep between retries if a transaction fails and the timeout was not exceeded. " +
+						"Enter zero to skip sleep."
+		);
 		options.addOption("r", "replica", true,
 				"Which replica to use for reads.\n\n" +
-				"Values:  master | any | sequence | preferRack.  Default: sequence\n" +
-				"master: Always use node containing master partition.\n" +
-				"any: Distribute reads across master and proles in round-robin fashion.\n" +
-				"sequence: Always try master first. If master fails, try proles in sequence.\n" +
-				"preferRack: Always try node on the same rack as the benchmark first. If no nodes on the same rack, use sequence.\n" +
-				"Use 'rackId' option to set rack."
-				);
+						"Values:  master | any | sequence | preferRack.  Default: sequence\n" +
+						"master: Always use node containing master partition.\n" +
+						"any: Distribute reads across master and proles in round-robin fashion.\n" +
+						"sequence: Always try master first. If master fails, try proles in sequence.\n" +
+						"preferRack: Always try node on the same rack as the benchmark first. If no nodes on the same rack, use sequence.\n" +
+						"Use 'rackId' option to set rack."
+		);
 		options.addOption("readModeAP", true,
 				"Read consistency level when in AP mode.\n" +
-				"Values:  one | all.  Default: one"
-				);
+						"Values:  one | all.  Default: one"
+		);
 		options.addOption("readModeSC", true,
 				"Read consistency level when in SC (strong consistency) mode.\n" +
-				"Values:  session | linearize | allow_replica | allow_unavailable.  Default: session"
-				);
+						"Values:  session | linearize | allow_replica | allow_unavailable.  Default: session"
+		);
 		options.addOption("commitLevel", true,
 				"Desired replica consistency guarantee when committing a transaction on the server.\n" +
-				"Values:  all | master.  Default: all"
-				);
+						"Values:  all | master.  Default: all"
+		);
 
 		options.addOption("Y", "connPoolsPerNode", true,
 				"Number of synchronous connection pools per node.  Default 1."
-				);
+		);
 		options.addOption("z", "threads", true,
-			"Set the number of threads the client will use to generate load. "
-			);
+				"Set the number of threads the client will use to generate load. "
+		);
 		options.addOption("latency", true,
-			"ycsb[,<warmup count>] | [alt,]<columns>,<range shift increment>[,us|ms]\n" +
-			"ycsb: Show the timings in ycsb format.\n" +
-			"alt: Show both count and pecentage in each elapsed time bucket.\n" +
-			"default: Show pecentage in each elapsed time bucket.\n" +
-			"<columns>: Number of elapsed time ranges.\n" +
-			"<range shift increment>: Power of 2 multiple between each range starting at column 3.\n" +
-			"(ms|us): display times in milliseconds (ms, default) or microseconds (us)\n\n" +
-			"A latency definition of '-latency 7,1' results in this layout:\n" +
-			"    <=1ms >1ms >2ms >4ms >8ms >16ms >32ms\n" +
-			"       x%   x%   x%   x%   x%    x%    x%\n" +
-			"A latency definition of '-latency 4,3' results in this layout:\n" +
-			"    <=1ms >1ms >8ms >64ms\n" +
-			"       x%   x%   x%    x%\n\n" +
-			"Latency columns are cumulative. If a transaction takes 9ms, it will be included in both the >1ms and >8ms columns."
-			);
+				"ycsb[,<warmup count>] | [alt,]<columns>,<range shift increment>[,us|ms]\n" +
+						"ycsb: Show the timings in ycsb format.\n" +
+						"alt: Show both count and pecentage in each elapsed time bucket.\n" +
+						"default: Show pecentage in each elapsed time bucket.\n" +
+						"<columns>: Number of elapsed time ranges.\n" +
+						"<range shift increment>: Power of 2 multiple between each range starting at column 3.\n" +
+						"(ms|us): display times in milliseconds (ms, default) or microseconds (us)\n\n" +
+						"A latency definition of '-latency 7,1' results in this layout:\n" +
+						"    <=1ms >1ms >2ms >4ms >8ms >16ms >32ms\n" +
+						"       x%   x%   x%   x%   x%    x%    x%\n" +
+						"A latency definition of '-latency 4,3' results in this layout:\n" +
+						"    <=1ms >1ms >8ms >64ms\n" +
+						"       x%   x%   x%    x%\n\n" +
+						"Latency columns are cumulative. If a transaction takes 9ms, it will be included in both the >1ms and >8ms columns."
+		);
 
 		options.addOption("N", "reportNotFound", false, "Report not found errors. Data should be fully initialized before using this option.");
 		options.addOption("D", "debug", false, "Run benchmarks in debug mode.");
@@ -295,20 +294,20 @@ public class Main implements Log.Callback {
 		options.addOption("V", "version", false, "Print version.");
 
 		options.addOption("B", "batchSize", true,
-			"Enable batch mode with number of records to process in each batch get call. " +
-			"Batch mode is valid only for RU (read update) workloads. Batch mode is disabled by default."
-			);
+				"Enable batch mode with number of records to process in each batch get call. " +
+						"Batch mode is valid only for RU (read update) workloads. Batch mode is disabled by default."
+		);
 
 		options.addOption("BT", "batchThreads", true,
-			"Maximum number of concurrent batch sub-threads for each batch command.\n" +
-			"1   : Run each batch node command sequentially.\n" +
-			"0   : Run all batch node commands in parallel.\n" +
-			"> 1 : Run maximum batchThreads in parallel.  When a node command finshes, start a new one until all finished."
-			);
+				"Maximum number of concurrent batch sub-threads for each batch command.\n" +
+						"1   : Run each batch node command sequentially.\n" +
+						"0   : Run all batch node commands in parallel.\n" +
+						"> 1 : Run maximum batchThreads in parallel.  When a node command finshes, start a new one until all finished."
+		);
 
 		options.addOption("BSN", "batchShowNodes", false,
-			"Print target nodes and count of keys directed at each node once on start of benchmarks."
-			);
+				"Print target nodes and count of keys directed at each node once on start of benchmarks."
+		);
 
 		options.addOption("prole", false, "Distribute reads across proles in round-robin fashion.");
 
@@ -320,19 +319,19 @@ public class Main implements Log.Callback {
 		options.addOption("tls", "tlsEnable", false, "Use TLS/SSL sockets");
 		options.addOption("tp", "tlsProtocols", true,
 				"Allow TLS protocols\n" +
-				"Values:  TLSv1,TLSv1.1,TLSv1.2 separated by comma\n" +
-				"Default: TLSv1.2"
-				);
+						"Values:  TLSv1,TLSv1.1,TLSv1.2 separated by comma\n" +
+						"Default: TLSv1.2"
+		);
 		options.addOption("tlsCiphers", "tlsCipherSuite", true,
 				"Allow TLS cipher suites\n" +
-				"Values:  cipher names defined by JVM separated by comma\n" +
-				"Default: null (default cipher list provided by JVM)"
-				);
+						"Values:  cipher names defined by JVM separated by comma\n" +
+						"Default: null (default cipher list provided by JVM)"
+		);
 		options.addOption("tr", "tlsRevoke", true,
 				"Revoke certificates identified by their serial number\n" +
-				"Values:  serial numbers separated by comma\n" +
-				"Default: null (Do not revoke certificates)"
-				);
+						"Values:  serial numbers separated by comma\n" +
+						"Default: null (Do not revoke certificates)"
+		);
 		options.addOption("tlsLoginOnly", false, "Use TLS/SSL sockets on node login only");
 		options.addOption("auth", true, "Authentication mode. Values: " + Arrays.toString(AuthMode.values()));
 
@@ -340,14 +339,14 @@ public class Main implements Log.Callback {
 		options.addOption("nettyEpoll", false, "Use Netty epoll event loops for async benchmarks (Linux only)");
 		options.addOption("elt", "eventLoopType", true,
 				"Use specified event loop type for async examples\n" +
-				"Value: DIRECT_NIO | NETTY_NIO | NETTY_EPOLL | NETTY_KQUEUE | NETTY_IOURING"
-				);
+						"Value: DIRECT_NIO | NETTY_NIO | NETTY_EPOLL | NETTY_KQUEUE | NETTY_IOURING"
+		);
 
 		options.addOption("proxy", false, "Use proxy client.");
 
 		options.addOption("upn", "udfPackageName", true, "Specify the package name where the udf function is located");
 		options.addOption("ufn", "udfFunctionName", true, "Specify the udf function name that must be used in the udf benchmarks");
-		options.addOption("ufv","udfFunctionValues",true, "The udf argument values comma separated");
+		options.addOption("ufv", "udfFunctionValues", true, "The udf argument values comma separated");
 		options.addOption("sendKey", false, "Send key to server");
 
 		// parse the command line arguments
@@ -379,9 +378,9 @@ public class Main implements Log.Callback {
 		args.batchPolicy = clientPolicy.batchPolicyDefault;
 
 		if (line.hasOption("e")) {
-			args.writePolicy.expiration =  Integer.parseInt(line.getOptionValue("e"));
+			args.writePolicy.expiration = Integer.parseInt(line.getOptionValue("e"));
 			if (args.writePolicy.expiration < -1) {
-				throw new Exception("Invalid expiration: "+ args.writePolicy.expiration + " It should be >= -1");
+				throw new Exception("Invalid expiration: " + args.writePolicy.expiration + " It should be >= -1");
 			}
 		}
 
@@ -513,7 +512,8 @@ public class Main implements Log.Callback {
 
 		if (line.hasOption("keys")) {
 			this.nKeys = Long.parseLong(line.getOptionValue("keys"));
-		} else {
+		}
+		else {
 			this.nKeys = 100000;
 		}
 
@@ -525,7 +525,7 @@ public class Main implements Log.Callback {
 		if (line.hasOption("keyFile")) {
 			if (startKey + nKeys > Integer.MAX_VALUE) {
 				throw new Exception("Invalid arguments when keyFile specified.  startkey " + startKey +
-									" + keys " + nKeys + " must be <= " + Integer.MAX_VALUE);
+						" + keys " + nKeys + " must be <= " + Integer.MAX_VALUE);
 			}
 
 			this.filepath = line.getOptionValue("keyFile");
@@ -546,12 +546,13 @@ public class Main implements Log.Callback {
 				else if (keyType.equals("I")) {
 					if (Utils.isNumeric(keyList.get(0))) {
 						args.keyType = KeyType.INTEGER;
-					} else {
-						throw new Exception("Invalid keyType '"+keyType+"' Key type doesn't match with file content type.");
+					}
+					else {
+						throw new Exception("Invalid keyType '" + keyType + "' Key type doesn't match with file content type.");
 					}
 				}
 				else {
-					throw new Exception("Invalid keyType: "+keyType);
+					throw new Exception("Invalid keyType: " + keyType);
 				}
 			}
 			else {
@@ -570,7 +571,7 @@ public class Main implements Log.Callback {
 		if (line.hasOption("objectSpec")) {
 			String[] objectsArr = line.getOptionValue("objectSpec").split(",");
 			args.objectSpec = new DBObjectSpec[objectsArr.length];
-			for (int i=0; i<objectsArr.length; i++) {
+			for (int i = 0; i < objectsArr.length; i++) {
 				String[] objarr = objectsArr[i].split(":");
 				DBObjectSpec dbobj = new DBObjectSpec();
 				dbobj.type = objarr[0].charAt(0);
@@ -586,7 +587,7 @@ public class Main implements Log.Callback {
 		else {
 			args.objectSpec = new DBObjectSpec[1];
 			DBObjectSpec dbobj = new DBObjectSpec();
-			dbobj.type = 'I';	// If the object is not specified, it has one bin of integer type
+			dbobj.type = 'I';    // If the object is not specified, it has one bin of integer type
 			args.objectSpec[0] = dbobj;
 		}
 
@@ -809,7 +810,7 @@ public class Main implements Log.Callback {
 			if (level.equals("master")) {
 				args.writePolicy.commitLevel = CommitLevel.COMMIT_MASTER;
 			}
-			else if (! level.equals("all")) {
+			else if (!level.equals("all")) {
 				throw new Exception("Invalid commitLevel: " + level);
 			}
 		}
@@ -838,7 +839,7 @@ public class Main implements Log.Callback {
 		}
 
 		if (line.hasOption("batchSize")) {
-			args.batchSize =  Integer.parseInt(line.getOptionValue("batchSize"));
+			args.batchSize = Integer.parseInt(line.getOptionValue("batchSize"));
 		}
 
 		if (line.hasOption("batchThreads")) {
@@ -850,11 +851,11 @@ public class Main implements Log.Callback {
 		}
 
 		if (line.hasOption("asyncMaxCommands")) {
-			this.asyncMaxCommands =  Integer.parseInt(line.getOptionValue("asyncMaxCommands"));
+			this.asyncMaxCommands = Integer.parseInt(line.getOptionValue("asyncMaxCommands"));
 		}
 
 		if (line.hasOption("eventLoops")) {
-			this.eventLoopSize =  Integer.parseInt(line.getOptionValue("eventLoops"));
+			this.eventLoopSize = Integer.parseInt(line.getOptionValue("eventLoops"));
 		}
 
 		if (line.hasOption("latency")) {
@@ -922,7 +923,7 @@ public class Main implements Log.Callback {
 			}
 		}
 
-		if (! line.hasOption("random")) {
+		if (!line.hasOption("random")) {
 			args.setFixedBins();
 		}
 
@@ -942,29 +943,29 @@ public class Main implements Log.Callback {
 			this.useProxyClient = true;
 		}
 
-		if(line.hasOption("udfPackageName")){
+		if (line.hasOption("udfPackageName")) {
 			args.udfPackageName = line.getOptionValue("udfPackageName");
 		}
 
-		if(line.hasOption("udfFunctionName")){
-			if(args.udfPackageName == null){
+		if (line.hasOption("udfFunctionName")) {
+			if (args.udfPackageName == null) {
 				throw new Exception("Udf Package name missing");
 			}
 			args.udfFunctionName = line.getOptionValue("udfFunctionName");
 		}
 
-		if(line.hasOption("udfFunctionValues")){
+		if (line.hasOption("udfFunctionValues")) {
 			Object[] udfVals = line.getOptionValue("udfFunctionValues").split(",");
-			if(args.udfPackageName == null){
+			if (args.udfPackageName == null) {
 				throw new Exception("Udf Package name missing");
 			}
 
-			if(args.udfFunctionName == null){
+			if (args.udfFunctionName == null) {
 				throw new Exception("Udf Function name missing");
 			}
 			Value[] udfValues = new Value[udfVals.length];
 			int index = 0;
-			for(Object value : udfVals){
+			for (Object value : udfVals) {
 				udfValues[index++] = Value.get(value);
 			}
 			args.udfValues = udfValues;
@@ -975,10 +976,10 @@ public class Main implements Log.Callback {
 		}
 
 		System.out.println("Benchmark: " + this.hosts[0]
-			+ ", namespace: " + args.namespace
-			+ ", set: " + (args.setName.length() > 0? args.setName : "<empty>")
-			+ ", threads: " + this.nThreads
-			+ ", workload: " + args.workload);
+				+ ", namespace: " + args.namespace
+				+ ", set: " + (args.setName.length() > 0 ? args.setName : "<empty>")
+				+ ", threads: " + this.nThreads
+				+ ", workload: " + args.workload);
 
 		if (args.workload == Workload.READ_UPDATE || args.workload == Workload.READ_REPLACE) {
 			System.out.print("read: " + args.readPct + '%');
@@ -991,65 +992,65 @@ public class Main implements Log.Callback {
 		}
 
 		System.out.println("keys: " + this.nKeys
-			+ ", start key: " + this.startKey
-			+ ", transactions: " + args.transactionLimit
-			+ ", bins: " + args.nBins
-			+ ", random values: " + (args.fixedBins == null)
-			+ ", throughput: " + (args.throughput == 0 ? "unlimited" : (args.throughput + " tps")));
+				+ ", start key: " + this.startKey
+				+ ", transactions: " + args.transactionLimit
+				+ ", bins: " + args.nBins
+				+ ", random values: " + (args.fixedBins == null)
+				+ ", throughput: " + (args.throughput == 0 ? "unlimited" : (args.throughput + " tps")));
 
 		System.out.println("client policy:");
 		System.out.println(
-			"    loginTimeout: " + clientPolicy.loginTimeout
-			+ ", tendTimeout: " + clientPolicy.timeout
-			+ ", tendInterval: " + clientPolicy.tendInterval
-			+ ", maxSocketIdle: " + clientPolicy.maxSocketIdle
-			+ ", maxErrorRate: " + clientPolicy.maxErrorRate);
+				"    loginTimeout: " + clientPolicy.loginTimeout
+						+ ", tendTimeout: " + clientPolicy.timeout
+						+ ", tendInterval: " + clientPolicy.tendInterval
+						+ ", maxSocketIdle: " + clientPolicy.maxSocketIdle
+						+ ", maxErrorRate: " + clientPolicy.maxErrorRate);
 		System.out.println(
-			"    errorRateWindow: " + clientPolicy.errorRateWindow
-			+ ", minConnsPerNode: " + clientPolicy.minConnsPerNode
-			+ ", maxConnsPerNode: " + clientPolicy.maxConnsPerNode
-			+ ", asyncMinConnsPerNode: " + clientPolicy.asyncMinConnsPerNode
-			+ ", asyncMaxConnsPerNode: " + clientPolicy.asyncMaxConnsPerNode);
+				"    errorRateWindow: " + clientPolicy.errorRateWindow
+						+ ", minConnsPerNode: " + clientPolicy.minConnsPerNode
+						+ ", maxConnsPerNode: " + clientPolicy.maxConnsPerNode
+						+ ", asyncMinConnsPerNode: " + clientPolicy.asyncMinConnsPerNode
+						+ ", asyncMaxConnsPerNode: " + clientPolicy.asyncMaxConnsPerNode);
 
 		if (args.workload != Workload.INITIALIZE) {
 			System.out.println("read policy:");
 			System.out.println(
 					"    connectTimeout: " + args.readPolicy.connectTimeout
-					+ ", socketTimeout: " + args.readPolicy.socketTimeout
-					+ ", totalTimeout: " + args.readPolicy.totalTimeout
-					+ ", timeoutDelay: " + args.readPolicy.timeoutDelay
-					+ ", maxRetries: " + args.readPolicy.maxRetries
-					+ ", sleepBetweenRetries: " + args.readPolicy.sleepBetweenRetries
-					);
+							+ ", socketTimeout: " + args.readPolicy.socketTimeout
+							+ ", totalTimeout: " + args.readPolicy.totalTimeout
+							+ ", timeoutDelay: " + args.readPolicy.timeoutDelay
+							+ ", maxRetries: " + args.readPolicy.maxRetries
+							+ ", sleepBetweenRetries: " + args.readPolicy.sleepBetweenRetries
+			);
 
 			System.out.println(
 					"    readModeAP: " + args.readPolicy.readModeAP
-					+ ", readModeSC: " + args.readPolicy.readModeSC
-					+ ", replica: " + args.readPolicy.replica
-					+ ", reportNotFound: " + args.reportNotFound);
+							+ ", readModeSC: " + args.readPolicy.readModeSC
+							+ ", replica: " + args.readPolicy.replica
+							+ ", reportNotFound: " + args.reportNotFound);
 		}
 
 		System.out.println("write policy:");
 		System.out.println(
-			"    connectTimeout: " + args.writePolicy.connectTimeout
-			+ ", socketTimeout: " + args.writePolicy.socketTimeout
-			+ ", totalTimeout: " + args.writePolicy.totalTimeout
-			+ ", timeoutDelay: " + args.writePolicy.timeoutDelay
-			+ ", maxRetries: " + args.writePolicy.maxRetries
-			+ ", sleepBetweenRetries: " + args.writePolicy.sleepBetweenRetries
-			);
+				"    connectTimeout: " + args.writePolicy.connectTimeout
+						+ ", socketTimeout: " + args.writePolicy.socketTimeout
+						+ ", totalTimeout: " + args.writePolicy.totalTimeout
+						+ ", timeoutDelay: " + args.writePolicy.timeoutDelay
+						+ ", maxRetries: " + args.writePolicy.maxRetries
+						+ ", sleepBetweenRetries: " + args.writePolicy.sleepBetweenRetries
+		);
 
 		System.out.println("    commitLevel: " + args.writePolicy.commitLevel);
 
 		if (args.batchSize > 1) {
 			System.out.println("batch size: " + args.batchSize
-				+ ", batch threads: " + args.batchPolicy.maxConcurrentThreads);
+					+ ", batch threads: " + args.batchPolicy.maxConcurrentThreads);
 		}
 
 		if (this.asyncEnabled) {
-			System.out.println("Async " + this.eventLoopType + ": MaxCommands " +  this.asyncMaxCommands
-				+ ", EventLoops: " + this.eventLoopSize
-				);
+			System.out.println("Async " + this.eventLoopType + ": MaxCommands " + this.asyncMaxCommands
+					+ ", EventLoops: " + this.eventLoopSize
+			);
 		}
 		else {
 			System.out.println("Sync: connPoolsPerNode: " + clientPolicy.connPoolsPerNode);
@@ -1061,28 +1062,28 @@ public class Main implements Log.Callback {
 			System.out.print("bin[" + binCount + "]: ");
 
 			switch (spec.type) {
-			case 'I':
-				System.out.println("integer");
-				break;
+				case 'I':
+					System.out.println("integer");
+					break;
 
-			case 'S':
-				System.out.println("string[" + spec.size + "]");
-				break;
+				case 'S':
+					System.out.println("string[" + spec.size + "]");
+					break;
 
-			case 'B':
-				System.out.println("byte[" + spec.size + "]");
-				break;
+				case 'B':
+					System.out.println("byte[" + spec.size + "]");
+					break;
 
-			case 'R':
-				System.out.println("random[" + spec.size + "]");
-				break;
+				case 'R':
+					System.out.println("random[" + spec.size + "]");
+					break;
 			}
 			binCount++;
 		}
 
 		System.out.println("debug: " + args.debug);
 
-		Log.Level level = (args.debug)? Log.Level.DEBUG : Log.Level.INFO;
+		Log.Level level = (args.debug) ? Log.Level.DEBUG : Log.Level.INFO;
 		Log.setLevel(level);
 		Log.setCallback(this);
 		args.updatePolicy = new WritePolicy(args.writePolicy);
@@ -1115,7 +1116,7 @@ public class Main implements Log.Callback {
 				eventPolicy.minTimeout = args.readPolicy.socketTimeout;
 			}
 
-			if (args.writePolicy.socketTimeout > 0 &&  args.writePolicy.socketTimeout < eventPolicy.minTimeout) {
+			if (args.writePolicy.socketTimeout > 0 && args.writePolicy.socketTimeout < eventPolicy.minTimeout) {
 				eventPolicy.minTimeout = args.writePolicy.socketTimeout;
 			}
 
@@ -1158,9 +1159,9 @@ public class Main implements Log.Callback {
 					clientPolicy.asyncMaxConnsPerNode = this.asyncMaxCommands;
 				}
 
-				IAerospikeClient client = useProxyClient?
-					new AerospikeClientProxy(clientPolicy, hosts) :
-					new AerospikeClient(clientPolicy, hosts);
+				IAerospikeClient client = useProxyClient ?
+						new AerospikeClientProxy(clientPolicy, hosts) :
+						new AerospikeClient(clientPolicy, hosts);
 
 				try {
 					if (initialize) {
@@ -1170,17 +1171,17 @@ public class Main implements Log.Callback {
 						showBatchNodes(client);
 						doAsyncRWTest(client);
 					}
-				}
-				finally {
+				} finally {
 					client.close();
 				}
-			}
-			finally {
+			} finally {
 				eventLoops.close();
 			}
 		}
 		else {
-			IAerospikeClient client = new AerospikeClient(clientPolicy, hosts);
+			IAerospikeClient client = useProxyClient ?
+					new AerospikeClientProxy(clientPolicy, hosts) :
+					new AerospikeClient(clientPolicy, hosts);
 
 			try {
 				if (initialize) {
@@ -1190,8 +1191,7 @@ public class Main implements Log.Callback {
 					showBatchNodes(client);
 					doRWTest(client);
 				}
-			}
-			finally {
+			} finally {
 				client.close();
 			}
 		}
@@ -1206,8 +1206,8 @@ public class Main implements Log.Callback {
 		long rem = this.nKeys - (keysPerTask * ntasks);
 		long start = this.startKey;
 
-		for (long i = 0 ; i < ntasks; i++) {
-			long keyCount = (i < rem)? keysPerTask + 1 : keysPerTask;
+		for (long i = 0; i < ntasks; i++) {
+			long keyCount = (i < rem) ? keysPerTask + 1 : keysPerTask;
 			InsertTaskSync it = new InsertTaskSync(client, args, counters, start, keyCount);
 			es.execute(it);
 			start += keyCount;
@@ -1234,7 +1234,7 @@ public class Main implements Log.Callback {
 
 		for (int i = 0; i < maxConcurrentCommands; i++) {
 			// Allocate separate tasks for each seed command and reuse them in callbacks.
-			long keyCount = (i < keysRem)? keysPerCommand + 1 : keysPerCommand;
+			long keyCount = (i < keysRem) ? keysPerCommand + 1 : keysPerCommand;
 
 			// Start seed commands on random event loops.
 			EventLoop eventLoop = this.eventLoops.next();
@@ -1252,7 +1252,7 @@ public class Main implements Log.Callback {
 		while (total < this.nKeys) {
 			long time = System.currentTimeMillis();
 
-			int	numWrites = this.counters.write.count.getAndSet(0);
+			int numWrites = this.counters.write.count.getAndSet(0);
 			int timeoutWrites = this.counters.write.timeouts.getAndSet(0);
 			int errorWrites = this.counters.write.errors.getAndSet(0);
 			total += numWrites;
@@ -1261,7 +1261,7 @@ public class Main implements Log.Callback {
 
 			String date = SimpleDateFormat.format(new Date(time));
 			System.out.println(date.toString() + " write(count=" + total + " tps=" + numWrites +
-				" timeouts=" + timeoutWrites + " errors=" + errorWrites + ")");
+					" timeouts=" + timeoutWrites + " errors=" + errorWrites + ")");
 
 			if (this.counters.write.latency != null) {
 				this.counters.write.latency.printHeader(System.out);
@@ -1281,7 +1281,7 @@ public class Main implements Log.Callback {
 		ExecutorService es = Executors.newFixedThreadPool(this.nThreads);
 		RWTask[] tasks = new RWTask[this.nThreads];
 
-		for (int i = 0 ; i < this.nThreads; i++) {
+		for (int i = 0; i < this.nThreads; i++) {
 			RWTaskSync rt = new RWTaskSync(client, args, counters, this.startKey, this.nKeys);
 			tasks[i] = rt;
 			es.execute(rt);
@@ -1325,11 +1325,11 @@ public class Main implements Log.Callback {
 		while (true) {
 			long time = System.currentTimeMillis();
 
-			int	numWrites = this.counters.write.count.getAndSet(0);
+			int numWrites = this.counters.write.count.getAndSet(0);
 			int timeoutWrites = this.counters.write.timeouts.getAndSet(0);
 			int errorWrites = this.counters.write.errors.getAndSet(0);
 
-			int	numReads = this.counters.read.count.getAndSet(0);
+			int numReads = this.counters.read.count.getAndSet(0);
 			int timeoutReads = this.counters.read.timeouts.getAndSet(0);
 			int errorReads = this.counters.read.errors.getAndSet(0);
 
@@ -1370,7 +1370,7 @@ public class Main implements Log.Callback {
 				}
 			}
 
-			if (args.transactionLimit > 0 ) {
+			if (args.transactionLimit > 0) {
 				transactionTotal += numWrites + timeoutWrites + errorWrites + numReads + timeoutReads + errorReads;
 
 				if (transactionTotal >= args.transactionLimit) {
@@ -1432,19 +1432,19 @@ public class Main implements Log.Callback {
 		}
 
 		System.out.println(date.toString() + ' ' + level.toString() +
-			" Thread " + name + ' ' + message);
+				" Thread " + name + ' ' + message);
 	}
 
 	private static class UsageException extends Exception {
 		private static final long serialVersionUID = 1L;
 	}
 
-	private static void printVersion()
-	{
+	private static void printVersion() {
 		final Properties properties = new Properties();
 		try {
 			properties.load(Main.class.getClassLoader().getResourceAsStream("project.properties"));
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			System.out.println("None");
 		} finally {
 			System.out.println(properties.getProperty("name"));

--- a/benchmarks/src/com/aerospike/benchmarks/Main.java
+++ b/benchmarks/src/com/aerospike/benchmarks/Main.java
@@ -26,6 +26,13 @@ import java.util.Properties;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.CommandLineParser;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.HelpFormatter;
+import org.apache.commons.cli.Options;
+import org.apache.commons.cli.ParseException;
+
 import com.aerospike.client.AerospikeClient;
 import com.aerospike.client.Host;
 import com.aerospike.client.IAerospikeClient;
@@ -53,17 +60,12 @@ import com.aerospike.client.policy.TlsPolicy;
 import com.aerospike.client.policy.WritePolicy;
 import com.aerospike.client.proxy.AerospikeClientProxy;
 import com.aerospike.client.util.Util;
+
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.epoll.EpollEventLoopGroup;
 import io.netty.channel.kqueue.KQueueEventLoopGroup;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.incubator.channel.uring.IOUringEventLoopGroup;
-import org.apache.commons.cli.CommandLine;
-import org.apache.commons.cli.CommandLineParser;
-import org.apache.commons.cli.DefaultParser;
-import org.apache.commons.cli.HelpFormatter;
-import org.apache.commons.cli.Options;
-import org.apache.commons.cli.ParseException;
 
 public class Main implements Log.Callback {
 
@@ -71,7 +73,7 @@ public class Main implements Log.Callback {
 	public static List<String> keyList = null;
 
 	public static void main(String[] args) {
-		Main program = null;
+		Main program;
 
 		try {
 			program = new Main(args);
@@ -114,16 +116,16 @@ public class Main implements Log.Callback {
 
 		Options options = new Options();
 		options.addOption("h", "hosts", true,
-				"List of seed hosts in format: " +
-						"hostname1[:tlsname][:port1],...\n" +
-						"The tlsname is only used when connecting with a secure TLS enabled server. " +
-						"If the port is not specified, the default port is used. " +
-						"IPv6 addresses must be enclosed in square brackets.\n" +
-						"Default: localhost\n" +
-						"Examples:\n" +
-						"host1\n" +
-						"host1:3000,host2:3000\n" +
-						"192.168.1.10:cert1:3000,[2001::1111]:cert2:3000\n"
+			"List of seed hosts in format: " +
+				"hostname1[:tlsname][:port1],...\n" +
+				"The tlsname is only used when connecting with a secure TLS enabled server. " +
+				"If the port is not specified, the default port is used. " +
+				"IPv6 addresses must be enclosed in square brackets.\n" +
+				"Default: localhost\n" +
+				"Examples:\n" +
+				"host1\n" +
+				"host1:3000,host2:3000\n" +
+				"192.168.1.10:cert1:3000,[2001::1111]:cert2:3000\n"
 		);
 		options.addOption("p", "port", true, "Set the default port on which to connect to Aerospike.");
 		options.addOption("U", "user", true, "User name");
@@ -135,97 +137,97 @@ public class Main implements Log.Callback {
 		options.addOption("servicesAlternate", false, "Set to enable use of services-alternate instead of services in info request during cluster tending");
 
 		options.addOption("lt", "loginTimeout", true,
-				"Set expected loginTimeout in milliseconds. The timeout is used when user " +
-						"authentication is enabled and a node login is being performed. Default: 5000"
+			"Set expected loginTimeout in milliseconds. The timeout is used when user " +
+				"authentication is enabled and a node login is being performed. Default: 5000"
 		);
 		options.addOption("tt", "tendTimeout", true,
-				"Set cluster tend info call timeout in milliseconds. Default: 1000"
+			"Set cluster tend info call timeout in milliseconds. Default: 1000"
 		);
 		options.addOption("ti", "tendInterval", true,
-				"Interval between cluster tends in milliseconds. Default: 1000"
+			"Interval between cluster tends in milliseconds. Default: 1000"
 		);
 		options.addOption("maxSocketIdle", true,
-				"Maximum socket idle in connection pool in seconds. Default: 0"
+			"Maximum socket idle in connection pool in seconds. Default: 0"
 		);
 		options.addOption("maxErrorRate", true,
-				"Maximum number of errors allowed per node per tend iteration. Default: 100"
+			"Maximum number of errors allowed per node per tend iteration. Default: 100"
 		);
 		options.addOption("errorRateWindow", true,
-				"Number of cluster tend iterations that defines the window for maxErrorRate. Default: 1"
+			"Number of cluster tend iterations that defines the window for maxErrorRate. Default: 1"
 		);
 		options.addOption("minConnsPerNode", true,
-				"Minimum number of sync connections pre-allocated per server node. Default: 0"
+			"Minimum number of sync connections pre-allocated per server node. Default: 0"
 		);
 		options.addOption("maxConnsPerNode", true,
-				"Maximum number of sync connections allowed per server node. Default: 100"
+			"Maximum number of sync connections allowed per server node. Default: 100"
 		);
 		options.addOption("asyncMinConnsPerNode", true,
-				"Minimum number of async connections pre-allocated per server node. Default: 0"
+			"Minimum number of async connections pre-allocated per server node. Default: 0"
 		);
 		options.addOption("asyncMaxConnsPerNode", true,
-				"Maximum number of async connections allowed per server node. Default: 100"
+			"Maximum number of async connections allowed per server node. Default: 100"
 		);
 		options.addOption("k", "keys", true,
-				"Set the number of keys the client is dealing with. " +
-						"If using an 'insert' workload (detailed below), the client will write this " +
-						"number of keys, starting from value = startkey. Otherwise, the client " +
-						"will read and update randomly across the values between startkey and " +
-						"startkey + num_keys.  startkey can be set using '-S' or '-startkey'."
+			"Set the number of keys the client is dealing with. " +
+				"If using an 'insert' workload (detailed below), the client will write this " +
+				"number of keys, starting from value = startkey. Otherwise, the client " +
+				"will read and update randomly across the values between startkey and " +
+				"startkey + num_keys.  startkey can be set using '-S' or '-startkey'."
 		);
 		options.addOption("b", "bins", true,
-				"Set the number of Aerospike bins. " +
-						"Each bin will contain an object defined with -o. The default is single bin (-b 1)."
+			"Set the number of Aerospike bins. " +
+				"Each bin will contain an object defined with -o. The default is single bin (-b 1)."
 		);
 		options.addOption("o", "objectSpec", true,
-				"I | S:<size> | B:<size> | R:<size>:<rand_pct>\n" +
-						"Set the type of object(s) to use in Aerospike transactions. Type can be 'I' " +
-						"for integer, 'S' for string, or 'B' for Java blob. If type is 'I' (integer), " +
-						"do not set a size (integers are always 8 bytes). If object_type is 'S' " +
-						"(string), this value represents the length of the string."
+			"I | S:<size> | B:<size> | R:<size>:<rand_pct>\n" +
+				"Set the type of object(s) to use in Aerospike transactions. Type can be 'I' " +
+				"for integer, 'S' for string, or 'B' for Java blob. If type is 'I' (integer), " +
+				"do not set a size (integers are always 8 bytes). If object_type is 'S' " +
+				"(string), this value represents the length of the string."
 		);
 		options.addOption("R", "random", false,
-				"Use dynamically generated random bin values instead of default static fixed bin values."
+			"Use dynamically generated random bin values instead of default static fixed bin values."
 		);
 		options.addOption("S", "startkey", true,
-				"Set the starting value of the working set of keys. " +
-						"If using an 'insert' workload, the start_value indicates the first value to write. " +
-						"Otherwise, the start_value indicates the smallest value in the working set of keys."
+			"Set the starting value of the working set of keys. " +
+				"If using an 'insert' workload, the start_value indicates the first value to write. " +
+				"Otherwise, the start_value indicates the smallest value in the working set of keys."
 		);
 		options.addOption("w", "workload", true,
-				"I | RU,<percent>[,<percent2>][,<percent3>] | RR,<percent>[,<percent2>][,<percent3>], RMU | RMI | RMD\n" +
-						"Set the desired workload.\n\n" +
-						"   -w I sets a linear 'insert' workload.\n\n" +
-						"   -w RU,80 sets a random read-update workload with 80% reads and 20% writes.\n\n" +
-						"      100% of reads will read all bins.\n\n" +
-						"      100% of writes will write all bins.\n\n" +
-						"   -w RU,80,60,30 sets a random multi-bin read-update workload with 80% reads and 20% writes.\n\n" +
-						"      60% of reads will read all bins. 40% of reads will read a single bin.\n\n" +
-						"      30% of writes will write all bins. 70% of writes will write a single bin.\n\n" +
-						"   -w RR,20 sets a random read-replace workload with 20% reads and 80% replace all bin(s) writes.\n\n" +
-						"      100% of reads will read all bins.\n\n" +
-						"      100% of writes will replace all bins.\n\n" +
-						"   -w RMU sets a random read all bins-update one bin workload with 50% reads.\n\n" +
-						"   -w RMI sets a random read all bins-increment one integer bin workload with 50% reads.\n\n" +
-						"   -w RMD sets a random read all bins-decrement one integer bin workload with 50% reads.\n\n" +
-						"   -w TXN,r:1000,w:200,v:20%\n\n" +
-						"      form business transactions with 1000 reads, 200 writes with a variation (+/-) of 20%\n\n"
+			"I | RU,<percent>[,<percent2>][,<percent3>] | RR,<percent>[,<percent2>][,<percent3>], RMU | RMI | RMD\n" +
+				"Set the desired workload.\n\n" +
+				"   -w I sets a linear 'insert' workload.\n\n" +
+				"   -w RU,80 sets a random read-update workload with 80% reads and 20% writes.\n\n" +
+				"      100% of reads will read all bins.\n\n" +
+				"      100% of writes will write all bins.\n\n" +
+				"   -w RU,80,60,30 sets a random multi-bin read-update workload with 80% reads and 20% writes.\n\n" +
+				"      60% of reads will read all bins. 40% of reads will read a single bin.\n\n" +
+				"      30% of writes will write all bins. 70% of writes will write a single bin.\n\n" +
+				"   -w RR,20 sets a random read-replace workload with 20% reads and 80% replace all bin(s) writes.\n\n" +
+				"      100% of reads will read all bins.\n\n" +
+				"      100% of writes will replace all bins.\n\n" +
+				"   -w RMU sets a random read all bins-update one bin workload with 50% reads.\n\n" +
+				"   -w RMI sets a random read all bins-increment one integer bin workload with 50% reads.\n\n" +
+				"   -w RMD sets a random read all bins-decrement one integer bin workload with 50% reads.\n\n" +
+				"   -w TXN,r:1000,w:200,v:20%\n\n" +
+				"      form business transactions with 1000 reads, 200 writes with a variation (+/-) of 20%\n\n"
 		);
 		options.addOption("e", "expirationTime", true,
-				"Set expiration time of each record in seconds.\n" +
-						" -1: Never expire\n" +
-						"  0: Default to namespace expiration time\n" +
-						" >0: Actual given expiration time"
+			"Set expiration time of each record in seconds.\n" +
+				" -1: Never expire\n" +
+				"  0: Default to namespace expiration time\n" +
+				" >0: Actual given expiration time"
 		);
 		options.addOption("g", "throughput", true,
-				"Set a target transactions per second for the client. The client should not exceed this " +
-						"average throughput."
+			"Set a target transactions per second for the client. The client should not exceed this " +
+				"average throughput."
 		);
 		options.addOption("t", "transactions", true,
-				"Number of transactions to perform in read/write mode before shutting down. " +
-						"The default is to run indefinitely."
+			"Number of transactions to perform in read/write mode before shutting down. " +
+				"The default is to run indefinitely."
 		);
 		options.addOption("ct", "connectTimeout", true,
-				"Set socket connection timeout in milliseconds. Default: 0"
+			"Set socket connection timeout in milliseconds. Default: 0"
 		);
 
 		options.addOption("T", "timeout", true, "Set read and write socketTimeout and totalTimeout to the same timeout in milliseconds.");
@@ -240,52 +242,52 @@ public class Main implements Log.Callback {
 		options.addOption("rackId", true, "Set Rack where this benchmark instance resides.  Default: 0");
 		options.addOption("maxRetries", true, "Maximum number of retries before aborting the current transaction.");
 		options.addOption("sleepBetweenRetries", true,
-				"Milliseconds to sleep between retries if a transaction fails and the timeout was not exceeded. " +
-						"Enter zero to skip sleep."
+			"Milliseconds to sleep between retries if a transaction fails and the timeout was not exceeded. " +
+				"Enter zero to skip sleep."
 		);
 		options.addOption("r", "replica", true,
-				"Which replica to use for reads.\n\n" +
-						"Values:  master | any | sequence | preferRack.  Default: sequence\n" +
-						"master: Always use node containing master partition.\n" +
-						"any: Distribute reads across master and proles in round-robin fashion.\n" +
-						"sequence: Always try master first. If master fails, try proles in sequence.\n" +
-						"preferRack: Always try node on the same rack as the benchmark first. If no nodes on the same rack, use sequence.\n" +
-						"Use 'rackId' option to set rack."
+			"Which replica to use for reads.\n\n" +
+				"Values:  master | any | sequence | preferRack.  Default: sequence\n" +
+				"master: Always use node containing master partition.\n" +
+				"any: Distribute reads across master and proles in round-robin fashion.\n" +
+				"sequence: Always try master first. If master fails, try proles in sequence.\n" +
+				"preferRack: Always try node on the same rack as the benchmark first. If no nodes on the same rack, use sequence.\n" +
+				"Use 'rackId' option to set rack."
 		);
 		options.addOption("readModeAP", true,
-				"Read consistency level when in AP mode.\n" +
-						"Values:  one | all.  Default: one"
+			"Read consistency level when in AP mode.\n" +
+				"Values:  one | all.  Default: one"
 		);
 		options.addOption("readModeSC", true,
-				"Read consistency level when in SC (strong consistency) mode.\n" +
-						"Values:  session | linearize | allow_replica | allow_unavailable.  Default: session"
+			"Read consistency level when in SC (strong consistency) mode.\n" +
+				"Values:  session | linearize | allow_replica | allow_unavailable.  Default: session"
 		);
 		options.addOption("commitLevel", true,
-				"Desired replica consistency guarantee when committing a transaction on the server.\n" +
-						"Values:  all | master.  Default: all"
+			"Desired replica consistency guarantee when committing a transaction on the server.\n" +
+				"Values:  all | master.  Default: all"
 		);
 
 		options.addOption("Y", "connPoolsPerNode", true,
-				"Number of synchronous connection pools per node.  Default 1."
+			"Number of synchronous connection pools per node.  Default 1."
 		);
 		options.addOption("z", "threads", true,
-				"Set the number of threads the client will use to generate load. "
+			"Set the number of threads the client will use to generate load. "
 		);
 		options.addOption("latency", true,
-				"ycsb[,<warmup count>] | [alt,]<columns>,<range shift increment>[,us|ms]\n" +
-						"ycsb: Show the timings in ycsb format.\n" +
-						"alt: Show both count and pecentage in each elapsed time bucket.\n" +
-						"default: Show pecentage in each elapsed time bucket.\n" +
-						"<columns>: Number of elapsed time ranges.\n" +
-						"<range shift increment>: Power of 2 multiple between each range starting at column 3.\n" +
-						"(ms|us): display times in milliseconds (ms, default) or microseconds (us)\n\n" +
-						"A latency definition of '-latency 7,1' results in this layout:\n" +
-						"    <=1ms >1ms >2ms >4ms >8ms >16ms >32ms\n" +
-						"       x%   x%   x%   x%   x%    x%    x%\n" +
-						"A latency definition of '-latency 4,3' results in this layout:\n" +
-						"    <=1ms >1ms >8ms >64ms\n" +
-						"       x%   x%   x%    x%\n\n" +
-						"Latency columns are cumulative. If a transaction takes 9ms, it will be included in both the >1ms and >8ms columns."
+			"ycsb[,<warmup count>] | [alt,]<columns>,<range shift increment>[,us|ms]\n" +
+				"ycsb: Show the timings in ycsb format.\n" +
+				"alt: Show both count and pecentage in each elapsed time bucket.\n" +
+				"default: Show pecentage in each elapsed time bucket.\n" +
+				"<columns>: Number of elapsed time ranges.\n" +
+				"<range shift increment>: Power of 2 multiple between each range starting at column 3.\n" +
+				"(ms|us): display times in milliseconds (ms, default) or microseconds (us)\n\n" +
+				"A latency definition of '-latency 7,1' results in this layout:\n" +
+				"    <=1ms >1ms >2ms >4ms >8ms >16ms >32ms\n" +
+				"       x%   x%   x%   x%   x%    x%    x%\n" +
+				"A latency definition of '-latency 4,3' results in this layout:\n" +
+				"    <=1ms >1ms >8ms >64ms\n" +
+				"       x%   x%   x%    x%\n\n" +
+				"Latency columns are cumulative. If a transaction takes 9ms, it will be included in both the >1ms and >8ms columns."
 		);
 
 		options.addOption("N", "reportNotFound", false, "Report not found errors. Data should be fully initialized before using this option.");
@@ -294,19 +296,19 @@ public class Main implements Log.Callback {
 		options.addOption("V", "version", false, "Print version.");
 
 		options.addOption("B", "batchSize", true,
-				"Enable batch mode with number of records to process in each batch get call. " +
-						"Batch mode is valid only for RU (read update) workloads. Batch mode is disabled by default."
+			"Enable batch mode with number of records to process in each batch get call. " +
+				"Batch mode is valid only for RU (read update) workloads. Batch mode is disabled by default."
 		);
 
 		options.addOption("BT", "batchThreads", true,
-				"Maximum number of concurrent batch sub-threads for each batch command.\n" +
-						"1   : Run each batch node command sequentially.\n" +
-						"0   : Run all batch node commands in parallel.\n" +
-						"> 1 : Run maximum batchThreads in parallel.  When a node command finshes, start a new one until all finished."
+			"Maximum number of concurrent batch sub-threads for each batch command.\n" +
+				"1   : Run each batch node command sequentially.\n" +
+				"0   : Run all batch node commands in parallel.\n" +
+				"> 1 : Run maximum batchThreads in parallel.  When a node command finshes, start a new one until all finished."
 		);
 
 		options.addOption("BSN", "batchShowNodes", false,
-				"Print target nodes and count of keys directed at each node once on start of benchmarks."
+			"Print target nodes and count of keys directed at each node once on start of benchmarks."
 		);
 
 		options.addOption("prole", false, "Distribute reads across proles in round-robin fashion.");
@@ -318,19 +320,19 @@ public class Main implements Log.Callback {
 		options.addOption("KT", "keyType", true, "Type of the key(String/Integer) in the file, default is String");
 		options.addOption("tls", "tlsEnable", false, "Use TLS/SSL sockets");
 		options.addOption("tp", "tlsProtocols", true,
-				"Allow TLS protocols\n" +
-						"Values:  TLSv1,TLSv1.1,TLSv1.2 separated by comma\n" +
-						"Default: TLSv1.2"
+			"Allow TLS protocols\n" +
+				"Values:  TLSv1,TLSv1.1,TLSv1.2 separated by comma\n" +
+				"Default: TLSv1.2"
 		);
 		options.addOption("tlsCiphers", "tlsCipherSuite", true,
-				"Allow TLS cipher suites\n" +
-						"Values:  cipher names defined by JVM separated by comma\n" +
-						"Default: null (default cipher list provided by JVM)"
+			"Allow TLS cipher suites\n" +
+				"Values:  cipher names defined by JVM separated by comma\n" +
+				"Default: null (default cipher list provided by JVM)"
 		);
 		options.addOption("tr", "tlsRevoke", true,
-				"Revoke certificates identified by their serial number\n" +
-						"Values:  serial numbers separated by comma\n" +
-						"Default: null (Do not revoke certificates)"
+			"Revoke certificates identified by their serial number\n" +
+				"Values:  serial numbers separated by comma\n" +
+				"Default: null (Do not revoke certificates)"
 		);
 		options.addOption("tlsLoginOnly", false, "Use TLS/SSL sockets on node login only");
 		options.addOption("auth", true, "Authentication mode. Values: " + Arrays.toString(AuthMode.values()));
@@ -338,8 +340,8 @@ public class Main implements Log.Callback {
 		options.addOption("netty", false, "Use Netty NIO event loops for async benchmarks");
 		options.addOption("nettyEpoll", false, "Use Netty epoll event loops for async benchmarks (Linux only)");
 		options.addOption("elt", "eventLoopType", true,
-				"Use specified event loop type for async examples\n" +
-						"Value: DIRECT_NIO | NETTY_NIO | NETTY_EPOLL | NETTY_KQUEUE | NETTY_IOURING"
+			"Use specified event loop type for async examples\n" +
+				"Value: DIRECT_NIO | NETTY_NIO | NETTY_EPOLL | NETTY_KQUEUE | NETTY_IOURING"
 		);
 
 		options.addOption("proxy", false, "Use proxy client.");
@@ -525,7 +527,7 @@ public class Main implements Log.Callback {
 		if (line.hasOption("keyFile")) {
 			if (startKey + nKeys > Integer.MAX_VALUE) {
 				throw new Exception("Invalid arguments when keyFile specified.  startkey " + startKey +
-						" + keys " + nKeys + " must be <= " + Integer.MAX_VALUE);
+					" + keys " + nKeys + " must be <= " + Integer.MAX_VALUE);
 			}
 
 			this.filepath = line.getOptionValue("keyFile");
@@ -976,10 +978,10 @@ public class Main implements Log.Callback {
 		}
 
 		System.out.println("Benchmark: " + this.hosts[0]
-				+ ", namespace: " + args.namespace
-				+ ", set: " + (args.setName.length() > 0 ? args.setName : "<empty>")
-				+ ", threads: " + this.nThreads
-				+ ", workload: " + args.workload);
+			+ ", namespace: " + args.namespace
+			+ ", set: " + (args.setName.length() > 0 ? args.setName : "<empty>")
+			+ ", threads: " + this.nThreads
+			+ ", workload: " + args.workload);
 
 		if (args.workload == Workload.READ_UPDATE || args.workload == Workload.READ_REPLACE) {
 			System.out.print("read: " + args.readPct + '%');
@@ -992,64 +994,64 @@ public class Main implements Log.Callback {
 		}
 
 		System.out.println("keys: " + this.nKeys
-				+ ", start key: " + this.startKey
-				+ ", transactions: " + args.transactionLimit
-				+ ", bins: " + args.nBins
-				+ ", random values: " + (args.fixedBins == null)
-				+ ", throughput: " + (args.throughput == 0 ? "unlimited" : (args.throughput + " tps")));
+			+ ", start key: " + this.startKey
+			+ ", transactions: " + args.transactionLimit
+			+ ", bins: " + args.nBins
+			+ ", random values: " + (args.fixedBins == null)
+			+ ", throughput: " + (args.throughput == 0 ? "unlimited" : (args.throughput + " tps")));
 
 		System.out.println("client policy:");
 		System.out.println(
-				"    loginTimeout: " + clientPolicy.loginTimeout
-						+ ", tendTimeout: " + clientPolicy.timeout
-						+ ", tendInterval: " + clientPolicy.tendInterval
-						+ ", maxSocketIdle: " + clientPolicy.maxSocketIdle
-						+ ", maxErrorRate: " + clientPolicy.maxErrorRate);
+			"    loginTimeout: " + clientPolicy.loginTimeout
+				+ ", tendTimeout: " + clientPolicy.timeout
+				+ ", tendInterval: " + clientPolicy.tendInterval
+				+ ", maxSocketIdle: " + clientPolicy.maxSocketIdle
+				+ ", maxErrorRate: " + clientPolicy.maxErrorRate);
 		System.out.println(
-				"    errorRateWindow: " + clientPolicy.errorRateWindow
-						+ ", minConnsPerNode: " + clientPolicy.minConnsPerNode
-						+ ", maxConnsPerNode: " + clientPolicy.maxConnsPerNode
-						+ ", asyncMinConnsPerNode: " + clientPolicy.asyncMinConnsPerNode
-						+ ", asyncMaxConnsPerNode: " + clientPolicy.asyncMaxConnsPerNode);
+			"    errorRateWindow: " + clientPolicy.errorRateWindow
+				+ ", minConnsPerNode: " + clientPolicy.minConnsPerNode
+				+ ", maxConnsPerNode: " + clientPolicy.maxConnsPerNode
+				+ ", asyncMinConnsPerNode: " + clientPolicy.asyncMinConnsPerNode
+				+ ", asyncMaxConnsPerNode: " + clientPolicy.asyncMaxConnsPerNode);
 
 		if (args.workload != Workload.INITIALIZE) {
 			System.out.println("read policy:");
 			System.out.println(
-					"    connectTimeout: " + args.readPolicy.connectTimeout
-							+ ", socketTimeout: " + args.readPolicy.socketTimeout
-							+ ", totalTimeout: " + args.readPolicy.totalTimeout
-							+ ", timeoutDelay: " + args.readPolicy.timeoutDelay
-							+ ", maxRetries: " + args.readPolicy.maxRetries
-							+ ", sleepBetweenRetries: " + args.readPolicy.sleepBetweenRetries
+				"    connectTimeout: " + args.readPolicy.connectTimeout
+					+ ", socketTimeout: " + args.readPolicy.socketTimeout
+					+ ", totalTimeout: " + args.readPolicy.totalTimeout
+					+ ", timeoutDelay: " + args.readPolicy.timeoutDelay
+					+ ", maxRetries: " + args.readPolicy.maxRetries
+					+ ", sleepBetweenRetries: " + args.readPolicy.sleepBetweenRetries
 			);
 
 			System.out.println(
-					"    readModeAP: " + args.readPolicy.readModeAP
-							+ ", readModeSC: " + args.readPolicy.readModeSC
-							+ ", replica: " + args.readPolicy.replica
-							+ ", reportNotFound: " + args.reportNotFound);
+				"    readModeAP: " + args.readPolicy.readModeAP
+					+ ", readModeSC: " + args.readPolicy.readModeSC
+					+ ", replica: " + args.readPolicy.replica
+					+ ", reportNotFound: " + args.reportNotFound);
 		}
 
 		System.out.println("write policy:");
 		System.out.println(
-				"    connectTimeout: " + args.writePolicy.connectTimeout
-						+ ", socketTimeout: " + args.writePolicy.socketTimeout
-						+ ", totalTimeout: " + args.writePolicy.totalTimeout
-						+ ", timeoutDelay: " + args.writePolicy.timeoutDelay
-						+ ", maxRetries: " + args.writePolicy.maxRetries
-						+ ", sleepBetweenRetries: " + args.writePolicy.sleepBetweenRetries
+			"    connectTimeout: " + args.writePolicy.connectTimeout
+				+ ", socketTimeout: " + args.writePolicy.socketTimeout
+				+ ", totalTimeout: " + args.writePolicy.totalTimeout
+				+ ", timeoutDelay: " + args.writePolicy.timeoutDelay
+				+ ", maxRetries: " + args.writePolicy.maxRetries
+				+ ", sleepBetweenRetries: " + args.writePolicy.sleepBetweenRetries
 		);
 
 		System.out.println("    commitLevel: " + args.writePolicy.commitLevel);
 
 		if (args.batchSize > 1) {
 			System.out.println("batch size: " + args.batchSize
-					+ ", batch threads: " + args.batchPolicy.maxConcurrentThreads);
+				+ ", batch threads: " + args.batchPolicy.maxConcurrentThreads);
 		}
 
 		if (this.asyncEnabled) {
 			System.out.println("Async " + this.eventLoopType + ": MaxCommands " + this.asyncMaxCommands
-					+ ", EventLoops: " + this.eventLoopSize
+				+ ", EventLoops: " + this.eventLoopSize
 			);
 		}
 		else {
@@ -1101,7 +1103,7 @@ public class Main implements Log.Callback {
 		String syntax = Main.class.getName() + " [<options>]";
 		formatter.printHelp(pw, 100, syntax, "options:", options, 0, 2, null);
 
-		System.out.println(sw.toString());
+		System.out.println(sw);
 	}
 
 	private static String getLatencyUsage(String latencyString) {
@@ -1160,8 +1162,8 @@ public class Main implements Log.Callback {
 				}
 
 				IAerospikeClient client = useProxyClient ?
-						new AerospikeClientProxy(clientPolicy, hosts) :
-						new AerospikeClient(clientPolicy, hosts);
+					new AerospikeClientProxy(clientPolicy, hosts) :
+					new AerospikeClient(clientPolicy, hosts);
 
 				try {
 					if (initialize) {
@@ -1171,17 +1173,19 @@ public class Main implements Log.Callback {
 						showBatchNodes(client);
 						doAsyncRWTest(client);
 					}
-				} finally {
+				}
+				finally {
 					client.close();
 				}
-			} finally {
+			}
+			finally {
 				eventLoops.close();
 			}
 		}
 		else {
 			IAerospikeClient client = useProxyClient ?
-					new AerospikeClientProxy(clientPolicy, hosts) :
-					new AerospikeClient(clientPolicy, hosts);
+				new AerospikeClientProxy(clientPolicy, hosts) :
+				new AerospikeClient(clientPolicy, hosts);
 
 			try {
 				if (initialize) {
@@ -1191,7 +1195,8 @@ public class Main implements Log.Callback {
 					showBatchNodes(client);
 					doRWTest(client);
 				}
-			} finally {
+			}
+			finally {
 				client.close();
 			}
 		}
@@ -1260,8 +1265,8 @@ public class Main implements Log.Callback {
 			this.counters.periodBegin.set(time);
 
 			String date = SimpleDateFormat.format(new Date(time));
-			System.out.println(date.toString() + " write(count=" + total + " tps=" + numWrites +
-					" timeouts=" + timeoutWrites + " errors=" + errorWrites + ")");
+			System.out.println(date + " write(count=" + total + " tps=" + numWrites +
+				" timeouts=" + timeoutWrites + " errors=" + errorWrites + ")");
 
 			if (this.counters.write.latency != null) {
 				this.counters.write.latency.printHeader(System.out);
@@ -1345,7 +1350,7 @@ public class Main implements Log.Callback {
 			this.counters.periodBegin.set(time);
 
 			String date = SimpleDateFormat.format(new Date(time));
-			System.out.print(date.toString());
+			System.out.print(date);
 			System.out.print(" write(tps=" + numWrites + " timeouts=" + timeoutWrites + " errors=" + errorWrites + ")");
 			System.out.print(" read(tps=" + numReads + " timeouts=" + timeoutReads + " errors=" + errorReads);
 			if (this.counters.transaction.latency != null) {
@@ -1431,8 +1436,8 @@ public class Main implements Log.Callback {
 			name = Long.toString(thread.getId());
 		}
 
-		System.out.println(date.toString() + ' ' + level.toString() +
-				" Thread " + name + ' ' + message);
+		System.out.println(date + ' ' + level.toString() +
+			" Thread " + name + ' ' + message);
 	}
 
 	private static class UsageException extends Exception {
@@ -1446,7 +1451,8 @@ public class Main implements Log.Callback {
 		}
 		catch (Exception e) {
 			System.out.println("None");
-		} finally {
+		}
+		finally {
 			System.out.println(properties.getProperty("name"));
 			System.out.println("Version " + properties.getProperty("version"));
 		}

--- a/proxy/pom.xml
+++ b/proxy/pom.xml
@@ -22,7 +22,7 @@
     <dependency>
       <groupId>com.aerospike</groupId>
       <artifactId>aerospike-proxy-stub</artifactId>
-      <version>0.5.0</version>
+      <version>0.9.0-SNAPSHOT</version>
     </dependency>
 
     <dependency>

--- a/proxy/src/com/aerospike/client/proxy/AerospikeClientProxy.java
+++ b/proxy/src/com/aerospike/client/proxy/AerospikeClientProxy.java
@@ -94,6 +94,7 @@ import com.aerospike.client.task.ExecuteTask;
 import com.aerospike.client.task.IndexTask;
 import com.aerospike.client.task.RegisterTask;
 import com.aerospike.client.util.Util;
+
 import io.netty.channel.Channel;
 
 /**
@@ -441,22 +442,22 @@ public class AerospikeClientProxy implements IAerospikeClient, Closeable {
 
 	@Override
 	public void delete(
-			EventLoop eventLoop,
-			BatchRecordArrayListener listener,
-			BatchPolicy batchPolicy,
-			BatchDeletePolicy deletePolicy,
-			Key[] keys
+		EventLoop eventLoop,
+		BatchRecordArrayListener listener,
+		BatchPolicy batchPolicy,
+		BatchDeletePolicy deletePolicy,
+		Key[] keys
 	) {
 		throw new AerospikeException(NotSupported + "batch delete");
 	}
 
 	@Override
 	public void delete(
-			EventLoop eventLoop,
-			BatchRecordSequenceListener listener,
-			BatchPolicy batchPolicy,
-			BatchDeletePolicy deletePolicy,
-			Key[] keys
+		EventLoop eventLoop,
+		BatchRecordSequenceListener listener,
+		BatchPolicy batchPolicy,
+		BatchDeletePolicy deletePolicy,
+		Key[] keys
 	) {
 		throw new AerospikeException(NotSupported + "batch delete");
 	}
@@ -664,6 +665,9 @@ public class AerospikeClientProxy implements IAerospikeClient, Closeable {
 
 	@Override
 	public void operate(EventLoop eventLoop, RecordListener listener, WritePolicy policy, Key key, Operation... operations) {
+		if (policy == null) {
+			policy = writePolicyDefault;
+		}
 		OperateArgs args = new OperateArgs(policy, writePolicyDefault, operatePolicyReadDefault, key, operations);
 		OperateCommandProxy command = new OperateCommandProxy(executor, listener, policy, key, args);
 		command.execute();
@@ -680,54 +684,54 @@ public class AerospikeClientProxy implements IAerospikeClient, Closeable {
 
 	@Override
 	public void operate(
-			EventLoop eventLoop,
-			BatchOperateListListener listener,
-			BatchPolicy policy,
-			List<BatchRecord> records
+		EventLoop eventLoop,
+		BatchOperateListListener listener,
+		BatchPolicy policy,
+		List<BatchRecord> records
 	) {
 		throw new AerospikeException(NotSupported + "batch operate");
 	}
 
 	@Override
 	public void operate(
-			EventLoop eventLoop,
-			BatchRecordSequenceListener listener,
-			BatchPolicy policy,
-			List<BatchRecord> records
+		EventLoop eventLoop,
+		BatchRecordSequenceListener listener,
+		BatchPolicy policy,
+		List<BatchRecord> records
 	) {
 		throw new AerospikeException(NotSupported + "batch operate");
 	}
 
 	@Override
 	public BatchResults operate(
-			BatchPolicy batchPolicy,
-			BatchWritePolicy writePolicy,
-			Key[] keys,
-			Operation... ops
+		BatchPolicy batchPolicy,
+		BatchWritePolicy writePolicy,
+		Key[] keys,
+		Operation... ops
 	) {
 		throw new AerospikeException(NotSupported + "batch operate");
 	}
 
 	@Override
 	public void operate(
-			EventLoop eventLoop,
-			BatchRecordArrayListener listener,
-			BatchPolicy batchPolicy,
-			BatchWritePolicy writePolicy,
-			Key[] keys,
-			Operation... ops
+		EventLoop eventLoop,
+		BatchRecordArrayListener listener,
+		BatchPolicy batchPolicy,
+		BatchWritePolicy writePolicy,
+		Key[] keys,
+		Operation... ops
 	) {
 		throw new AerospikeException(NotSupported + "batch operate");
 	}
 
 	@Override
 	public void operate(
-			EventLoop eventLoop,
-			BatchRecordSequenceListener listener,
-			BatchPolicy batchPolicy,
-			BatchWritePolicy writePolicy,
-			Key[] keys,
-			Operation... ops
+		EventLoop eventLoop,
+		BatchRecordSequenceListener listener,
+		BatchPolicy batchPolicy,
+		BatchWritePolicy writePolicy,
+		Key[] keys,
+		Operation... ops
 	) {
 		throw new AerospikeException(NotSupported + "batch operate");
 	}
@@ -738,67 +742,67 @@ public class AerospikeClientProxy implements IAerospikeClient, Closeable {
 
 	@Override
 	public void scanAll(
-			ScanPolicy policy,
-			String namespace,
-			String setName,
-			ScanCallback callback,
-			String... binNames
+		ScanPolicy policy,
+		String namespace,
+		String setName,
+		ScanCallback callback,
+		String... binNames
 	) {
 	}
 
 	@Override
 	public void scanAll(
-			EventLoop eventLoop,
-			RecordSequenceListener listener,
-			ScanPolicy policy,
-			String namespace,
-			String setName,
-			String... binNames
+		EventLoop eventLoop,
+		RecordSequenceListener listener,
+		ScanPolicy policy,
+		String namespace,
+		String setName,
+		String... binNames
 	) {
 	}
 
 	@Override
 	public void scanNode(
-			ScanPolicy policy,
-			String nodeName,
-			String namespace,
-			String setName,
-			ScanCallback callback,
-			String... binNames
+		ScanPolicy policy,
+		String nodeName,
+		String namespace,
+		String setName,
+		ScanCallback callback,
+		String... binNames
 	) {
 	}
 
 	@Override
 	public void scanNode(
-			ScanPolicy policy,
-			Node node,
-			String namespace,
-			String setName,
-			ScanCallback callback,
-			String... binNames
+		ScanPolicy policy,
+		Node node,
+		String namespace,
+		String setName,
+		ScanCallback callback,
+		String... binNames
 	) {
 	}
 
 	@Override
 	public void scanPartitions(
-			ScanPolicy policy,
-			PartitionFilter partitionFilter,
-			String namespace,
-			String setName,
-			ScanCallback callback,
-			String... binNames
+		ScanPolicy policy,
+		PartitionFilter partitionFilter,
+		String namespace,
+		String setName,
+		ScanCallback callback,
+		String... binNames
 	) {
 	}
 
 	@Override
 	public void scanPartitions(
-			EventLoop eventLoop,
-			RecordSequenceListener listener,
-			ScanPolicy policy,
-			PartitionFilter partitionFilter,
-			String namespace,
-			String setName,
-			String... binNames
+		EventLoop eventLoop,
+		RecordSequenceListener listener,
+		ScanPolicy policy,
+		PartitionFilter partitionFilter,
+		String namespace,
+		String setName,
+		String... binNames
 	) {
 	}
 
@@ -813,11 +817,11 @@ public class AerospikeClientProxy implements IAerospikeClient, Closeable {
 
 	@Override
 	public RegisterTask register(
-			Policy policy,
-			ClassLoader resourceLoader,
-			String resourcePath,
-			String serverPath,
-			Language language
+		Policy policy,
+		ClassLoader resourceLoader,
+		String resourcePath,
+		String serverPath,
+		Language language
 	) {
 		throw new AerospikeException(NotSupported + "register");
 	}
@@ -842,58 +846,58 @@ public class AerospikeClientProxy implements IAerospikeClient, Closeable {
 
 	@Override
 	public void execute(
-			EventLoop eventLoop,
-			ExecuteListener listener,
-			WritePolicy policy,
-			Key key,
-			String packageName,
-			String functionName,
-			Value... functionArgs
+		EventLoop eventLoop,
+		ExecuteListener listener,
+		WritePolicy policy,
+		Key key,
+		String packageName,
+		String functionName,
+		Value... functionArgs
 	) {
 		if (policy == null) {
 			policy = writePolicyDefault;
 		}
 		ExecuteCommandProxy command = new ExecuteCommandProxy(executor, listener, policy, key,
-				packageName, functionName, functionArgs);
+			packageName, functionName, functionArgs);
 		command.execute();
 	}
 
 	@Override
 	public BatchResults execute(
-			BatchPolicy batchPolicy,
-			BatchUDFPolicy udfPolicy,
-			Key[] keys,
-			String packageName,
-			String functionName,
-			Value... functionArgs
+		BatchPolicy batchPolicy,
+		BatchUDFPolicy udfPolicy,
+		Key[] keys,
+		String packageName,
+		String functionName,
+		Value... functionArgs
 	) {
 		throw new AerospikeException(NotSupported + "batch execute");
 	}
 
 	@Override
 	public void execute(
-			EventLoop eventLoop,
-			BatchRecordArrayListener listener,
-			BatchPolicy batchPolicy,
-			BatchUDFPolicy udfPolicy,
-			Key[] keys,
-			String packageName,
-			String functionName,
-			Value... functionArgs
+		EventLoop eventLoop,
+		BatchRecordArrayListener listener,
+		BatchPolicy batchPolicy,
+		BatchUDFPolicy udfPolicy,
+		Key[] keys,
+		String packageName,
+		String functionName,
+		Value... functionArgs
 	) {
 		throw new AerospikeException(NotSupported + "batch execute");
 	}
 
 	@Override
 	public void execute(
-			EventLoop eventLoop,
-			BatchRecordSequenceListener listener,
-			BatchPolicy batchPolicy,
-			BatchUDFPolicy udfPolicy,
-			Key[] keys,
-			String packageName,
-			String functionName,
-			Value... functionArgs
+		EventLoop eventLoop,
+		BatchRecordSequenceListener listener,
+		BatchPolicy batchPolicy,
+		BatchUDFPolicy udfPolicy,
+		Key[] keys,
+		String packageName,
+		String functionName,
+		Value... functionArgs
 	) {
 		throw new AerospikeException(NotSupported + "batch execute");
 	}
@@ -904,11 +908,11 @@ public class AerospikeClientProxy implements IAerospikeClient, Closeable {
 
 	@Override
 	public ExecuteTask execute(
-			WritePolicy policy,
-			Statement statement,
-			String packageName,
-			String functionName,
-			Value... functionArgs
+		WritePolicy policy,
+		Statement statement,
+		String packageName,
+		String functionName,
+		Value... functionArgs
 	) {
 		return null;
 	}
@@ -951,21 +955,21 @@ public class AerospikeClientProxy implements IAerospikeClient, Closeable {
 
 	@Override
 	public void queryPartitions(
-			EventLoop eventLoop,
-			RecordSequenceListener listener,
-			QueryPolicy policy,
-			Statement statement,
-			PartitionFilter partitionFilter
+		EventLoop eventLoop,
+		RecordSequenceListener listener,
+		QueryPolicy policy,
+		Statement statement,
+		PartitionFilter partitionFilter
 	) {
 	}
 
 	@Override
 	public ResultSet queryAggregate(
-			QueryPolicy policy,
-			Statement statement,
-			String packageName,
-			String functionName,
-			Value... functionArgs
+		QueryPolicy policy,
+		Statement statement,
+		String packageName,
+		String functionName,
+		Value... functionArgs
 	) {
 		return null;
 	}
@@ -986,42 +990,42 @@ public class AerospikeClientProxy implements IAerospikeClient, Closeable {
 
 	@Override
 	public IndexTask createIndex(
-			Policy policy,
-			String namespace,
-			String setName,
-			String indexName,
-			String binName,
-			IndexType indexType
+		Policy policy,
+		String namespace,
+		String setName,
+		String indexName,
+		String binName,
+		IndexType indexType
 	) {
 		return null;
 	}
 
 	@Override
 	public IndexTask createIndex(
-			Policy policy,
-			String namespace,
-			String setName,
-			String indexName,
-			String binName,
-			IndexType indexType,
-			IndexCollectionType indexCollectionType,
-			CTX... ctx
+		Policy policy,
+		String namespace,
+		String setName,
+		String indexName,
+		String binName,
+		IndexType indexType,
+		IndexCollectionType indexCollectionType,
+		CTX... ctx
 	) {
 		return null;
 	}
 
 	@Override
 	public void createIndex(
-			EventLoop eventLoop,
-			IndexListener listener,
-			Policy policy,
-			String namespace,
-			String setName,
-			String indexName,
-			String binName,
-			IndexType indexType,
-			IndexCollectionType indexCollectionType,
-			CTX... ctx
+		EventLoop eventLoop,
+		IndexListener listener,
+		Policy policy,
+		String namespace,
+		String setName,
+		String indexName,
+		String binName,
+		IndexType indexType,
+		IndexCollectionType indexCollectionType,
+		CTX... ctx
 	) {
 	}
 
@@ -1032,12 +1036,12 @@ public class AerospikeClientProxy implements IAerospikeClient, Closeable {
 
 	@Override
 	public void dropIndex(
-			EventLoop eventLoop,
-			IndexListener listener,
-			Policy policy,
-			String namespace,
-			String setName,
-			String indexName
+		EventLoop eventLoop,
+		IndexListener listener,
+		Policy policy,
+		String namespace,
+		String setName,
+		String indexName
 	) {
 	}
 
@@ -1093,12 +1097,12 @@ public class AerospikeClientProxy implements IAerospikeClient, Closeable {
 
 	@Override
 	public void createRole(
-			AdminPolicy policy,
-			String roleName,
-			List<Privilege> privileges,
-			List<String> whitelist,
-			int readQuota,
-			int writeQuota
+		AdminPolicy policy,
+		String roleName,
+		List<Privilege> privileges,
+		List<String> whitelist,
+		int readQuota,
+		int writeQuota
 	) {
 	}
 
@@ -1154,7 +1158,7 @@ public class AerospikeClientProxy implements IAerospikeClient, Closeable {
 		if (policy.eventLoops != null) {
 			if (!(policy.eventLoops instanceof NettyEventLoops)) {
 				throw new AerospikeException(ResultCode.PARAMETER_ERROR,
-						"Netty event loops are required in proxy client");
+					"Netty event loops are required in proxy client");
 			}
 
 			NettyEventLoops nettyLoops = (NettyEventLoops)policy.eventLoops;
@@ -1169,13 +1173,13 @@ public class AerospikeClientProxy implements IAerospikeClient, Closeable {
 		}
 
 		int maxConnections = Math.min(MAX_CONNECTIONS, Math.max(MIN_CONNECTIONS,
-				Math.max(policy.asyncMaxConnsPerNode, policy.maxConnsPerNode)));
+			Math.max(policy.asyncMaxConnsPerNode, policy.maxConnsPerNode)));
 
 		return GrpcClientPolicy.newBuilder(eventLoops, channelType)
-				.maxChannels(maxConnections)
-				.connectTimeoutMillis(policy.timeout)
-				.tlsPolicy(policy.tlsPolicy)
-				.build();
+			.maxChannels(maxConnections)
+			.connectTimeoutMillis(policy.timeout)
+			.tlsPolicy(policy.tlsPolicy)
+			.build();
 	}
 
 	private static WriteListener prepareWriteListener(final CompletableFuture<Void> future) {

--- a/proxy/src/com/aerospike/client/proxy/AerospikeClientProxy.java
+++ b/proxy/src/com/aerospike/client/proxy/AerospikeClientProxy.java
@@ -94,7 +94,6 @@ import com.aerospike.client.task.ExecuteTask;
 import com.aerospike.client.task.IndexTask;
 import com.aerospike.client.task.RegisterTask;
 import com.aerospike.client.util.Util;
-
 import io.netty.channel.Channel;
 
 /**
@@ -172,7 +171,7 @@ public class AerospikeClientProxy implements IAerospikeClient, Closeable {
 	public final BatchDeletePolicy batchDeletePolicyDefault;
 
 	/**
-	 * Default user defined function policy used in batch UDF excecute commands.
+	 * Default user defined function policy used in batch UDF execute commands.
 	 */
 	public final BatchUDFPolicy batchUDFPolicyDefault;
 
@@ -340,7 +339,7 @@ public class AerospikeClientProxy implements IAerospikeClient, Closeable {
 
 	@Override
 	public void put(WritePolicy policy, Key key, Bin... bins) {
-		CompletableFuture<Void> future = new CompletableFuture<Void>();
+		CompletableFuture<Void> future = new CompletableFuture<>();
 		WriteListener listener = prepareWriteListener(future);
 		put(null, listener, policy, key, bins);
 		getFuture(future);
@@ -361,7 +360,7 @@ public class AerospikeClientProxy implements IAerospikeClient, Closeable {
 
 	@Override
 	public void append(WritePolicy policy, Key key, Bin... bins) {
-		CompletableFuture<Void> future = new CompletableFuture<Void>();
+		CompletableFuture<Void> future = new CompletableFuture<>();
 		WriteListener listener = prepareWriteListener(future);
 		append(null, listener, policy, key, bins);
 		getFuture(future);
@@ -378,7 +377,7 @@ public class AerospikeClientProxy implements IAerospikeClient, Closeable {
 
 	@Override
 	public void prepend(WritePolicy policy, Key key, Bin... bins) {
-		CompletableFuture<Void> future = new CompletableFuture<Void>();
+		CompletableFuture<Void> future = new CompletableFuture<>();
 		WriteListener listener = prepareWriteListener(future);
 		prepend(null, listener, policy, key, bins);
 		getFuture(future);
@@ -399,7 +398,7 @@ public class AerospikeClientProxy implements IAerospikeClient, Closeable {
 
 	@Override
 	public void add(WritePolicy policy, Key key, Bin... bins) {
-		CompletableFuture<Void> future = new CompletableFuture<Void>();
+		CompletableFuture<Void> future = new CompletableFuture<>();
 		WriteListener listener = prepareWriteListener(future);
 		add(null, listener, policy, key, bins);
 		getFuture(future);
@@ -420,7 +419,7 @@ public class AerospikeClientProxy implements IAerospikeClient, Closeable {
 
 	@Override
 	public boolean delete(WritePolicy policy, Key key) {
-		CompletableFuture<Boolean> future = new CompletableFuture<Boolean>();
+		CompletableFuture<Boolean> future = new CompletableFuture<>();
 		DeleteListener listener = prepareDeleteListener(future);
 		delete(null, listener, policy, key);
 		return getFuture(future);
@@ -442,22 +441,22 @@ public class AerospikeClientProxy implements IAerospikeClient, Closeable {
 
 	@Override
 	public void delete(
-		EventLoop eventLoop,
-		BatchRecordArrayListener listener,
-		BatchPolicy batchPolicy,
-		BatchDeletePolicy deletePolicy,
-		Key[] keys
+			EventLoop eventLoop,
+			BatchRecordArrayListener listener,
+			BatchPolicy batchPolicy,
+			BatchDeletePolicy deletePolicy,
+			Key[] keys
 	) {
 		throw new AerospikeException(NotSupported + "batch delete");
 	}
 
 	@Override
 	public void delete(
-		EventLoop eventLoop,
-		BatchRecordSequenceListener listener,
-		BatchPolicy batchPolicy,
-		BatchDeletePolicy deletePolicy,
-		Key[] keys
+			EventLoop eventLoop,
+			BatchRecordSequenceListener listener,
+			BatchPolicy batchPolicy,
+			BatchDeletePolicy deletePolicy,
+			Key[] keys
 	) {
 		throw new AerospikeException(NotSupported + "batch delete");
 	}
@@ -473,7 +472,7 @@ public class AerospikeClientProxy implements IAerospikeClient, Closeable {
 
 	@Override
 	public void touch(WritePolicy policy, Key key) {
-		CompletableFuture<Void> future = new CompletableFuture<Void>();
+		CompletableFuture<Void> future = new CompletableFuture<>();
 		WriteListener listener = prepareWriteListener(future);
 		touch(null, listener, policy, key);
 		getFuture(future);
@@ -494,7 +493,7 @@ public class AerospikeClientProxy implements IAerospikeClient, Closeable {
 
 	@Override
 	public boolean exists(Policy policy, Key key) {
-		CompletableFuture<Boolean> future = new CompletableFuture<Boolean>();
+		CompletableFuture<Boolean> future = new CompletableFuture<>();
 		ExistsListener listener = prepareExistsListener(future);
 		exists(null, listener, policy, key);
 		return getFuture(future);
@@ -681,54 +680,54 @@ public class AerospikeClientProxy implements IAerospikeClient, Closeable {
 
 	@Override
 	public void operate(
-		EventLoop eventLoop,
-		BatchOperateListListener listener,
-		BatchPolicy policy,
-		List<BatchRecord> records
+			EventLoop eventLoop,
+			BatchOperateListListener listener,
+			BatchPolicy policy,
+			List<BatchRecord> records
 	) {
 		throw new AerospikeException(NotSupported + "batch operate");
 	}
 
 	@Override
 	public void operate(
-		EventLoop eventLoop,
-		BatchRecordSequenceListener listener,
-		BatchPolicy policy,
-		List<BatchRecord> records
+			EventLoop eventLoop,
+			BatchRecordSequenceListener listener,
+			BatchPolicy policy,
+			List<BatchRecord> records
 	) {
 		throw new AerospikeException(NotSupported + "batch operate");
 	}
 
 	@Override
 	public BatchResults operate(
-		BatchPolicy batchPolicy,
-		BatchWritePolicy writePolicy,
-		Key[] keys,
-		Operation... ops
+			BatchPolicy batchPolicy,
+			BatchWritePolicy writePolicy,
+			Key[] keys,
+			Operation... ops
 	) {
 		throw new AerospikeException(NotSupported + "batch operate");
 	}
 
 	@Override
 	public void operate(
-		EventLoop eventLoop,
-		BatchRecordArrayListener listener,
-		BatchPolicy batchPolicy,
-		BatchWritePolicy writePolicy,
-		Key[] keys,
-		Operation... ops
+			EventLoop eventLoop,
+			BatchRecordArrayListener listener,
+			BatchPolicy batchPolicy,
+			BatchWritePolicy writePolicy,
+			Key[] keys,
+			Operation... ops
 	) {
 		throw new AerospikeException(NotSupported + "batch operate");
 	}
 
 	@Override
 	public void operate(
-		EventLoop eventLoop,
-		BatchRecordSequenceListener listener,
-		BatchPolicy batchPolicy,
-		BatchWritePolicy writePolicy,
-		Key[] keys,
-		Operation... ops
+			EventLoop eventLoop,
+			BatchRecordSequenceListener listener,
+			BatchPolicy batchPolicy,
+			BatchWritePolicy writePolicy,
+			Key[] keys,
+			Operation... ops
 	) {
 		throw new AerospikeException(NotSupported + "batch operate");
 	}
@@ -739,67 +738,67 @@ public class AerospikeClientProxy implements IAerospikeClient, Closeable {
 
 	@Override
 	public void scanAll(
-		ScanPolicy policy,
-		String namespace,
-		String setName,
-		ScanCallback callback,
-		String... binNames
+			ScanPolicy policy,
+			String namespace,
+			String setName,
+			ScanCallback callback,
+			String... binNames
 	) {
 	}
 
 	@Override
 	public void scanAll(
-		EventLoop eventLoop,
-		RecordSequenceListener listener,
-		ScanPolicy policy,
-		String namespace,
-		String setName,
-		String... binNames
+			EventLoop eventLoop,
+			RecordSequenceListener listener,
+			ScanPolicy policy,
+			String namespace,
+			String setName,
+			String... binNames
 	) {
 	}
 
 	@Override
 	public void scanNode(
-		ScanPolicy policy,
-		String nodeName,
-		String namespace,
-		String setName,
-		ScanCallback callback,
-		String... binNames
+			ScanPolicy policy,
+			String nodeName,
+			String namespace,
+			String setName,
+			ScanCallback callback,
+			String... binNames
 	) {
 	}
 
 	@Override
 	public void scanNode(
-		ScanPolicy policy,
-		Node node,
-		String namespace,
-		String setName,
-		ScanCallback callback,
-		String... binNames
+			ScanPolicy policy,
+			Node node,
+			String namespace,
+			String setName,
+			ScanCallback callback,
+			String... binNames
 	) {
 	}
 
 	@Override
 	public void scanPartitions(
-		ScanPolicy policy,
-		PartitionFilter partitionFilter,
-		String namespace,
-		String setName,
-		ScanCallback callback,
-		String... binNames
+			ScanPolicy policy,
+			PartitionFilter partitionFilter,
+			String namespace,
+			String setName,
+			ScanCallback callback,
+			String... binNames
 	) {
 	}
 
 	@Override
 	public void scanPartitions(
-		EventLoop eventLoop,
-		RecordSequenceListener listener,
-		ScanPolicy policy,
-		PartitionFilter partitionFilter,
-		String namespace,
-		String setName,
-		String... binNames
+			EventLoop eventLoop,
+			RecordSequenceListener listener,
+			ScanPolicy policy,
+			PartitionFilter partitionFilter,
+			String namespace,
+			String setName,
+			String... binNames
 	) {
 	}
 
@@ -814,11 +813,11 @@ public class AerospikeClientProxy implements IAerospikeClient, Closeable {
 
 	@Override
 	public RegisterTask register(
-		Policy policy,
-		ClassLoader resourceLoader,
-		String resourcePath,
-		String serverPath,
-		Language language
+			Policy policy,
+			ClassLoader resourceLoader,
+			String resourcePath,
+			String serverPath,
+			Language language
 	) {
 		throw new AerospikeException(NotSupported + "register");
 	}
@@ -843,58 +842,58 @@ public class AerospikeClientProxy implements IAerospikeClient, Closeable {
 
 	@Override
 	public void execute(
-		EventLoop eventLoop,
-		ExecuteListener listener,
-		WritePolicy policy,
-		Key key,
-		String packageName,
-		String functionName,
-		Value... functionArgs
+			EventLoop eventLoop,
+			ExecuteListener listener,
+			WritePolicy policy,
+			Key key,
+			String packageName,
+			String functionName,
+			Value... functionArgs
 	) {
 		if (policy == null) {
 			policy = writePolicyDefault;
 		}
 		ExecuteCommandProxy command = new ExecuteCommandProxy(executor, listener, policy, key,
-			packageName, functionName, functionArgs);
+				packageName, functionName, functionArgs);
 		command.execute();
 	}
 
 	@Override
 	public BatchResults execute(
-		BatchPolicy batchPolicy,
-		BatchUDFPolicy udfPolicy,
-		Key[] keys,
-		String packageName,
-		String functionName,
-		Value... functionArgs
+			BatchPolicy batchPolicy,
+			BatchUDFPolicy udfPolicy,
+			Key[] keys,
+			String packageName,
+			String functionName,
+			Value... functionArgs
 	) {
 		throw new AerospikeException(NotSupported + "batch execute");
 	}
 
 	@Override
 	public void execute(
-		EventLoop eventLoop,
-		BatchRecordArrayListener listener,
-		BatchPolicy batchPolicy,
-		BatchUDFPolicy udfPolicy,
-		Key[] keys,
-		String packageName,
-		String functionName,
-		Value... functionArgs
+			EventLoop eventLoop,
+			BatchRecordArrayListener listener,
+			BatchPolicy batchPolicy,
+			BatchUDFPolicy udfPolicy,
+			Key[] keys,
+			String packageName,
+			String functionName,
+			Value... functionArgs
 	) {
 		throw new AerospikeException(NotSupported + "batch execute");
 	}
 
 	@Override
 	public void execute(
-		EventLoop eventLoop,
-		BatchRecordSequenceListener listener,
-		BatchPolicy batchPolicy,
-		BatchUDFPolicy udfPolicy,
-		Key[] keys,
-		String packageName,
-		String functionName,
-		Value... functionArgs
+			EventLoop eventLoop,
+			BatchRecordSequenceListener listener,
+			BatchPolicy batchPolicy,
+			BatchUDFPolicy udfPolicy,
+			Key[] keys,
+			String packageName,
+			String functionName,
+			Value... functionArgs
 	) {
 		throw new AerospikeException(NotSupported + "batch execute");
 	}
@@ -905,11 +904,11 @@ public class AerospikeClientProxy implements IAerospikeClient, Closeable {
 
 	@Override
 	public ExecuteTask execute(
-		WritePolicy policy,
-		Statement statement,
-		String packageName,
-		String functionName,
-		Value... functionArgs
+			WritePolicy policy,
+			Statement statement,
+			String packageName,
+			String functionName,
+			Value... functionArgs
 	) {
 		return null;
 	}
@@ -952,21 +951,21 @@ public class AerospikeClientProxy implements IAerospikeClient, Closeable {
 
 	@Override
 	public void queryPartitions(
-		EventLoop eventLoop,
-		RecordSequenceListener listener,
-		QueryPolicy policy,
-		Statement statement,
-		PartitionFilter partitionFilter
+			EventLoop eventLoop,
+			RecordSequenceListener listener,
+			QueryPolicy policy,
+			Statement statement,
+			PartitionFilter partitionFilter
 	) {
 	}
 
 	@Override
 	public ResultSet queryAggregate(
-		QueryPolicy policy,
-		Statement statement,
-		String packageName,
-		String functionName,
-		Value... functionArgs
+			QueryPolicy policy,
+			Statement statement,
+			String packageName,
+			String functionName,
+			Value... functionArgs
 	) {
 		return null;
 	}
@@ -987,42 +986,42 @@ public class AerospikeClientProxy implements IAerospikeClient, Closeable {
 
 	@Override
 	public IndexTask createIndex(
-		Policy policy,
-		String namespace,
-		String setName,
-		String indexName,
-		String binName,
-		IndexType indexType
+			Policy policy,
+			String namespace,
+			String setName,
+			String indexName,
+			String binName,
+			IndexType indexType
 	) {
 		return null;
 	}
 
 	@Override
 	public IndexTask createIndex(
-		Policy policy,
-		String namespace,
-		String setName,
-		String indexName,
-		String binName,
-		IndexType indexType,
-		IndexCollectionType indexCollectionType,
-		CTX... ctx
+			Policy policy,
+			String namespace,
+			String setName,
+			String indexName,
+			String binName,
+			IndexType indexType,
+			IndexCollectionType indexCollectionType,
+			CTX... ctx
 	) {
 		return null;
 	}
 
 	@Override
 	public void createIndex(
-		EventLoop eventLoop,
-		IndexListener listener,
-		Policy policy,
-		String namespace,
-		String setName,
-		String indexName,
-		String binName,
-		IndexType indexType,
-		IndexCollectionType indexCollectionType,
-		CTX... ctx
+			EventLoop eventLoop,
+			IndexListener listener,
+			Policy policy,
+			String namespace,
+			String setName,
+			String indexName,
+			String binName,
+			IndexType indexType,
+			IndexCollectionType indexCollectionType,
+			CTX... ctx
 	) {
 	}
 
@@ -1033,12 +1032,12 @@ public class AerospikeClientProxy implements IAerospikeClient, Closeable {
 
 	@Override
 	public void dropIndex(
-		EventLoop eventLoop,
-		IndexListener listener,
-		Policy policy,
-		String namespace,
-		String setName,
-		String indexName
+			EventLoop eventLoop,
+			IndexListener listener,
+			Policy policy,
+			String namespace,
+			String setName,
+			String indexName
 	) {
 	}
 
@@ -1094,12 +1093,12 @@ public class AerospikeClientProxy implements IAerospikeClient, Closeable {
 
 	@Override
 	public void createRole(
-		AdminPolicy policy,
-		String roleName,
-		List<Privilege> privileges,
-		List<String> whitelist,
-		int readQuota,
-		int writeQuota
+			AdminPolicy policy,
+			String roleName,
+			List<Privilege> privileges,
+			List<String> whitelist,
+			int readQuota,
+			int writeQuota
 	) {
 	}
 
@@ -1153,14 +1152,14 @@ public class AerospikeClientProxy implements IAerospikeClient, Closeable {
 		Class<? extends Channel> channelType = null;
 
 		if (policy.eventLoops != null) {
-			if (! (policy.eventLoops instanceof NettyEventLoops)) {
+			if (!(policy.eventLoops instanceof NettyEventLoops)) {
 				throw new AerospikeException(ResultCode.PARAMETER_ERROR,
-					"Netty event loops are required in proxy client");
+						"Netty event loops are required in proxy client");
 			}
 
 			NettyEventLoops nettyLoops = (NettyEventLoops)policy.eventLoops;
 			NettyEventLoop[] array = nettyLoops.getArray();
-			eventLoops = new ArrayList<io.netty.channel.EventLoop>(array.length);
+			eventLoops = new ArrayList<>(array.length);
 
 			for (NettyEventLoop loop : array) {
 				eventLoops.add(loop.get());
@@ -1170,13 +1169,13 @@ public class AerospikeClientProxy implements IAerospikeClient, Closeable {
 		}
 
 		int maxConnections = Math.min(MAX_CONNECTIONS, Math.max(MIN_CONNECTIONS,
-			Math.max(policy.asyncMaxConnsPerNode, policy.maxConnsPerNode)));
+				Math.max(policy.asyncMaxConnsPerNode, policy.maxConnsPerNode)));
 
 		return GrpcClientPolicy.newBuilder(eventLoops, channelType)
-			.maxChannels(maxConnections)
-			.connectTimeoutMillis(policy.timeout)
-			.tlsPolicy(policy.tlsPolicy)
-			.build();
+				.maxChannels(maxConnections)
+				.connectTimeoutMillis(policy.timeout)
+				.tlsPolicy(policy.tlsPolicy)
+				.build();
 	}
 
 	private static WriteListener prepareWriteListener(final CompletableFuture<Void> future) {

--- a/proxy/src/com/aerospike/client/proxy/DeleteCommandProxy.java
+++ b/proxy/src/com/aerospike/client/proxy/DeleteCommandProxy.java
@@ -23,27 +23,28 @@ import com.aerospike.client.command.Command;
 import com.aerospike.client.listener.DeleteListener;
 import com.aerospike.client.policy.WritePolicy;
 import com.aerospike.client.proxy.grpc.GrpcCallExecutor;
+import com.aerospike.proxy.client.KVSGrpc;
 
 public final class DeleteCommandProxy extends CommandProxy {
-    private final DeleteListener listener;
-    private final WritePolicy writePolicy;
-    private final Key key;
+	private final DeleteListener listener;
+	private final WritePolicy writePolicy;
+	private final Key key;
 
-    public DeleteCommandProxy(
-    	GrpcCallExecutor executor,
-    	DeleteListener listener,
-    	WritePolicy writePolicy,
-    	Key key
-    ) {
-        super(executor, writePolicy);
-        this.listener = listener;
-        this.writePolicy = writePolicy;
-        this.key = key;
-    }
+	public DeleteCommandProxy(
+			GrpcCallExecutor executor,
+			DeleteListener listener,
+			WritePolicy writePolicy,
+			Key key
+	) {
+		super(KVSGrpc.getDeleteStreamingMethod(), executor, writePolicy);
+		this.listener = listener;
+		this.writePolicy = writePolicy;
+		this.key = key;
+	}
 
 	@Override
 	void writeCommand(Command command) {
-        command.setDelete(writePolicy, key);
+		command.setDelete(writePolicy, key);
 	}
 
 	@Override
@@ -77,10 +78,10 @@ public final class DeleteCommandProxy extends CommandProxy {
 		catch (Throwable t) {
 			logOnSuccessError(t);
 		}
-    }
+	}
 
-    @Override
-    void onFailure(AerospikeException ae) {
-        listener.onFailure(ae);
-    }
+	@Override
+	void onFailure(AerospikeException ae) {
+		listener.onFailure(ae);
+	}
 }

--- a/proxy/src/com/aerospike/client/proxy/ExecuteCommandProxy.java
+++ b/proxy/src/com/aerospike/client/proxy/ExecuteCommandProxy.java
@@ -26,36 +26,38 @@ import com.aerospike.client.command.Command;
 import com.aerospike.client.listener.ExecuteListener;
 import com.aerospike.client.policy.WritePolicy;
 import com.aerospike.client.proxy.grpc.GrpcCallExecutor;
+import com.aerospike.proxy.client.KVSGrpc;
 
 public final class ExecuteCommandProxy extends ReadCommandProxy {
-    private final ExecuteListener executeListener;
-    private final WritePolicy writePolicy;
-    private final Key key;
- 	private final String packageName;
+	private final ExecuteListener executeListener;
+	private final WritePolicy writePolicy;
+	private final Key key;
+	private final String packageName;
 	private final String functionName;
 	private final Value[] args;
 
-    public ExecuteCommandProxy(
-    	GrpcCallExecutor executor,
-    	ExecuteListener executeListener,
-    	WritePolicy writePolicy,
-    	Key key,
-    	String packageName,
-    	String functionName,
-    	Value[] args
-    ) {
-    	super(executor, null, writePolicy, key, false);
-        this.executeListener = executeListener;
-        this.writePolicy = writePolicy;
-        this.key = key;
-        this.packageName = packageName;
-        this.functionName = functionName;
-        this.args = args;
-    }
+	public ExecuteCommandProxy(
+			GrpcCallExecutor executor,
+			ExecuteListener executeListener,
+			WritePolicy writePolicy,
+			Key key,
+			String packageName,
+			String functionName,
+			Value[] args
+	) {
+		super(KVSGrpc.getExecuteStreamingMethod(), executor, null, writePolicy
+				, key, false);
+		this.executeListener = executeListener;
+		this.writePolicy = writePolicy;
+		this.key = key;
+		this.packageName = packageName;
+		this.functionName = functionName;
+		this.args = args;
+	}
 
 	@Override
 	void writeCommand(Command command) {
-        command.setUdf(writePolicy, key, packageName, functionName, args);
+		command.setUdf(writePolicy, key, packageName, functionName, args);
 	}
 
 	@Override
@@ -76,7 +78,7 @@ public final class ExecuteCommandProxy extends ReadCommandProxy {
 			return null;
 		}
 
-		Map<String,Object> map = record.bins;
+		Map<String, Object> map = record.bins;
 
 		Object obj = map.get("SUCCESS");
 
@@ -102,8 +104,8 @@ public final class ExecuteCommandProxy extends ReadCommandProxy {
 		throw new AerospikeException(resultCode);
 	}
 
-    @Override
-    void onFailure(AerospikeException ae) {
-        executeListener.onFailure(ae);
-    }
+	@Override
+	void onFailure(AerospikeException ae) {
+		executeListener.onFailure(ae);
+	}
 }

--- a/proxy/src/com/aerospike/client/proxy/ExistsCommandProxy.java
+++ b/proxy/src/com/aerospike/client/proxy/ExistsCommandProxy.java
@@ -23,25 +23,26 @@ import com.aerospike.client.command.Command;
 import com.aerospike.client.listener.ExistsListener;
 import com.aerospike.client.policy.Policy;
 import com.aerospike.client.proxy.grpc.GrpcCallExecutor;
+import com.aerospike.proxy.client.KVSGrpc;
 
 public final class ExistsCommandProxy extends CommandProxy {
-    private final ExistsListener listener;
-    private final Key key;
+	private final ExistsListener listener;
+	private final Key key;
 
-    public ExistsCommandProxy(
-    	GrpcCallExecutor executor,
-    	ExistsListener listener,
-    	Policy policy,
-    	Key key
-    ) {
-        super(executor, policy);
-        this.listener = listener;
-        this.key = key;
-    }
+	public ExistsCommandProxy(
+			GrpcCallExecutor executor,
+			ExistsListener listener,
+			Policy policy,
+			Key key
+	) {
+		super(KVSGrpc.getExistsStreamingMethod(), executor, policy);
+		this.listener = listener;
+		this.key = key;
+	}
 
 	@Override
 	void writeCommand(Command command) {
-        command.setExists(policy, key);
+		command.setExists(policy, key);
 	}
 
 	@Override
@@ -75,10 +76,10 @@ public final class ExistsCommandProxy extends CommandProxy {
 		catch (Throwable t) {
 			logOnSuccessError(t);
 		}
-    }
+	}
 
-    @Override
-    void onFailure(AerospikeException ae) {
-        listener.onFailure(ae);
-    }
+	@Override
+	void onFailure(AerospikeException ae) {
+		listener.onFailure(ae);
+	}
 }

--- a/proxy/src/com/aerospike/client/proxy/OperateCommandProxy.java
+++ b/proxy/src/com/aerospike/client/proxy/OperateCommandProxy.java
@@ -23,24 +23,26 @@ import com.aerospike.client.command.OperateArgs;
 import com.aerospike.client.listener.RecordListener;
 import com.aerospike.client.policy.Policy;
 import com.aerospike.client.proxy.grpc.GrpcCallExecutor;
+import com.aerospike.proxy.client.KVSGrpc;
 
 public final class OperateCommandProxy extends ReadCommandProxy {
 	private final OperateArgs args;
 
 	public OperateCommandProxy(
-		GrpcCallExecutor executor,
-		RecordListener listener,
-		Policy policy,
-		Key key,
-		OperateArgs args
+			GrpcCallExecutor executor,
+			RecordListener listener,
+			Policy policy,
+			Key key,
+			OperateArgs args
 	) {
-		super(executor, listener, policy, key, true);
+		super(KVSGrpc.getOperateStreamingMethod(), executor, listener, policy,
+				key, true);
 		this.args = args;
 	}
 
 	@Override
 	void writeCommand(Command command) {
-        command.setOperate(args.writePolicy, key, args);
+		command.setOperate(args.writePolicy, key, args);
 	}
 
 	@Override

--- a/proxy/src/com/aerospike/client/proxy/ReadCommandProxy.java
+++ b/proxy/src/com/aerospike/client/proxy/ReadCommandProxy.java
@@ -24,6 +24,9 @@ import com.aerospike.client.command.Command;
 import com.aerospike.client.listener.RecordListener;
 import com.aerospike.client.policy.Policy;
 import com.aerospike.client.proxy.grpc.GrpcCallExecutor;
+import com.aerospike.proxy.client.KVSGrpc;
+import com.aerospike.proxy.client.Kvs;
+import io.grpc.MethodDescriptor;
 
 public class ReadCommandProxy extends CommandProxy {
 	private final RecordListener listener;
@@ -32,13 +35,13 @@ public class ReadCommandProxy extends CommandProxy {
 	private final boolean isOperation;
 
 	public ReadCommandProxy(
-		GrpcCallExecutor executor,
-		RecordListener listener,
-		Policy policy,
-		Key key,
-		String[] binNames
+			GrpcCallExecutor executor,
+			RecordListener listener,
+			Policy policy,
+			Key key,
+			String[] binNames
 	) {
-		super(executor, policy);
+		super(KVSGrpc.getGetStreamingMethod(), executor, policy);
 		this.listener = listener;
 		this.key = key;
 		this.binNames = binNames;
@@ -46,13 +49,14 @@ public class ReadCommandProxy extends CommandProxy {
 	}
 
 	public ReadCommandProxy(
-		GrpcCallExecutor executor,
-		RecordListener listener,
-		Policy policy,
-		Key key,
-		boolean isOperation
-	) {
-		super(executor, policy);
+			MethodDescriptor<Kvs.AerospikeRequestPayload,
+					Kvs.AerospikeResponsePayload> streamingMethodDescriptor,
+			GrpcCallExecutor executor,
+			RecordListener listener,
+			Policy policy,
+			Key key,
+			boolean isOperation) {
+		super(streamingMethodDescriptor, executor, policy);
 		this.listener = listener;
 		this.key = key;
 		this.binNames = null;
@@ -61,7 +65,7 @@ public class ReadCommandProxy extends CommandProxy {
 
 	@Override
 	void writeCommand(Command command) {
-        command.setRead(policy, key, binNames);
+		command.setRead(policy, key, binNames);
 	}
 
 	@Override
@@ -74,7 +78,7 @@ public class ReadCommandProxy extends CommandProxy {
 		catch (Throwable t) {
 			logOnSuccessError(t);
 		}
-    }
+	}
 
 	protected final Record parseRecordResult(Parser parser) {
 		Record record = null;
@@ -142,8 +146,8 @@ public class ReadCommandProxy extends CommandProxy {
 		throw new AerospikeException(code, message);
 	}
 
-    @Override
-    void onFailure(AerospikeException ae) {
-        listener.onFailure(ae);
-    }
+	@Override
+	void onFailure(AerospikeException ae) {
+		listener.onFailure(ae);
+	}
 }

--- a/proxy/src/com/aerospike/client/proxy/ReadHeaderCommandProxy.java
+++ b/proxy/src/com/aerospike/client/proxy/ReadHeaderCommandProxy.java
@@ -24,21 +24,22 @@ import com.aerospike.client.command.Command;
 import com.aerospike.client.listener.RecordListener;
 import com.aerospike.client.policy.Policy;
 import com.aerospike.client.proxy.grpc.GrpcCallExecutor;
+import com.aerospike.proxy.client.KVSGrpc;
 
 public final class ReadHeaderCommandProxy extends CommandProxy {
-    private final RecordListener listener;
-    private final Key key;
+	private final RecordListener listener;
+	private final Key key;
 
-    public ReadHeaderCommandProxy(
-    	GrpcCallExecutor executor,
-    	RecordListener listener,
-    	Policy policy,
-    	Key key
-    ) {
-        super(executor, policy);
-        this.listener = listener;
-        this.key = key;
-    }
+	public ReadHeaderCommandProxy(
+			GrpcCallExecutor executor,
+			RecordListener listener,
+			Policy policy,
+			Key key
+	) {
+		super(KVSGrpc.getGetHeaderStreamingMethod(), executor, policy);
+		this.listener = listener;
+		this.key = key;
+	}
 
 	@Override
 	void writeCommand(Command command) {
@@ -76,8 +77,8 @@ public final class ReadHeaderCommandProxy extends CommandProxy {
 		}
 	}
 
-    @Override
-    void onFailure(AerospikeException ae) {
-        listener.onFailure(ae);
-    }
+	@Override
+	void onFailure(AerospikeException ae) {
+		listener.onFailure(ae);
+	}
 }

--- a/proxy/src/com/aerospike/client/proxy/TouchCommandProxy.java
+++ b/proxy/src/com/aerospike/client/proxy/TouchCommandProxy.java
@@ -23,27 +23,28 @@ import com.aerospike.client.command.Command;
 import com.aerospike.client.listener.WriteListener;
 import com.aerospike.client.policy.WritePolicy;
 import com.aerospike.client.proxy.grpc.GrpcCallExecutor;
+import com.aerospike.proxy.client.KVSGrpc;
 
 public final class TouchCommandProxy extends CommandProxy {
-    private final WriteListener listener;
-    private final WritePolicy writePolicy;
-    private final Key key;
+	private final WriteListener listener;
+	private final WritePolicy writePolicy;
+	private final Key key;
 
-    public TouchCommandProxy(
-    	GrpcCallExecutor executor,
-    	WriteListener listener,
-    	WritePolicy writePolicy,
-    	Key key
-    ) {
-        super(executor, writePolicy);
-        this.listener = listener;
-        this.writePolicy = writePolicy;
-        this.key = key;
-    }
+	public TouchCommandProxy(
+			GrpcCallExecutor executor,
+			WriteListener listener,
+			WritePolicy writePolicy,
+			Key key
+	) {
+		super(KVSGrpc.getTouchStreamingMethod(), executor, writePolicy);
+		this.listener = listener;
+		this.writePolicy = writePolicy;
+		this.key = key;
+	}
 
 	@Override
 	void writeCommand(Command command) {
-        command.setTouch(writePolicy, key);
+		command.setTouch(writePolicy, key);
 	}
 
 	@Override
@@ -70,10 +71,10 @@ public final class TouchCommandProxy extends CommandProxy {
 		catch (Throwable t) {
 			logOnSuccessError(t);
 		}
-    }
+	}
 
-    @Override
-    void onFailure(AerospikeException ae) {
-        listener.onFailure(ae);
-    }
+	@Override
+	void onFailure(AerospikeException ae) {
+		listener.onFailure(ae);
+	}
 }

--- a/proxy/src/com/aerospike/client/proxy/WriteCommandProxy.java
+++ b/proxy/src/com/aerospike/client/proxy/WriteCommandProxy.java
@@ -25,33 +25,34 @@ import com.aerospike.client.command.Command;
 import com.aerospike.client.listener.WriteListener;
 import com.aerospike.client.policy.WritePolicy;
 import com.aerospike.client.proxy.grpc.GrpcCallExecutor;
+import com.aerospike.proxy.client.KVSGrpc;
 
 public final class WriteCommandProxy extends CommandProxy {
-    private final WriteListener listener;
-    private final WritePolicy writePolicy;
-    private final Key key;
-    private final Bin[] bins;
-    private final Operation.Type type;
+	private final WriteListener listener;
+	private final WritePolicy writePolicy;
+	private final Key key;
+	private final Bin[] bins;
+	private final Operation.Type type;
 
-    public WriteCommandProxy(
-    	GrpcCallExecutor executor,
-    	WriteListener listener,
-    	WritePolicy writePolicy,
-    	Key key,
-    	Bin[] bins,
-    	Operation.Type type
-    ) {
-        super(executor, writePolicy);
-        this.listener = listener;
-        this.writePolicy = writePolicy;
-        this.key = key;
-        this.bins = bins;
-        this.type = type;
-    }
+	public WriteCommandProxy(
+			GrpcCallExecutor executor,
+			WriteListener listener,
+			WritePolicy writePolicy,
+			Key key,
+			Bin[] bins,
+			Operation.Type type
+	) {
+		super(KVSGrpc.getPutStreamingMethod(), executor, writePolicy);
+		this.listener = listener;
+		this.writePolicy = writePolicy;
+		this.key = key;
+		this.bins = bins;
+		this.type = type;
+	}
 
 	@Override
 	void writeCommand(Command command) {
-        command.setWrite(writePolicy, type, key, bins);
+		command.setWrite(writePolicy, type, key, bins);
 	}
 
 	@Override
@@ -78,10 +79,10 @@ public final class WriteCommandProxy extends CommandProxy {
 		catch (Throwable t) {
 			logOnSuccessError(t);
 		}
-    }
+	}
 
-    @Override
-    void onFailure(AerospikeException ae) {
-        listener.onFailure(ae);
-    }
+	@Override
+	void onFailure(AerospikeException ae) {
+		listener.onFailure(ae);
+	}
 }

--- a/proxy/src/com/aerospike/client/proxy/auth/AuthTokenManager.java
+++ b/proxy/src/com/aerospike/client/proxy/auth/AuthTokenManager.java
@@ -35,7 +35,6 @@ import com.aerospike.proxy.client.Auth;
 import com.aerospike.proxy.client.AuthServiceGrpc;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
-
 import io.grpc.CallOptions;
 import io.grpc.Deadline;
 import io.grpc.ManagedChannel;
@@ -45,292 +44,286 @@ import io.grpc.stub.StreamObserver;
  * An access token manager for Aerospike proxy.
  */
 public class AuthTokenManager implements Closeable {
-    /**
-     * A conservative estimate of minimum amount of time in millis it takes for
-     * token refresh to complete. Auto refresh should be scheduled at least
-     * this amount before expiry, i.e, ff remaining expiry time is less than
-     * this amount refresh should be scheduled immediately.
-     */
-    private static final int refreshMinTime = 5000;
+	/**
+	 * A conservative estimate of minimum amount of time in millis it takes for
+	 * token refresh to complete. Auto refresh should be scheduled at least
+	 * this amount before expiry, i.e, ff remaining expiry time is less than
+	 * this amount refresh should be scheduled immediately.
+	 */
+	private static final int refreshMinTime = 5000;
 
-    /**
-     * A cap on refresh time in millis to throttle an auto refresh requests in
-     * case of token refresh failure.
-     */
-    private static final int maxExponentialBackOff = 15000;
+	/**
+	 * A cap on refresh time in millis to throttle an auto refresh requests in
+	 * case of token refresh failure.
+	 */
+	private static final int maxExponentialBackOff = 15000;
 
-    /**
-     * Fraction of token expiry time to elapse before scheduling an auto
-     * refresh.
-     *
-     * @see AuthTokenManager#refreshMinTime
-     */
-    private static final float refreshAfterFraction = 0.95f;
+	/**
+	 * Fraction of token expiry time to elapse before scheduling an auto
+	 * refresh.
+	 *
+	 * @see AuthTokenManager#refreshMinTime
+	 */
+	private static final float refreshAfterFraction = 0.95f;
 
-    /**
-     * An {@link ObjectMapper} to parse access token.
-     */
-    private static final ObjectMapper objectMapper = new ObjectMapper();
+	/**
+	 * An {@link ObjectMapper} to parse access token.
+	 */
+	private static final ObjectMapper objectMapper = new ObjectMapper();
 
-    private final ClientPolicy clientPolicy;
-    private final GrpcChannelProvider channelProvider;
-    private final ScheduledExecutorService executor;
-    private final AtomicBoolean isFetchingToken = new AtomicBoolean(false);
-    private final AtomicBoolean isClosed = new AtomicBoolean(false);
-    private volatile AccessToken accessToken;
-    private volatile boolean fetchScheduled;
+	private final ClientPolicy clientPolicy;
+	private final GrpcChannelProvider channelProvider;
+	private final ScheduledExecutorService executor;
+	private final AtomicBoolean isFetchingToken = new AtomicBoolean(false);
+	private final AtomicBoolean isClosed = new AtomicBoolean(false);
+	private volatile AccessToken accessToken;
+	private volatile boolean fetchScheduled;
 
-    /**
-     * Count of consecutive errors while refreshing the token.
-     */
-    private final AtomicInteger consecutiveRefreshErrors =
-            new AtomicInteger(0);
+	/**
+	 * Count of consecutive errors while refreshing the token.
+	 */
+	private final AtomicInteger consecutiveRefreshErrors =
+			new AtomicInteger(0);
 
-    /**
-     * A {@link ScheduledFuture} holding reference to the next auto schedule task.
-     */
-    private ScheduledFuture<?> refreshFuture;
+	/**
+	 * A {@link ScheduledFuture} holding reference to the next auto schedule task.
+	 */
+	private ScheduledFuture<?> refreshFuture;
 
-    public AuthTokenManager(ClientPolicy clientPolicy, GrpcChannelProvider grpcCallExecutor) {
-        this.clientPolicy = clientPolicy;
-        this.channelProvider = grpcCallExecutor;
-        this.executor = Executors.newSingleThreadScheduledExecutor(new ThreadFactoryBuilder().setNameFormat("auth-manager").build());
-        this.accessToken = new AccessToken(System.currentTimeMillis(), 0, "");
-        fetchToken(true);
-    }
+	public AuthTokenManager(ClientPolicy clientPolicy, GrpcChannelProvider grpcCallExecutor) {
+		this.clientPolicy = clientPolicy;
+		this.channelProvider = grpcCallExecutor;
+		this.executor = Executors.newSingleThreadScheduledExecutor(new ThreadFactoryBuilder().setNameFormat("auth-manager").build());
+		this.accessToken = new AccessToken(System.currentTimeMillis(), 0, "");
+		fetchToken(true);
+	}
 
-    public CallOptions setCallCredentials(
-            CallOptions callOptions) {
-        if (isTokenRequired()) {
-            if (!isTokenValid()) {
-                if (Log.warnEnabled()) {
-                    // TODO: This warns for evey call, spamming the output.
-                    //  Should be rate limited. Possibly once in a few seconds.
-                    // This alerts that auto refresh didn't finish correctly. In normal scenario, this should never
-                    // happen.
-                    Log.warn("Trying to refresh token before setting into call");
-                }
-                unsafeScheduleRefresh(0, false);
-                try {
-                    int sleepTime = 10;
-                    int retries = refreshMinTime / sleepTime;
-                    for (int i = 0; i < retries && !isTokenValid(); i++) {
-                        //noinspection BusyWait
-                        Thread.sleep(sleepTime);
-                    }
-                } catch (InterruptedException e) {
-                    throw new RuntimeException(e);
-                }
-            }
-            if (!isTokenValid()) {
-                throw new IllegalStateException("Access token has expired");
-            }
-            return callOptions.withCallCredentials(new BearerTokenCallCredentials(accessToken.token));
-        }
-        return callOptions;
-    }
+	public CallOptions setCallCredentials(
+			CallOptions callOptions) {
+		if (isTokenRequired()) {
+			if (!isTokenValid()) {
+				if (Log.warnEnabled()) {
+					// TODO: This warns for evey call, spamming the output.
+					//  Should be rate limited. Possibly once in a few seconds.
+					// This alerts that auto refresh didn't finish correctly. In normal scenario, this should never
+					// happen.
+					Log.warn("Trying to refresh token before setting into call");
+				}
+				unsafeScheduleRefresh(0, false);
+			}
+			if (!isTokenValid()) {
+				throw new IllegalStateException("Access token has expired");
+			}
+			return callOptions.withCallCredentials(new BearerTokenCallCredentials(accessToken.token));
+		}
+		return callOptions;
+	}
 
-    /**
-     * Fetch the new token if expired or scheduled for auto refresh.
-     *
-     * @param forceRefresh A boolean flag to refresh token forcefully. This is required for initialization and auto
-     *                     refresh. Auto refresh will get rejected as token won't be expired at that time, but we need
-     *                     to refresh it beforehand. If true, this function will run from the <b>invoking thread</b>,
-     *                     not from the scheduler.
-     */
-    private void fetchToken(boolean forceRefresh) {
-        fetchScheduled = false;
-        if (isClosed.get() || !isTokenRequired() || isFetchingToken.get()) {
-            return;
-        }
-        if (shouldRefresh(forceRefresh)) {
-            try {
-                if (Log.debugEnabled()) {
-                    Log.debug("Starting token refresh");
-                }
-                Auth.AerospikeAuthRequest aerospikeAuthRequest = Auth.AerospikeAuthRequest.newBuilder()
-                        .setUsername(clientPolicy.user).setPassword(clientPolicy.password).build();
-                ManagedChannel channel = channelProvider.getControlChannel();
-                if (channel == null) {
-                    isFetchingToken.set(false);
-                    // Channel is unavailable. Try again.
-                    unsafeScheduleRefresh(10, true);
-                    return;
-                }
+	/**
+	 * Fetch the new token if expired or scheduled for auto refresh.
+	 *
+	 * @param forceRefresh A boolean flag to refresh token forcefully. This is required for initialization and auto
+	 *                     refresh. Auto refresh will get rejected as token won't be expired at that time, but we need
+	 *                     to refresh it beforehand. If true, this function will run from the <b>invoking thread</b>,
+	 *                     not from the scheduler.
+	 */
+	private void fetchToken(boolean forceRefresh) {
+		fetchScheduled = false;
+		if (isClosed.get() || !isTokenRequired() || isFetchingToken.get()) {
+			return;
+		}
+		if (shouldRefresh(forceRefresh)) {
+			try {
+				if (Log.debugEnabled()) {
+					Log.debug("Starting token refresh");
+				}
+				Auth.AerospikeAuthRequest aerospikeAuthRequest = Auth.AerospikeAuthRequest.newBuilder()
+						.setUsername(clientPolicy.user).setPassword(clientPolicy.password).build();
+				ManagedChannel channel = channelProvider.getControlChannel();
+				if (channel == null) {
+					isFetchingToken.set(false);
+					// Channel is unavailable. Try again.
+					unsafeScheduleRefresh(10, true);
+					return;
+				}
 
-                isFetchingToken.set(true);
-                AuthServiceGrpc.newStub(channel).withDeadline(Deadline.after(refreshMinTime, TimeUnit.MILLISECONDS))
-                        .get(aerospikeAuthRequest, new StreamObserver<Auth.AerospikeAuthResponse>() {
-                            @Override
-                            public void onNext(Auth.AerospikeAuthResponse aerospikeAuthResponse) {
-                                try {
-                                    accessToken =
-                                            parseToken(aerospikeAuthResponse.getToken());
-                                    if (Log.debugEnabled()) {
-                                        Log.debug(String.format("Fetched token successfully " +
-                                                "with TTL %d", accessToken.ttl));
-                                    }
-                                    unsafeScheduleNextRefresh();
-                                    consecutiveRefreshErrors.set(0);
-                                } catch (Exception e) {
-                                    onFetchError(e);
-                                }
-                            }
+				isFetchingToken.set(true);
+				AuthServiceGrpc.newStub(channel).withDeadline(Deadline.after(refreshMinTime, TimeUnit.MILLISECONDS))
+						.get(aerospikeAuthRequest, new StreamObserver<Auth.AerospikeAuthResponse>() {
+							@Override
+							public void onNext(Auth.AerospikeAuthResponse aerospikeAuthResponse) {
+								try {
+									accessToken =
+											parseToken(aerospikeAuthResponse.getToken());
+									if (Log.debugEnabled()) {
+										Log.debug(String.format("Fetched token successfully " +
+												"with TTL %d", accessToken.ttl));
+									}
+									unsafeScheduleNextRefresh();
+									consecutiveRefreshErrors.set(0);
+								}
+								catch (Exception e) {
+									onFetchError(e);
+								}
+							}
 
-                            @Override
-                            public void onError(Throwable t) {
-                                onFetchError(t);
-                            }
+							@Override
+							public void onError(Throwable t) {
+								onFetchError(t);
+							}
 
-                            @Override
-                            public void onCompleted() {
-                                isFetchingToken.set(false);
-                            }
-                        });
+							@Override
+							public void onCompleted() {
+								isFetchingToken.set(false);
+							}
+						});
 
-            } catch (Exception e) {
-                onFetchError(e);
-            }
-        }
-    }
+			}
+			catch (Exception e) {
+				onFetchError(e);
+			}
+		}
+	}
 
-    private void onFetchError(Throwable t) {
-        consecutiveRefreshErrors.incrementAndGet();
-        Log.error(t.getMessage());
-        unsafeScheduleNextRefresh();
-        isFetchingToken.set(false);
-    }
+	private void onFetchError(Throwable t) {
+		consecutiveRefreshErrors.incrementAndGet();
+		Log.error(t.getMessage());
+		unsafeScheduleNextRefresh();
+		isFetchingToken.set(false);
+	}
 
-    private boolean shouldRefresh(boolean forceRefresh) {
-        return forceRefresh || !isTokenValid();
-    }
+	private boolean shouldRefresh(boolean forceRefresh) {
+		return forceRefresh || !isTokenValid();
+	}
 
-    private void unsafeScheduleNextRefresh() {
-        long ttl = accessToken.ttl;
-        long delay = (long) Math.floor(ttl * refreshAfterFraction);
+	private void unsafeScheduleNextRefresh() {
+		long ttl = accessToken.ttl;
+		long delay = (long)Math.floor(ttl * refreshAfterFraction);
 
-        if (ttl - delay < refreshMinTime) {
-            // We need at least refreshMinTimeMillis to refresh, schedule
-            // immediately.
-            delay = ttl - refreshMinTime;
-        }
+		if (ttl - delay < refreshMinTime) {
+			// We need at least refreshMinTimeMillis to refresh, schedule
+			// immediately.
+			delay = ttl - refreshMinTime;
+		}
 
-        if (!isTokenValid()) {
-            // Force immediate refresh.
-            delay = 0;
-        }
+		if (!isTokenValid()) {
+			// Force immediate refresh.
+			delay = 0;
+		}
 
-        if (delay == 0 && consecutiveRefreshErrors.get() > 0) {
-            // If we continue to fail then schedule will be too aggressive on fetching new token. Avoid that by increasing
-            // fetch delay.
+		if (delay == 0 && consecutiveRefreshErrors.get() > 0) {
+			// If we continue to fail then schedule will be too aggressive on fetching new token. Avoid that by increasing
+			// fetch delay.
 
-            delay = (long) (Math.pow(2, consecutiveRefreshErrors.get()) * 1000);
-            if (delay > maxExponentialBackOff) {
-                delay = maxExponentialBackOff;
-            }
+			delay = (long)(Math.pow(2, consecutiveRefreshErrors.get()) * 1000);
+			if (delay > maxExponentialBackOff) {
+				delay = maxExponentialBackOff;
+			}
 
-            // Handle wrap around.
-            if (delay < 0) {
-                delay = 0;
-            }
-        }
-        unsafeScheduleRefresh(delay, true);
-    }
+			// Handle wrap around.
+			if (delay < 0) {
+				delay = 0;
+			}
+		}
+		unsafeScheduleRefresh(delay, true);
+	}
 
-    private void unsafeScheduleRefresh(long delay, boolean forceRefresh) {
-        if (isClosed.get() || !forceRefresh || fetchScheduled) {
-            return;
-        }
-        if (!executor.isShutdown()) {
-            //noinspection ConstantValue
-            refreshFuture = executor.schedule(() -> fetchToken(forceRefresh), delay, TimeUnit.MILLISECONDS);
-            fetchScheduled = true;
-            if (Log.debugEnabled()) {
-                Log.debug(String.format("Scheduled refresh after %d millis", delay));
-            }
-        }
-    }
+	private void unsafeScheduleRefresh(long delay, boolean forceRefresh) {
+		if (isClosed.get() || !forceRefresh || fetchScheduled) {
+			return;
+		}
+		if (!executor.isShutdown()) {
+			//noinspection ConstantValue
+			refreshFuture = executor.schedule(() -> fetchToken(forceRefresh), delay, TimeUnit.MILLISECONDS);
+			fetchScheduled = true;
+			if (Log.debugEnabled()) {
+				Log.debug(String.format("Scheduled refresh after %d millis", delay));
+			}
+		}
+	}
 
-    private boolean isTokenRequired() {
-        return clientPolicy.user != null;
-    }
+	private boolean isTokenRequired() {
+		return clientPolicy.user != null;
+	}
 
-    @SuppressWarnings("BooleanMethodIsAlwaysInverted")
-    private boolean isTokenValid() {
-        AccessToken token = accessToken;
-        return !isTokenRequired() || (token != null && System.currentTimeMillis() <= token.expiry);
-    }
+	@SuppressWarnings("BooleanMethodIsAlwaysInverted")
+	private boolean isTokenValid() {
+		AccessToken token = accessToken;
+		return !isTokenRequired() || (token != null && System.currentTimeMillis() <= token.expiry);
+	}
 
-    private AccessToken parseToken(String token) throws IOException {
-        String claims = token.split("\\.")[1];
-        byte[] decodedClaims = Base64.getDecoder().decode(claims);
-        @SuppressWarnings("unchecked")
-        Map<Object, Object> parsedClaims = objectMapper.readValue(decodedClaims, Map.class);
-        Object expiryToken = parsedClaims.get("exp");
-        Object iat = parsedClaims.get("iat");
-        if (expiryToken instanceof Integer && iat instanceof Integer) {
-            int ttl = ((Integer) expiryToken - (Integer) iat) * 1000;
-            if (ttl <= 0) {
-                throw new IllegalArgumentException("token 'iat' > 'exp'");
-            }
-            // Set expiry based on local clock.
-            long expiry = System.currentTimeMillis() + ttl;
-            return new AccessToken(expiry, ttl, token);
-        } else {
-            throw new IllegalArgumentException("Unsupported access token format");
-        }
-    }
+	private AccessToken parseToken(String token) throws IOException {
+		String claims = token.split("\\.")[1];
+		byte[] decodedClaims = Base64.getDecoder().decode(claims);
+		@SuppressWarnings("unchecked")
+		Map<Object, Object> parsedClaims = objectMapper.readValue(decodedClaims, Map.class);
+		Object expiryToken = parsedClaims.get("exp");
+		Object iat = parsedClaims.get("iat");
+		if (expiryToken instanceof Integer && iat instanceof Integer) {
+			int ttl = ((Integer)expiryToken - (Integer)iat) * 1000;
+			if (ttl <= 0) {
+				throw new IllegalArgumentException("token 'iat' > 'exp'");
+			}
+			// Set expiry based on local clock.
+			long expiry = System.currentTimeMillis() + ttl;
+			return new AccessToken(expiry, ttl, token);
+		}
+		else {
+			throw new IllegalArgumentException("Unsupported access token format");
+		}
+	}
 
-    @Override
-    public void close() {
-        if (isClosed.get()) {
-            return;
-        }
+	@Override
+	public void close() {
+		if (isClosed.get()) {
+			return;
+		}
 
-        isClosed.set(true);
-        // TODO copied from java.util.concurrent.ExecutorService#close available from Java 19.
-        boolean terminated = executor.isTerminated();
-        if (!terminated) {
-            if (refreshFuture != null) {
-                refreshFuture.cancel(true);
-            }
-            executor.shutdown();
-            boolean interrupted = false;
-            while (!terminated) {
-                try {
-                    terminated = executor.awaitTermination(1L, TimeUnit.DAYS);
-                } catch (InterruptedException e) {
-                    if (!interrupted) {
-                        executor.shutdownNow();
-                        interrupted = true;
-                    }
-                }
-            }
-            if (interrupted) {
-                Thread.currentThread().interrupt();
-            }
-        }
-    }
+		isClosed.set(true);
+		// TODO copied from java.util.concurrent.ExecutorService#close available from Java 19.
+		boolean terminated = executor.isTerminated();
+		if (!terminated) {
+			if (refreshFuture != null) {
+				refreshFuture.cancel(true);
+			}
+			executor.shutdown();
+			boolean interrupted = false;
+			while (!terminated) {
+				try {
+					terminated = executor.awaitTermination(1L, TimeUnit.DAYS);
+				}
+				catch (InterruptedException e) {
+					if (!interrupted) {
+						executor.shutdownNow();
+						interrupted = true;
+					}
+				}
+			}
+			if (interrupted) {
+				Thread.currentThread().interrupt();
+			}
+		}
+	}
 
 
-    private static class AccessToken {
-        /**
-         * Local token expiry timestamp in millis.
-         */
-        private final long expiry;
-        /**
-         * Remaining time to live for the token in millis.
-         */
-        private final long ttl;
-        /**
-         * An access token for Aerospike proxy.
-         */
-        private final String token;
+	private static class AccessToken {
+		/**
+		 * Local token expiry timestamp in millis.
+		 */
+		private final long expiry;
+		/**
+		 * Remaining time to live for the token in millis.
+		 */
+		private final long ttl;
+		/**
+		 * An access token for Aerospike proxy.
+		 */
+		private final String token;
 
-        public AccessToken(long expiry, long ttl, String token) {
-            this.expiry = expiry;
-            this.ttl = ttl;
-            this.token = token;
-        }
-    }
+		public AccessToken(long expiry, long ttl, String token) {
+			this.expiry = expiry;
+			this.ttl = ttl;
+			this.token = token;
+		}
+	}
 }

--- a/proxy/src/com/aerospike/client/proxy/grpc/GrpcCallExecutor.java
+++ b/proxy/src/com/aerospike/client/proxy/grpc/GrpcCallExecutor.java
@@ -24,7 +24,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.LongAdder;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-
 import javax.annotation.Nullable;
 
 import com.aerospike.client.AerospikeException;
@@ -32,127 +31,129 @@ import com.aerospike.client.Host;
 import com.aerospike.client.ResultCode;
 import com.aerospike.client.proxy.auth.AuthTokenManager;
 import com.aerospike.proxy.client.Kvs;
-
 import io.grpc.ManagedChannel;
 import io.netty.channel.EventLoop;
 
 public class GrpcCallExecutor implements Closeable {
-    private static final int QUEUE_SIZE_UPPER_BOUND = 100 * 1024;
-    private final List<GrpcChannelExecutor> channelExecutors;
-    private final List<GrpcChannelExecutor> controlChannelExecutors;
-    private final GrpcClientPolicy grpcClientPolicy;
-    private final Random random = new Random();
-    private final AtomicBoolean isClosed = new AtomicBoolean(false);
+	private static final int QUEUE_SIZE_UPPER_BOUND = 100 * 1024;
+	private final List<GrpcChannelExecutor> channelExecutors;
+	private final List<GrpcChannelExecutor> controlChannelExecutors;
+	private final GrpcClientPolicy grpcClientPolicy;
+	private final Random random = new Random();
+	private final AtomicBoolean isClosed = new AtomicBoolean(false);
 
-    /**
-     * Maximum allowed queue size.
-     */
-    private final int maxQueueSize;
+	/**
+	 * Maximum allowed queue size.
+	 */
+	private final int maxQueueSize;
 
-    private final LongAdder totalQueueSize = new LongAdder();
+	private final LongAdder totalQueueSize = new LongAdder();
 
-    public GrpcCallExecutor(GrpcClientPolicy grpcClientPolicy,
-                            @Nullable AuthTokenManager authTokenManager,
-                            Host... hosts) {
-        if (hosts == null || hosts.length < 1) {
-            throw new AerospikeException(ResultCode.PARAMETER_ERROR,
-                    "need at least one seed host");
-        }
+	public GrpcCallExecutor(GrpcClientPolicy grpcClientPolicy,
+							@Nullable AuthTokenManager authTokenManager,
+							Host... hosts) {
+		if (hosts == null || hosts.length < 1) {
+			throw new AerospikeException(ResultCode.PARAMETER_ERROR,
+					"need at least one seed host");
+		}
 
-        this.grpcClientPolicy = grpcClientPolicy;
-        maxQueueSize =
-                Math.min(QUEUE_SIZE_UPPER_BOUND,
-                        5 * grpcClientPolicy.maxChannels
-                                * grpcClientPolicy.maxConcurrentStreamsPerChannel
-                                * grpcClientPolicy.maxConcurrentRequestsPerStream);
+		this.grpcClientPolicy = grpcClientPolicy;
+		maxQueueSize =
+				Math.min(QUEUE_SIZE_UPPER_BOUND,
+						5 * grpcClientPolicy.maxChannels
+								* grpcClientPolicy.maxConcurrentStreamsPerChannel
+								* grpcClientPolicy.maxConcurrentRequestsPerStream);
 
-        try {
-            this.channelExecutors =
-                    IntStream.range(0, grpcClientPolicy.maxChannels).mapToObj(value ->
-                            GrpcChannelExecutor.newInstance(grpcClientPolicy,
-                                    authTokenManager, hosts)
-                    ).collect(Collectors.toList());
-            this.controlChannelExecutors =
-                    IntStream.range(0, 1).mapToObj(value ->
-                            GrpcChannelExecutor.newInstance(grpcClientPolicy,
-                                    authTokenManager, hosts)
-                    ).collect(Collectors.toList());
-        } catch (Exception e) {
-            throw new AerospikeException(ResultCode.SERVER_ERROR, e);
-        }
-    }
+		try {
+			this.channelExecutors =
+					IntStream.range(0, grpcClientPolicy.maxChannels).mapToObj(value ->
+							GrpcChannelExecutor.newInstance(grpcClientPolicy,
+									authTokenManager, hosts)
+					).collect(Collectors.toList());
+			this.controlChannelExecutors =
+					IntStream.range(0, 1).mapToObj(value ->
+							GrpcChannelExecutor.newInstance(grpcClientPolicy,
+									authTokenManager, hosts)
+					).collect(Collectors.toList());
+		}
+		catch (Exception e) {
+			throw new AerospikeException(ResultCode.SERVER_ERROR, e);
+		}
+	}
 
-    public void execute(GrpcStreamingUnaryCall call) {
-        if (totalQueueSize.sum() > maxQueueSize) {
-            throw new AerospikeException(ResultCode.NO_MORE_CONNECTIONS,
-                    "Maximum queue " + maxQueueSize +
-                            " size exceeded");
-        }
-        GrpcChannelExecutor executor =
-                grpcClientPolicy.grpcChannelSelector.select(channelExecutors,
-                        call.getMethodDescriptor());
+	public void execute(GrpcStreamingUnaryCall call) {
+		if (totalQueueSize.sum() > maxQueueSize) {
+			throw new AerospikeException(ResultCode.NO_MORE_CONNECTIONS,
+					"Maximum queue " + maxQueueSize +
+							" size exceeded");
+		}
+		GrpcChannelExecutor executor =
+				grpcClientPolicy.grpcChannelSelector.select(channelExecutors,
+						call.getStreamingMethodDescriptor());
 
-        // TODO: In case of timeouts, lots of calls will end up filling the
-        //  wait queues and timeout once removed for execution from the wait
-        //  queue. Have a upper limit on the number of concurrent transactions
-        //  per channel and reject this call if all the channels are full.
-        totalQueueSize.increment();
-        try {
-            executor.execute(new WrappedGrpcStreamingUnaryCall(call));
-        } catch (Exception e) {
-            // Call scheduling failed.
-            totalQueueSize.decrement();
-        }
-    }
+		// TODO: In case of timeouts, lots of calls will end up filling the
+		//  wait queues and timeout once removed for execution from the wait
+		//  queue. Have a upper limit on the number of concurrent transactions
+		//  per channel and reject this call if all the channels are full.
+		totalQueueSize.increment();
+		try {
+			executor.execute(new WrappedGrpcStreamingUnaryCall(call));
+		}
+		catch (Exception e) {
+			// Call scheduling failed.
+			totalQueueSize.decrement();
+		}
+	}
 
-    public EventLoop getEventLoop() {
-        return channelExecutors.get(random.nextInt(channelExecutors.size()))
-                .getEventLoop();
-    }
+	public EventLoop getEventLoop() {
+		return channelExecutors.get(random.nextInt(channelExecutors.size()))
+				.getEventLoop();
+	}
 
-    public ManagedChannel getControlChannel() {
-        if (controlChannelExecutors.isEmpty()) {
-            return null;
-        }
-        return controlChannelExecutors.get(random.nextInt(controlChannelExecutors.size()))
-                .getChannel();
-    }
+	public ManagedChannel getControlChannel() {
+		if (controlChannelExecutors.isEmpty()) {
+			return null;
+		}
+		return controlChannelExecutors.get(random.nextInt(controlChannelExecutors.size()))
+				.getChannel();
+	}
 
-    @Override
-    public void close() {
-        if (isClosed.getAndSet(true)) {
-            return;
-        }
+	@Override
+	public void close() {
+		if (isClosed.getAndSet(true)) {
+			return;
+		}
 
-        isClosed.set(true);
-        closeExecutors(channelExecutors);
-        closeExecutors(controlChannelExecutors);
-    }
+		isClosed.set(true);
+		closeExecutors(channelExecutors);
+		closeExecutors(controlChannelExecutors);
+	}
 
-    private void closeExecutors(List<GrpcChannelExecutor> executors) {
-    	// TODO FIX HANG!
-        for (GrpcChannelExecutor executor : executors) {
-            executor.shutdown();
-        }
+	private void closeExecutors(List<GrpcChannelExecutor> executors) {
+		// TODO FIX HANG!
+		for (GrpcChannelExecutor executor : executors) {
+			executor.shutdown();
+		}
 
-        if (grpcClientPolicy.closeEventLoops) {
-            grpcClientPolicy.eventLoops.stream()
-                    .map(eventLoop ->
-                            eventLoop.shutdownGracefully(0,
-                                    grpcClientPolicy.terminationWaitMillis, TimeUnit.MILLISECONDS)
+		if (grpcClientPolicy.closeEventLoops) {
+			grpcClientPolicy.eventLoops.stream()
+					.map(eventLoop ->
+							eventLoop.shutdownGracefully(0,
+									grpcClientPolicy.terminationWaitMillis, TimeUnit.MILLISECONDS)
 
-                    ).forEach(future -> {
-                                try {
-                                    future.await(grpcClientPolicy.terminationWaitMillis);
-                                } catch (Exception e) {
-                                    // TODO log error?
-                                }
-                            }
-                    );
-        }
+					).forEach(future -> {
+								try {
+									future.await(grpcClientPolicy.terminationWaitMillis);
+								}
+								catch (Exception e) {
+									// TODO log error?
+								}
+							}
+					);
+		}
 
-        // FIXME: each executor waits for terminationWaitMillis which will be
-        //  add up to greater than the terminationWaitMillis.
+		// FIXME: each executor waits for terminationWaitMillis which will be
+		//  add up to greater than the terminationWaitMillis.
     	/*
         for (GrpcChannelExecutor executor : executors) {
             executor.shutdown();
@@ -190,23 +191,23 @@ public class GrpcCallExecutor implements Closeable {
                     );
         }
         */
-    }
+	}
 
-    private class WrappedGrpcStreamingUnaryCall extends GrpcStreamingUnaryCall {
-        WrappedGrpcStreamingUnaryCall(GrpcStreamingUnaryCall delegate) {
-            super(delegate);
-        }
+	private class WrappedGrpcStreamingUnaryCall extends GrpcStreamingUnaryCall {
+		WrappedGrpcStreamingUnaryCall(GrpcStreamingUnaryCall delegate) {
+			super(delegate);
+		}
 
-        @Override
-        public void onSuccess(Kvs.AerospikeResponsePayload payload) {
-            totalQueueSize.decrement();
-            super.onSuccess(payload);
-        }
+		@Override
+		public void onSuccess(Kvs.AerospikeResponsePayload payload) {
+			totalQueueSize.decrement();
+			super.onSuccess(payload);
+		}
 
-        @Override
-        public void onError(Throwable t) {
-            totalQueueSize.decrement();
-            super.onError(t);
-        }
-    }
+		@Override
+		public void onError(Throwable t) {
+			totalQueueSize.decrement();
+			super.onError(t);
+		}
+	}
 }

--- a/proxy/src/com/aerospike/client/proxy/grpc/GrpcChannelExecutor.java
+++ b/proxy/src/com/aerospike/client/proxy/grpc/GrpcChannelExecutor.java
@@ -30,11 +30,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
-
 import javax.annotation.Nullable;
 import javax.net.ssl.KeyManagerFactory;
-
-import org.jctools.queues.SpscUnboundedArrayQueue;
 
 import com.aerospike.client.AerospikeException;
 import com.aerospike.client.Host;
@@ -45,7 +42,6 @@ import com.aerospike.client.proxy.auth.AuthTokenManager;
 import com.aerospike.client.util.Util;
 import com.aerospike.proxy.client.Kvs;
 import com.google.protobuf.ByteString;
-
 import io.grpc.CallOptions;
 import io.grpc.ManagedChannel;
 import io.grpc.MethodDescriptor;
@@ -66,6 +62,7 @@ import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.util.concurrent.ScheduledFuture;
 import io.netty.util.internal.shaded.org.jctools.queues.MpscUnboundedArrayQueue;
+import org.jctools.queues.SpscUnboundedArrayQueue;
 
 /**
  * All gRPC requests on a HTTP/2 channel are handled by this class throughout
@@ -75,512 +72,519 @@ import io.netty.util.internal.shaded.org.jctools.queues.MpscUnboundedArrayQueue;
  * TODO: handle close of channel.
  */
 public class GrpcChannelExecutor implements Runnable {
-    /**
-     * System property to configure gRPC override authority used as hostname
-     * in TLS verification of the proxy server.
-     */
-    public static final String OVERRIDE_AUTHORITY = "com.aerospike.client" +
-            ".overrideAuthority";
-
-    private static final String AEROSPIKE_CLIENT_USER_AGENT =
-            "AerospikeClientJava/" + AerospikeClientProxy.Version;
-    /**
-     * The delay between iterations of this executor.
-     * <p>
-     * TODO: how to select interval of execution?
-     */
-    private static final long ITERATION_DELAY_MICROS = 250;
-    /**
-     * Unique executor ids.
-     */
-    private static final AtomicLong executorIdIndex = new AtomicLong();
-    private static final AtomicInteger streamIdIndex = new AtomicInteger();
-
-    /**
-     * The HTTP/2 channel of this executor.
-     */
-    private final ManagedChannel channel;
-    /**
-     * The Aerospike gRPC client policy.
-     */
-    private final GrpcClientPolicy grpcClientPolicy;
-    /**
-     * The auth token manager.
-     */
-    private final AuthTokenManager authTokenManager;
-    /**
-     * The event loop bound to the <code>channel</code>. All queued requests
-     * will be executed on this event loop. Some requests will be queued on
-     * this channel in the gRPC callback and some from the pending queue.
-     */
-    private final EventLoop eventLoop;
-    /**
-     * Queued unary calls awaiting execution.
-     */
-    private final MpscUnboundedArrayQueue<GrpcStreamingUnaryCall> pendingCalls =
-            new MpscUnboundedArrayQueue<>(32);
-    /**
-     * Queue of closed streams.
-     */
-    private final MpscUnboundedArrayQueue<GrpcStream> closedStreams =
-            new MpscUnboundedArrayQueue<>(32);
-    /**
-     * Map of stream id to streams.
-     */
-    private final Map<Integer, GrpcStream> streams = new HashMap<>();
-    /**
-     * Indicates if this executor is shutdown.
-     */
-    private final AtomicBoolean isClosed = new AtomicBoolean(false);
-    /**
-     * Unique id of the executor.
-     */
-    private final long id;
-    // Statistics.
-    private final AtomicLong ongoingRequests = new AtomicLong();
-    /**
-     * The future to cancel the scheduled iteration of this executor.
-     */
-    private ScheduledFuture<?> iterateFuture;
-    // These are only accessed from the event loop thread
-    // assigned to this channel
-    private volatile long bytesSent;
-    private volatile long bytesReceived;
-    private volatile long requestsSent;
-    private volatile long responsesReceived;
-    private volatile long streamsOpen;
-    private volatile long streamsClosed;
-
-    private GrpcChannelExecutor(ManagedChannel channel,
-                                GrpcClientPolicy grpcClientPolicy,
-                                @Nullable AuthTokenManager authTokenManager,
-                                EventLoop eventLoop, long id) {
-        if (channel == null) {
-            throw new NullPointerException("channel");
-        }
-        if (eventLoop == null) {
-            throw new NullPointerException("eventLoop");
-        }
-        if (grpcClientPolicy == null) {
-            throw new NullPointerException("grpcClientPolicy");
-        }
-
-        this.authTokenManager = authTokenManager;
-        this.channel = channel;
-        this.eventLoop = eventLoop;
-        this.grpcClientPolicy = grpcClientPolicy;
-        this.id = id;
-    }
-
-    public static GrpcChannelExecutor newInstance(GrpcClientPolicy grpcClientPolicy,
-                                                  @Nullable AuthTokenManager authTokenManager,
-                                                  Host... hosts) {
-        if (grpcClientPolicy == null) {
-            throw new NullPointerException("grpcClientPolicy");
-        }
-        if (hosts == null || hosts.length == 0) {
-            throw new IllegalArgumentException("hosts should be non-empty");
-        }
-
-        ChannelAndEventLoop channelAndEventLoop = createGrpcChannel(grpcClientPolicy, hosts);
-        GrpcChannelExecutor executor =
-                new GrpcChannelExecutor(channelAndEventLoop.managedChannel,
-                        grpcClientPolicy, authTokenManager, channelAndEventLoop.eventLoop,
-                        executorIdIndex.getAndIncrement());
-
-        ScheduledFuture<?> future = channelAndEventLoop.eventLoop.scheduleAtFixedRate(executor, 0,
-                ITERATION_DELAY_MICROS, TimeUnit.MICROSECONDS);
-        executor.setScheduledFuture(future);
-
-        return executor;
-    }
-
-    /**
-     * Create a gRPC channel.
-     */
-    @SuppressWarnings("deprecation")
-    private static ChannelAndEventLoop createGrpcChannel(GrpcClientPolicy grpcClientPolicy,
-                                                         Host[] hosts) {
-        NettyChannelBuilder builder;
-
-        if (hosts.length == 1) {
-            builder = NettyChannelBuilder.forAddress(hosts[0].name, hosts[0].port);
-        } else {
-            // Setup round-robin load balancing.
-            NameResolver.Factory nameResolverFactory = new MultiAddressNameResolverFactory(
-                    Arrays.stream(hosts)
-                            .map((host) -> new InetSocketAddress(host.name, host.port))
-                            .collect(
-                                    Collectors.<SocketAddress>toList()));
-            builder = NettyChannelBuilder.forTarget(String.format("%s:%d",
-                    hosts[0].name, hosts[0].port));
-            builder.nameResolverFactory(nameResolverFactory);
-            builder.defaultLoadBalancingPolicy("round_robin");
-        }
-
-        EventLoop eventLoop = grpcClientPolicy.nextEventLoop();
-        EventLoopGroup eventLoopGroup = new SingleEventLoopGroup(eventLoop);
-
-        builder
-                .eventLoopGroup(eventLoopGroup)
-                .perRpcBufferLimit(128 * 1024 * 1024)
-                .channelType(grpcClientPolicy.channelType)
-                .negotiationType(NegotiationType.PLAINTEXT)
-
-                // Execute callbacks in the assigned event loop.
-                // GrpcChannelExecutor.iterate and all of GrpcStream works on
-                // this assumption.
-                .directExecutor()
-
-                // Retry logic is part of the client code.
-                .disableRetry()
-
-                // Server and client flow control policy should be in sync.
-                .flowControlWindow(2 * 1024 * 1024)
-
-                // TODO: is this beneficial? See https://github.com/grpc/grpc-java/issues/8260
-                //  for discussion.
-                // Enabling this feature create too many pings and the server
-                // sends GO_AWAY response.
-                // .initialFlowControlWindow(1024 * 1024)
-
-                // TODO: Should these be part of GrpcClientPolicy?
-                .keepAliveWithoutCalls(true)
-                .keepAliveTime(25, TimeUnit.SECONDS)
-                .keepAliveTimeout(1, TimeUnit.MINUTES);
-
-        if (grpcClientPolicy.tlsPolicy != null) {
-            builder.sslContext(getSslContext(grpcClientPolicy.tlsPolicy));
-            builder.negotiationType(NegotiationType.TLS);
-        } else {
-            builder.usePlaintext();
-        }
-
-        // For testing. Set this to force a hostname irrespective of the
-        // target IP for TLS verification. A simpler way than adding a DNS
-        // entry in the hosts file.
-        String authorityProperty =
-                System.getProperty(OVERRIDE_AUTHORITY);
-        if (authorityProperty != null && !authorityProperty.trim().isEmpty()) {
-            builder.overrideAuthority(authorityProperty);
-        }
-
-        //setting buffer size can improve I/O
-        builder.withOption(ChannelOption.SO_SNDBUF, 1048576);
-        builder.withOption(ChannelOption.SO_RCVBUF, 1048576);
-        builder.withOption(ChannelOption.TCP_NODELAY, true);
-        builder.withOption(ChannelOption.CONNECT_TIMEOUT_MILLIS,
-                grpcClientPolicy.connectTimeoutMillis);
-        builder.userAgent(AEROSPIKE_CLIENT_USER_AGENT);
-
-        // better to have a receive buffer predictor
-        //builder.withOption(ChannelOption.valueOf("receiveBufferSizePredictorFactory"), new AdaptiveReceiveBufferSizePredictorFactory(MIN_PACKET_SIZE, INITIAL_PACKET_SIZE, MAX_PACKET_SIZE))
-
-        //if the server is sending 1000 messages per sec, optimum write buffer watermarks will
-        //prevent unnecessary throttling, Check NioSocketChannelConfig doc
-        builder.withOption(ChannelOption.WRITE_BUFFER_WATER_MARK,
-                new WriteBufferWaterMark(32 * 1024, 64 * 1024));
-
-        ManagedChannel channel = builder.build();
-        // TODO: ensure it is a single threaded event loop.
-        return new ChannelAndEventLoop(channel, eventLoop);
-    }
-
-    private static SslContext getSslContext(TlsPolicy tlsPolicy) {
-        try {
-            SslContextBuilder sslContextBuilder = GrpcSslContexts.forClient();
-            Field field = sslContextBuilder.getClass().getDeclaredField("apn");
-            field.setAccessible(true);
-            ApplicationProtocolConfig apn = (ApplicationProtocolConfig) field.get(sslContextBuilder);
-            if (tlsPolicy.context != null) {
-                CipherSuiteFilter csf = (tlsPolicy.ciphers != null) ? (iterable, list, set) -> {
-                    if (tlsPolicy.ciphers != null) {
-                        return tlsPolicy.ciphers;
-                    }
-                    return tlsPolicy.context.getSupportedSSLParameters().getCipherSuites();
-                } : IdentityCipherSuiteFilter.INSTANCE;
-                return new JdkSslContext(tlsPolicy.context, true, null, csf, apn, ClientAuth.NONE, null, false);
-            }
-            SslContextBuilder builder = SslContextBuilder.forClient();
-            builder.applicationProtocolConfig(apn);
-            if (tlsPolicy.protocols != null) {
-                builder.protocols(tlsPolicy.protocols);
-            }
-
-            if (tlsPolicy.ciphers != null) {
-                builder.ciphers(Arrays.asList(tlsPolicy.ciphers));
-            }
-
-            String keyStoreLocation = System.getProperty("javax.net.ssl.keyStore");
-
-            // Keystore is only required for mutual authentication.
-            if (keyStoreLocation != null) {
-                String keyStorePassword = System.getProperty("javax.net.ssl.keyStorePassword");
-                char[] pass = (keyStorePassword != null) ? keyStorePassword.toCharArray() : null;
-
-                KeyStore ks = KeyStore.getInstance(KeyStore.getDefaultType());
-
-                try (FileInputStream is = new FileInputStream(keyStoreLocation)) {
-                    ks.load(is, pass);
-                }
-
-                KeyManagerFactory kmf = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
-                kmf.init(ks, pass);
-
-                builder.keyManager(kmf);
-            }
-            return builder.build();
-        } catch (Exception e) {
-            throw new AerospikeException("Failed to init netty TLS: " + Util.getErrorMessage(e));
-        }
-    }
-
-    public void execute(GrpcStreamingUnaryCall call) {
-        // TODO: add always succeeds?
-        ongoingRequests.getAndIncrement();
-        pendingCalls.add(call);
-    }
-
-    @Override
-    public void run() {
-        try {
-            iterate();
-        } catch (Exception e) {
-            // TODO: signal failure, close channel?
-        }
-    }
-
-    /**
-     * Process a single iteration.
-     */
-    private void iterate() {
-        // Schedule pending calls onto streams.
-        final int LIMIT =
-                grpcClientPolicy.maxConcurrentStreamsPerChannel * grpcClientPolicy.maxConcurrentRequestsPerStream;
-        pendingCalls.drain(this::scheduleCalls, LIMIT);
-
-        // Execute stream calls.
-        streams.values().forEach(GrpcStream::executeCall);
-
-        // Process closed streams.
-        closedStreams.drain(this::processClosedStream, LIMIT);
-    }
-
-    /**
-     * Schedule the call on a stream.
-     */
-    @SuppressWarnings("NonAtomicOperationOnVolatileField")
-    private void scheduleCalls(GrpcStreamingUnaryCall call) {
-        // Update stats.
-    	ByteString payload = call.getRequestPayload();
-        bytesSent += payload.size();
-        requestsSent++;
-
-        GrpcStream stream =
-                grpcClientPolicy.grpcStreamSelector.select(new ArrayList<>(streams.values()), call.getMethodDescriptor());
-        if (stream != null) {
-            // TODO: what if add fails
-            stream.enqueue(call);
-            return;
-        }
-
-        // Create new stream.
-        SpscUnboundedArrayQueue<GrpcStreamingUnaryCall> queue =
-                new SpscUnboundedArrayQueue<>(128);
-        queue.add(call);
-
-        scheduleCallsOnNewStream(call.getMethodDescriptor(), queue);
-    }
-
-    @SuppressWarnings("NonAtomicOperationOnVolatileField")
-    private void processClosedStream(GrpcStream grpcStream) {
-        if (!streams.containsKey(grpcStream.getId())) {
-            // Should never happen.
-            // TODO: throw Exception.
-            return;
-        }
-
-        streamsOpen--;
-        streamsClosed++;
-        streams.remove(grpcStream.getId());
-
-        if (grpcStream.getQueue().isEmpty()) {
-            // Do nothing.
-            return;
-        }
-
-        // Reuse same queue which has pending requests.
-        scheduleCallsOnNewStream(grpcStream.getMethodDescriptor(), grpcStream.getQueue());
-    }
-
-    /**
-     * Schedule calls in pendingCalls on a new stream.
-     */
-    @SuppressWarnings("NonAtomicOperationOnVolatileField")
-    private void scheduleCallsOnNewStream(MethodDescriptor<Kvs.AerospikeRequestPayload, Kvs.AerospikeResponsePayload> methodDescriptor,
-                                          SpscUnboundedArrayQueue<GrpcStreamingUnaryCall> pendingCalls) {
-        CallOptions options = grpcClientPolicy.callOptions;
-        if (authTokenManager != null) {
-            try {
-                options = authTokenManager.setCallCredentials(grpcClientPolicy.callOptions);
-            } catch (Exception e) {
-                AerospikeException aerospikeException =
-                        new AerospikeException(ResultCode.NOT_AUTHENTICATED, e);
-                for (GrpcStreamingUnaryCall call = pendingCalls.poll();
-                     call != null;
-                     call = pendingCalls.poll()) {
-                    call.onError(aerospikeException);
-                }
-
-                return;
-            }
-        }
-
-        // Error out all expired calls. When the proxy server is not
-        // reachable, the pendingCalls cycles between streams. The sequence
-        // of events are
-        // - a new stream is created with pendingCalls
-        // - asyncBidiStream creation on the new stream fails immediately,
-        // onError method on the new stream is invoked
-        // - the onError of the new stream calls GrpcChannelExecutor
-        // .onStreamClosed with the same pendingCalls
-        // - in the next call of GrpcChannelExecutor.processClosedStreams in
-        // a iteration the above steps are repeated again
-        SpscUnboundedArrayQueue<GrpcStreamingUnaryCall> activeCalls =
-                new SpscUnboundedArrayQueue<>(128);
-        for (GrpcStreamingUnaryCall call = pendingCalls.poll(); call != null;
-             call = pendingCalls.poll()) {
-            if (call.hasExpired()) {
-                call.onError(new AerospikeException.Timeout(call.getPolicy(),
-                        call.getIteration()));
-            } else {
-                activeCalls.add(call);
-            }
-        }
-
-        if (activeCalls.isEmpty()) {
-            return;
-        }
-
-        GrpcStream stream = GrpcStream.newInstance(this, methodDescriptor,
-                activeCalls, options, grpcClientPolicy, nextStreamId(), eventLoop);
-
-        streams.put(stream.getId(), stream);
-        streamsOpen++;
-    }
-
-    private int nextStreamId() {
-        return streamIdIndex.getAndIncrement();
-    }
-
-
-    private void setScheduledFuture(ScheduledFuture<?> future) {
-        this.iterateFuture = future;
-    }
-
-    @Override
-    public String toString() {
-        return "GrpcChannelExecutor{id=" + id + '}';
-    }
-
-
-    public void shutdown() {
-        if (isClosed.getAndSet(true)) {
-            return;
-        }
-
-    	// TODO FIX shutdown() hang!
-    	// Just call shutdownNow() instead?
-        //channel.shutdown();
-        channel.shutdownNow();
-
-        // Cancel iterations.
-        iterateFuture.cancel(false);
-    }
-
-    /**
-     * Should be called after a call to shut down.
-     */
-    public boolean awaitTermination(long terminationWaitMillis) {
-        final long startTime = System.nanoTime();
-        boolean interrupted = false;
-        boolean terminated = false;
-        do {
-            try {
-                terminated = channel.awaitTermination(terminationWaitMillis,
-                        TimeUnit.MILLISECONDS);
-                break;
-            } catch (InterruptedException e) {
-                interrupted = true;
-            }
-        } while (TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startTime) < terminationWaitMillis);
-
-
-        if (interrupted) {
-            Thread.currentThread().interrupt();
-        }
-        return terminated;
-    }
-
-    public long getId() {
-        return id;
-    }
-
-    public long getOngoingRequests() {
-        return ongoingRequests.get();
-    }
-
-    @SuppressWarnings("NonAtomicOperationOnVolatileField")
-    void responseReceived(int responsePayloadSize) {
-        bytesReceived += responsePayloadSize;
-        responsesReceived++;
-        ongoingRequests.getAndDecrement();
-    }
-
-    public long getBytesSent() {
-        return bytesSent;
-    }
-
-    public long getBytesReceived() {
-        return bytesReceived;
-    }
-
-    public long getRequestsSent() {
-        return requestsSent;
-    }
-
-    public long getResponsesReceived() {
-        return responsesReceived;
-    }
-
-    public long getStreamsClosed() {
-        return streamsClosed;
-    }
-
-    public void onStreamClosed(GrpcStream grpcStream) {
-        // TODO: will element always be added?
-        closedStreams.add(grpcStream);
-    }
-
-    public ManagedChannel getChannel() {
-        return channel;
-    }
-
-    public EventLoop getEventLoop() {
-        return eventLoop;
-    }
-
-    public long getStreamsOpen() {
-        return streamsOpen;
-    }
-
-    private static class ChannelAndEventLoop {
-        final ManagedChannel managedChannel;
-        final EventLoop eventLoop;
-
-        private ChannelAndEventLoop(ManagedChannel managedChannel, EventLoop eventLoop) {
-            this.managedChannel = managedChannel;
-            this.eventLoop = eventLoop;
-        }
-    }
+	/**
+	 * System property to configure gRPC override authority used as hostname
+	 * in TLS verification of the proxy server.
+	 */
+	public static final String OVERRIDE_AUTHORITY = "com.aerospike.client" +
+			".overrideAuthority";
+
+	private static final String AEROSPIKE_CLIENT_USER_AGENT =
+			"AerospikeClientJava/" + AerospikeClientProxy.Version;
+	/**
+	 * The delay between iterations of this executor.
+	 * <p>
+	 * TODO: how to select interval of execution?
+	 */
+	private static final long ITERATION_DELAY_MICROS = 250;
+	/**
+	 * Unique executor ids.
+	 */
+	private static final AtomicLong executorIdIndex = new AtomicLong();
+	private static final AtomicInteger streamIdIndex = new AtomicInteger();
+
+	/**
+	 * The HTTP/2 channel of this executor.
+	 */
+	private final ManagedChannel channel;
+	/**
+	 * The Aerospike gRPC client policy.
+	 */
+	private final GrpcClientPolicy grpcClientPolicy;
+	/**
+	 * The auth token manager.
+	 */
+	private final AuthTokenManager authTokenManager;
+	/**
+	 * The event loop bound to the <code>channel</code>. All queued requests
+	 * will be executed on this event loop. Some requests will be queued on
+	 * this channel in the gRPC callback and some from the pending queue.
+	 */
+	private final EventLoop eventLoop;
+	/**
+	 * Queued unary calls awaiting execution.
+	 */
+	private final MpscUnboundedArrayQueue<GrpcStreamingUnaryCall> pendingCalls =
+			new MpscUnboundedArrayQueue<>(32);
+	/**
+	 * Queue of closed streams.
+	 */
+	private final MpscUnboundedArrayQueue<GrpcStream> closedStreams =
+			new MpscUnboundedArrayQueue<>(32);
+	/**
+	 * Map of stream id to streams.
+	 */
+	private final Map<Integer, GrpcStream> streams = new HashMap<>();
+	/**
+	 * Indicates if this executor is shutdown.
+	 */
+	private final AtomicBoolean isClosed = new AtomicBoolean(false);
+	/**
+	 * Unique id of the executor.
+	 */
+	private final long id;
+	// Statistics.
+	private final AtomicLong ongoingRequests = new AtomicLong();
+	/**
+	 * The future to cancel the scheduled iteration of this executor.
+	 */
+	private ScheduledFuture<?> iterateFuture;
+	// These are only accessed from the event loop thread
+	// assigned to this channel
+	private volatile long bytesSent;
+	private volatile long bytesReceived;
+	private volatile long requestsSent;
+	private volatile long responsesReceived;
+	private volatile long streamsOpen;
+	private volatile long streamsClosed;
+
+	private GrpcChannelExecutor(ManagedChannel channel,
+								GrpcClientPolicy grpcClientPolicy,
+								@Nullable AuthTokenManager authTokenManager,
+								EventLoop eventLoop, long id) {
+		if (channel == null) {
+			throw new NullPointerException("channel");
+		}
+		if (eventLoop == null) {
+			throw new NullPointerException("eventLoop");
+		}
+		if (grpcClientPolicy == null) {
+			throw new NullPointerException("grpcClientPolicy");
+		}
+
+		this.authTokenManager = authTokenManager;
+		this.channel = channel;
+		this.eventLoop = eventLoop;
+		this.grpcClientPolicy = grpcClientPolicy;
+		this.id = id;
+	}
+
+	public static GrpcChannelExecutor newInstance(GrpcClientPolicy grpcClientPolicy,
+												  @Nullable AuthTokenManager authTokenManager,
+												  Host... hosts) {
+		if (grpcClientPolicy == null) {
+			throw new NullPointerException("grpcClientPolicy");
+		}
+		if (hosts == null || hosts.length == 0) {
+			throw new IllegalArgumentException("hosts should be non-empty");
+		}
+
+		ChannelAndEventLoop channelAndEventLoop = createGrpcChannel(grpcClientPolicy, hosts);
+		GrpcChannelExecutor executor =
+				new GrpcChannelExecutor(channelAndEventLoop.managedChannel,
+						grpcClientPolicy, authTokenManager, channelAndEventLoop.eventLoop,
+						executorIdIndex.getAndIncrement());
+
+		ScheduledFuture<?> future = channelAndEventLoop.eventLoop.scheduleAtFixedRate(executor, 0,
+				ITERATION_DELAY_MICROS, TimeUnit.MICROSECONDS);
+		executor.setScheduledFuture(future);
+
+		return executor;
+	}
+
+	/**
+	 * Create a gRPC channel.
+	 */
+	@SuppressWarnings("deprecation")
+	private static ChannelAndEventLoop createGrpcChannel(GrpcClientPolicy grpcClientPolicy,
+														 Host[] hosts) {
+		NettyChannelBuilder builder;
+
+		if (hosts.length == 1) {
+			builder = NettyChannelBuilder.forAddress(hosts[0].name, hosts[0].port);
+		}
+		else {
+			// Setup round-robin load balancing.
+			NameResolver.Factory nameResolverFactory = new MultiAddressNameResolverFactory(
+					Arrays.stream(hosts)
+							.map((host) -> new InetSocketAddress(host.name, host.port))
+							.collect(
+									Collectors.<SocketAddress>toList()));
+			builder = NettyChannelBuilder.forTarget(String.format("%s:%d",
+					hosts[0].name, hosts[0].port));
+			builder.nameResolverFactory(nameResolverFactory);
+			builder.defaultLoadBalancingPolicy("round_robin");
+		}
+
+		EventLoop eventLoop = grpcClientPolicy.nextEventLoop();
+		EventLoopGroup eventLoopGroup = new SingleEventLoopGroup(eventLoop);
+
+		builder
+				.eventLoopGroup(eventLoopGroup)
+				.perRpcBufferLimit(128 * 1024 * 1024)
+				.channelType(grpcClientPolicy.channelType)
+				.negotiationType(NegotiationType.PLAINTEXT)
+
+				// Execute callbacks in the assigned event loop.
+				// GrpcChannelExecutor.iterate and all of GrpcStream works on
+				// this assumption.
+				.directExecutor()
+
+				// Retry logic is part of the client code.
+				.disableRetry()
+
+				// Server and client flow control policy should be in sync.
+				.flowControlWindow(2 * 1024 * 1024)
+
+				// TODO: is this beneficial? See https://github.com/grpc/grpc-java/issues/8260
+				//  for discussion.
+				// Enabling this feature create too many pings and the server
+				// sends GO_AWAY response.
+				// .initialFlowControlWindow(1024 * 1024)
+
+				// TODO: Should these be part of GrpcClientPolicy?
+				.keepAliveWithoutCalls(true)
+				.keepAliveTime(25, TimeUnit.SECONDS)
+				.keepAliveTimeout(1, TimeUnit.MINUTES);
+
+		if (grpcClientPolicy.tlsPolicy != null) {
+			builder.sslContext(getSslContext(grpcClientPolicy.tlsPolicy));
+			builder.negotiationType(NegotiationType.TLS);
+		}
+		else {
+			builder.usePlaintext();
+		}
+
+		// For testing. Set this to force a hostname irrespective of the
+		// target IP for TLS verification. A simpler way than adding a DNS
+		// entry in the hosts file.
+		String authorityProperty =
+				System.getProperty(OVERRIDE_AUTHORITY);
+		if (authorityProperty != null && !authorityProperty.trim().isEmpty()) {
+			builder.overrideAuthority(authorityProperty);
+		}
+
+		//setting buffer size can improve I/O
+		builder.withOption(ChannelOption.SO_SNDBUF, 1048576);
+		builder.withOption(ChannelOption.SO_RCVBUF, 1048576);
+		builder.withOption(ChannelOption.TCP_NODELAY, true);
+		builder.withOption(ChannelOption.CONNECT_TIMEOUT_MILLIS,
+				grpcClientPolicy.connectTimeoutMillis);
+		builder.userAgent(AEROSPIKE_CLIENT_USER_AGENT);
+
+		// better to have a receive buffer predictor
+		//builder.withOption(ChannelOption.valueOf("receiveBufferSizePredictorFactory"), new AdaptiveReceiveBufferSizePredictorFactory(MIN_PACKET_SIZE, INITIAL_PACKET_SIZE, MAX_PACKET_SIZE))
+
+		//if the server is sending 1000 messages per sec, optimum write buffer watermarks will
+		//prevent unnecessary throttling, Check NioSocketChannelConfig doc
+		builder.withOption(ChannelOption.WRITE_BUFFER_WATER_MARK,
+				new WriteBufferWaterMark(32 * 1024, 64 * 1024));
+
+		ManagedChannel channel = builder.build();
+		// TODO: ensure it is a single threaded event loop.
+		return new ChannelAndEventLoop(channel, eventLoop);
+	}
+
+	private static SslContext getSslContext(TlsPolicy tlsPolicy) {
+		try {
+			SslContextBuilder sslContextBuilder = GrpcSslContexts.forClient();
+			Field field = sslContextBuilder.getClass().getDeclaredField("apn");
+			field.setAccessible(true);
+			ApplicationProtocolConfig apn = (ApplicationProtocolConfig)field.get(sslContextBuilder);
+			if (tlsPolicy.context != null) {
+				CipherSuiteFilter csf = (tlsPolicy.ciphers != null) ? (iterable, list, set) -> {
+					if (tlsPolicy.ciphers != null) {
+						return tlsPolicy.ciphers;
+					}
+					return tlsPolicy.context.getSupportedSSLParameters().getCipherSuites();
+				} : IdentityCipherSuiteFilter.INSTANCE;
+				return new JdkSslContext(tlsPolicy.context, true, null, csf, apn, ClientAuth.NONE, null, false);
+			}
+			SslContextBuilder builder = SslContextBuilder.forClient();
+			builder.applicationProtocolConfig(apn);
+			if (tlsPolicy.protocols != null) {
+				builder.protocols(tlsPolicy.protocols);
+			}
+
+			if (tlsPolicy.ciphers != null) {
+				builder.ciphers(Arrays.asList(tlsPolicy.ciphers));
+			}
+
+			String keyStoreLocation = System.getProperty("javax.net.ssl.keyStore");
+
+			// Keystore is only required for mutual authentication.
+			if (keyStoreLocation != null) {
+				String keyStorePassword = System.getProperty("javax.net.ssl.keyStorePassword");
+				char[] pass = (keyStorePassword != null) ? keyStorePassword.toCharArray() : null;
+
+				KeyStore ks = KeyStore.getInstance(KeyStore.getDefaultType());
+
+				try (FileInputStream is = new FileInputStream(keyStoreLocation)) {
+					ks.load(is, pass);
+				}
+
+				KeyManagerFactory kmf = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+				kmf.init(ks, pass);
+
+				builder.keyManager(kmf);
+			}
+			return builder.build();
+		}
+		catch (Exception e) {
+			throw new AerospikeException("Failed to init netty TLS: " + Util.getErrorMessage(e));
+		}
+	}
+
+	public void execute(GrpcStreamingUnaryCall call) {
+		// TODO: add always succeeds?
+		ongoingRequests.getAndIncrement();
+		pendingCalls.add(call);
+	}
+
+	@Override
+	public void run() {
+		try {
+			iterate();
+		}
+		catch (Exception e) {
+			// TODO: signal failure, close channel?
+		}
+	}
+
+	/**
+	 * Process a single iteration.
+	 */
+	private void iterate() {
+		// Schedule pending calls onto streams.
+		final int LIMIT =
+				grpcClientPolicy.maxConcurrentStreamsPerChannel * grpcClientPolicy.maxConcurrentRequestsPerStream;
+		pendingCalls.drain(this::scheduleCalls, LIMIT);
+
+		// Execute stream calls.
+		streams.values().forEach(GrpcStream::executeCall);
+
+		// Process closed streams.
+		closedStreams.drain(this::processClosedStream, LIMIT);
+	}
+
+	/**
+	 * Schedule the call on a stream.
+	 */
+	@SuppressWarnings("NonAtomicOperationOnVolatileField")
+	private void scheduleCalls(GrpcStreamingUnaryCall call) {
+		// Update stats.
+		ByteString payload = call.getRequestPayload();
+		bytesSent += payload.size();
+		requestsSent++;
+
+		GrpcStream stream =
+				grpcClientPolicy.grpcStreamSelector.select(new ArrayList<>(streams.values()), call.getStreamingMethodDescriptor());
+		if (stream != null) {
+			// TODO: what if add fails
+			stream.enqueue(call);
+			return;
+		}
+
+		// Create new stream.
+		SpscUnboundedArrayQueue<GrpcStreamingUnaryCall> queue =
+				new SpscUnboundedArrayQueue<>(128);
+		queue.add(call);
+
+		scheduleCallsOnNewStream(call.getStreamingMethodDescriptor(), queue);
+	}
+
+	@SuppressWarnings("NonAtomicOperationOnVolatileField")
+	private void processClosedStream(GrpcStream grpcStream) {
+		if (!streams.containsKey(grpcStream.getId())) {
+			// Should never happen.
+			// TODO: throw Exception.
+			return;
+		}
+
+		streamsOpen--;
+		streamsClosed++;
+		streams.remove(grpcStream.getId());
+
+		if (grpcStream.getQueue().isEmpty()) {
+			// Do nothing.
+			return;
+		}
+
+		// Reuse same queue which has pending requests.
+		scheduleCallsOnNewStream(grpcStream.getMethodDescriptor(), grpcStream.getQueue());
+	}
+
+	/**
+	 * Schedule calls in pendingCalls on a new stream.
+	 */
+	@SuppressWarnings("NonAtomicOperationOnVolatileField")
+	private void scheduleCallsOnNewStream(MethodDescriptor<Kvs.AerospikeRequestPayload, Kvs.AerospikeResponsePayload> methodDescriptor,
+										  SpscUnboundedArrayQueue<GrpcStreamingUnaryCall> pendingCalls) {
+		CallOptions options = grpcClientPolicy.callOptions;
+		if (authTokenManager != null) {
+			try {
+				options = authTokenManager.setCallCredentials(grpcClientPolicy.callOptions);
+			}
+			catch (Exception e) {
+				AerospikeException aerospikeException =
+						new AerospikeException(ResultCode.NOT_AUTHENTICATED, e);
+				for (GrpcStreamingUnaryCall call = pendingCalls.poll();
+					 call != null;
+					 call = pendingCalls.poll()) {
+					call.onError(aerospikeException);
+				}
+
+				return;
+			}
+		}
+
+		// Error out all expired calls. When the proxy server is not
+		// reachable, the pendingCalls cycles between streams. The sequence
+		// of events are
+		// - a new stream is created with pendingCalls
+		// - asyncBidiStream creation on the new stream fails immediately,
+		// onError method on the new stream is invoked
+		// - the onError of the new stream calls GrpcChannelExecutor
+		// .onStreamClosed with the same pendingCalls
+		// - in the next call of GrpcChannelExecutor.processClosedStreams in
+		// an iteration the above steps repeat
+		SpscUnboundedArrayQueue<GrpcStreamingUnaryCall> activeCalls =
+				new SpscUnboundedArrayQueue<>(128);
+		for (GrpcStreamingUnaryCall call = pendingCalls.poll(); call != null;
+			 call = pendingCalls.poll()) {
+			if (call.hasExpired()) {
+				call.onError(new AerospikeException.Timeout(call.getPolicy(),
+						call.getIteration()));
+			}
+			else {
+				activeCalls.add(call);
+			}
+		}
+
+		if (activeCalls.isEmpty()) {
+			return;
+		}
+
+		GrpcStream stream = GrpcStream.newInstance(this, methodDescriptor,
+				activeCalls, options, grpcClientPolicy, nextStreamId(), eventLoop);
+
+		streams.put(stream.getId(), stream);
+		streamsOpen++;
+	}
+
+	private int nextStreamId() {
+		return streamIdIndex.getAndIncrement();
+	}
+
+
+	private void setScheduledFuture(ScheduledFuture<?> future) {
+		this.iterateFuture = future;
+	}
+
+	@Override
+	public String toString() {
+		return "GrpcChannelExecutor{id=" + id + '}';
+	}
+
+
+	public void shutdown() {
+		if (isClosed.getAndSet(true)) {
+			return;
+		}
+
+		// TODO FIX shutdown() hang!
+		// Just call shutdownNow() instead?
+		//channel.shutdown();
+		channel.shutdownNow();
+
+		// Cancel iterations.
+		iterateFuture.cancel(false);
+	}
+
+	/**
+	 * Should be called after a call to shut down.
+	 */
+	public boolean awaitTermination(long terminationWaitMillis) {
+		final long startTime = System.nanoTime();
+		boolean interrupted = false;
+		boolean terminated = false;
+		do {
+			try {
+				terminated = channel.awaitTermination(terminationWaitMillis,
+						TimeUnit.MILLISECONDS);
+				break;
+			}
+			catch (InterruptedException e) {
+				interrupted = true;
+			}
+		} while (TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startTime) < terminationWaitMillis);
+
+
+		if (interrupted) {
+			Thread.currentThread().interrupt();
+		}
+		return terminated;
+	}
+
+	public long getId() {
+		return id;
+	}
+
+	public long getOngoingRequests() {
+		return ongoingRequests.get();
+	}
+
+	@SuppressWarnings("NonAtomicOperationOnVolatileField")
+	void responseReceived(int responsePayloadSize) {
+		bytesReceived += responsePayloadSize;
+		responsesReceived++;
+		ongoingRequests.getAndDecrement();
+	}
+
+	public long getBytesSent() {
+		return bytesSent;
+	}
+
+	public long getBytesReceived() {
+		return bytesReceived;
+	}
+
+	public long getRequestsSent() {
+		return requestsSent;
+	}
+
+	public long getResponsesReceived() {
+		return responsesReceived;
+	}
+
+	public long getStreamsClosed() {
+		return streamsClosed;
+	}
+
+	public void onStreamClosed(GrpcStream grpcStream) {
+		// TODO: will element always be added?
+		closedStreams.add(grpcStream);
+	}
+
+	public ManagedChannel getChannel() {
+		return channel;
+	}
+
+	public EventLoop getEventLoop() {
+		return eventLoop;
+	}
+
+	public long getStreamsOpen() {
+		return streamsOpen;
+	}
+
+	private static class ChannelAndEventLoop {
+		final ManagedChannel managedChannel;
+		final EventLoop eventLoop;
+
+		private ChannelAndEventLoop(ManagedChannel managedChannel, EventLoop eventLoop) {
+			this.managedChannel = managedChannel;
+			this.eventLoop = eventLoop;
+		}
+	}
 }

--- a/proxy/src/com/aerospike/client/proxy/grpc/GrpcClientPolicy.java
+++ b/proxy/src/com/aerospike/client/proxy/grpc/GrpcClientPolicy.java
@@ -1,5 +1,11 @@
 package com.aerospike.client.proxy.grpc;
 
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+import javax.annotation.Nullable;
+
 import com.aerospike.client.policy.TlsPolicy;
 import io.grpc.CallOptions;
 import io.netty.channel.Channel;
@@ -12,348 +18,326 @@ import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.nio.NioSocketChannel;
 import io.netty.util.concurrent.DefaultThreadFactory;
 
-import javax.annotation.Nullable;
-import java.util.List;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.stream.Collectors;
-import java.util.stream.StreamSupport;
-
 /**
- * gRPC Aerospike proxy client policy. All of the knobs and configs that
+ * gRPC Aerospike proxy client policy. All the knobs and configs that
  * affect the working of the gRPC proxy client are combined into this policy
  * object.
  */
 public class GrpcClientPolicy {
-    /**
-     * The event loops to process the gRPC HTTP/2 requests.
-     */
-    public final List<EventLoop> eventLoops;
+	/**
+	 * The event loops to process the gRPC HTTP/2 requests.
+	 */
+	public final List<EventLoop> eventLoops;
 
-    /**
-     * The type of the eventLoops.
-     */
-    public final Class<? extends Channel> channelType;
-    /**
-     * Should the event loops be closed in close.
-     */
-    public final boolean closeEventLoops;
-    /**
-     * Maximum number of HTTP/2 channels (connections) to open to the Aerospike
-     * gRPC proxy server.
-     *
-     * <p>
-     * Generally HTTP/2 based gRPC recommends a single channel to be
-     * sufficient for most purposes. In our performance experiments we have
-     * found that any number greater than <code>8</code> yields no extra
-     * performance gains.
-     */
-    public final int maxChannels;
-    /**
-     * Maximum number of concurrent HTTP/2 streams to have in-flight per HTTP/2
-     * channel (connection).
-     *
-     * <p>
-     * Generally HTTP/2 servers restrict the number of concurrent HTTP/2 streams
-     * to about a <code>100</code> on a channel (connection).
-     */
-    public final int maxConcurrentStreamsPerChannel;
-    /**
-     * Maximum number of concurrent requests that are in-flight per streaming
-     * HTTP/2 call.
-     *
-     * <p>
-     * The Aerospike gRPC proxy server implements streaming for unary calls
-     * like Aerospike get, put, operate, etc to improve latency and throughput.
-     * <code>maxConcurrentRequestsPerStream</code> specifies the number of
-     * concurrent requests that can be sent on a single unary call based stream.
-     * <p/>
-     * <bold>NOTE</bold> This policy does not apply to queries, scans, etc.
-     */
-    public final int maxConcurrentRequestsPerStream;
-    /**
-     * Total number of HTTP/2 requests that are sent on a stream, after which
-     * the stream is closed.
-     *
-     * <p>
-     * The Aerospike gRPC proxy server implements streaming for unary calls
-     * like Aerospike get, put, operate, etc to improve latency and throughput.
-     * <code>totalRequestsPerStream</code> specifies the total number of
-     * requests that are sent on the stream, after which the stream is closed.
-     *
-     * <p>
-     * Requests to the Aerospike gRPC proxy server will be routed through a
-     * HTTP/2 load balancer over the public internet. HTTP/2 load balancer
-     * splits requests on a single HTTP/2 channel (connection) across the proxy
-     * servers, but it will send all requests on a HTTP/2 stream to a single
-     * gRPC Aerospike proxy server. This policy ensures that the requests are
-     * evenly load balanced across the gRPC Aerospike proxy servers.
-     * <p/>
-     * <bold>NOTE</bold> This policy does not apply to queries, scans, etc.
-     */
-    public final int totalRequestsPerStream;
-    /**
-     * The connection timeout in milliseconds when creating a new HTTP/2
-     * channel (connection) to a gRPC Aerospike proxy server.
-     */
-    public final int connectTimeoutMillis;
-    /**
-     * Strategy to select a channel for a gRPC request.
-     */
+	/**
+	 * The type of the eventLoops.
+	 */
+	public final Class<? extends Channel> channelType;
+	/**
+	 * Should the event loops be closed in close.
+	 */
+	public final boolean closeEventLoops;
+	/**
+	 * Maximum number of HTTP/2 channels (connections) to open to the Aerospike
+	 * gRPC proxy server.
+	 *
+	 * <p>
+	 * Generally HTTP/2 based gRPC recommends a single channel to be
+	 * sufficient for most purposes. In our performance experiments we have
+	 * found that any number greater than <code>8</code> yields no extra
+	 * performance gains.
+	 */
+	public final int maxChannels;
+	/**
+	 * Maximum number of concurrent HTTP/2 streams to have in-flight per HTTP/2
+	 * channel (connection).
+	 *
+	 * <p>
+	 * Generally HTTP/2 servers restrict the number of concurrent HTTP/2 streams
+	 * to about a <code>100</code> on a channel (connection).
+	 */
+	public final int maxConcurrentStreamsPerChannel;
+	/**
+	 * Maximum number of concurrent requests that are in-flight per streaming
+	 * HTTP/2 call.
+	 *
+	 * <p>
+	 * The Aerospike gRPC proxy server implements streaming for unary calls
+	 * like Aerospike get, put, operate, etc to improve latency and throughput.
+	 * <code>maxConcurrentRequestsPerStream</code> specifies the number of
+	 * concurrent requests that can be sent on a single unary call based stream.
+	 * <p/>
+	 * <bold>NOTE</bold> This policy does not apply to queries, scans, etc.
+	 */
+	public final int maxConcurrentRequestsPerStream;
+	/**
+	 * Total number of HTTP/2 requests that are sent on a stream, after which
+	 * the stream is closed.
+	 *
+	 * <p>
+	 * The Aerospike gRPC proxy server implements streaming for unary calls
+	 * like Aerospike get, put, operate, etc to improve latency and throughput.
+	 * <code>totalRequestsPerStream</code> specifies the total number of
+	 * requests that are sent on the stream, after which the stream is closed.
+	 *
+	 * <p>
+	 * Requests to the Aerospike gRPC proxy server will be routed through a
+	 * HTTP/2 load balancer over the public internet. HTTP/2 load balancer
+	 * splits requests on a single HTTP/2 channel (connection) across the proxy
+	 * servers, but it will send all requests on a HTTP/2 stream to a single
+	 * gRPC Aerospike proxy server. This policy ensures that the requests are
+	 * evenly load balanced across the gRPC Aerospike proxy servers.
+	 * <p/>
+	 * <bold>NOTE</bold> This policy does not apply to queries, scans, etc.
+	 */
+	public final int totalRequestsPerStream;
+	/**
+	 * The connection timeout in milliseconds when creating a new HTTP/2
+	 * channel (connection) to a gRPC Aerospike proxy server.
+	 */
+	public final int connectTimeoutMillis;
+	/**
+	 * Strategy to select a channel for a gRPC request.
+	 */
 
-    public final GrpcChannelSelector grpcChannelSelector;
-    /**
-     * Strategy to select a stream for a gRPC request.
-     */
+	public final GrpcChannelSelector grpcChannelSelector;
+	/**
+	 * Strategy to select a stream for a gRPC request.
+	 */
 
-    public final GrpcStreamSelector grpcStreamSelector;
-    /**
-     * Call options.
-     */
+	public final GrpcStreamSelector grpcStreamSelector;
+	/**
+	 * Call options.
+	 */
 
-    public final CallOptions callOptions;
-    /**
-     * The TLS policy to connect to the gRPC Aerospike proxy server.
-     * <p/>
-     * <bold>NOTE</bold> The channel (connection) will  be non-encrypted if
-     * this policy is <code>null</code>.
-     */
-    @Nullable
-    public final TlsPolicy tlsPolicy;
-    /**
-     * Milliseconds to wait for termination of the channels. Should be
-     * greater than the deadlines. The implementation is best-effort, its
-     * possible termination takes more time than this.
-     */
-    public final long terminationWaitMillis;
-    /**
-     * Index to get the next event loop.
-     */
-    private final AtomicInteger eventLoopIndex = new AtomicInteger(0);
+	public final CallOptions callOptions;
+	/**
+	 * The TLS policy to connect to the gRPC Aerospike proxy server.
+	 * <p/>
+	 * <bold>NOTE</bold> The channel (connection) will  be non-encrypted if
+	 * this policy is <code>null</code>.
+	 */
+	@Nullable
+	public final TlsPolicy tlsPolicy;
+	/**
+	 * Milliseconds to wait for termination of the channels. Should be
+	 * greater than the deadlines. The implementation is best-effort, its
+	 * possible termination takes more time than this.
+	 */
+	public final long terminationWaitMillis;
+	/**
+	 * Index to get the next event loop.
+	 */
+	private final AtomicInteger eventLoopIndex = new AtomicInteger(0);
 
-    private GrpcClientPolicy(int maxChannels,
-                             int maxConcurrentStreamsPerChannel,
-                             int maxConcurrentRequestsPerStream,
-                             int totalRequestsPerStream,
-                             int connectTimeoutMillis,
-                             long terminationWaitMillis,
-                             GrpcChannelSelector grpcChannelSelector,
-                             GrpcStreamSelector grpcStreamSelector,
-                             CallOptions callOptions,
-                             List<EventLoop> eventLoops,
-                             Class<? extends Channel> channelType,
-                             boolean closeEventLoops,
-                             @Nullable TlsPolicy tlsPolicy) {
-        this.maxChannels = maxChannels;
-        this.maxConcurrentStreamsPerChannel = maxConcurrentStreamsPerChannel;
-        this.maxConcurrentRequestsPerStream = maxConcurrentRequestsPerStream;
-        this.totalRequestsPerStream = totalRequestsPerStream;
-        this.connectTimeoutMillis = connectTimeoutMillis;
-        this.terminationWaitMillis = terminationWaitMillis;
-        this.grpcChannelSelector = grpcChannelSelector;
-        this.grpcStreamSelector = grpcStreamSelector;
-        this.callOptions = callOptions;
-        this.eventLoops = eventLoops;
-        this.channelType = channelType;
-        this.closeEventLoops = closeEventLoops;
-        this.tlsPolicy = tlsPolicy;
-    }
+	private GrpcClientPolicy(int maxChannels,
+							 int maxConcurrentStreamsPerChannel,
+							 int maxConcurrentRequestsPerStream,
+							 int totalRequestsPerStream,
+							 int connectTimeoutMillis,
+							 long terminationWaitMillis,
+							 GrpcChannelSelector grpcChannelSelector,
+							 GrpcStreamSelector grpcStreamSelector,
+							 CallOptions callOptions,
+							 List<EventLoop> eventLoops,
+							 Class<? extends Channel> channelType,
+							 boolean closeEventLoops,
+							 @Nullable TlsPolicy tlsPolicy) {
+		this.maxChannels = maxChannels;
+		this.maxConcurrentStreamsPerChannel = maxConcurrentStreamsPerChannel;
+		this.maxConcurrentRequestsPerStream = maxConcurrentRequestsPerStream;
+		this.totalRequestsPerStream = totalRequestsPerStream;
+		this.connectTimeoutMillis = connectTimeoutMillis;
+		this.terminationWaitMillis = terminationWaitMillis;
+		this.grpcChannelSelector = grpcChannelSelector;
+		this.grpcStreamSelector = grpcStreamSelector;
+		this.callOptions = callOptions;
+		this.eventLoops = eventLoops;
+		this.channelType = channelType;
+		this.closeEventLoops = closeEventLoops;
+		this.tlsPolicy = tlsPolicy;
+	}
 
-    public static Builder newBuilder(@Nullable List<EventLoop> eventLoops,
-                                     @Nullable Class<? extends Channel> channelType) {
-        Builder builder = new Builder();
+	public static Builder newBuilder(@Nullable List<EventLoop> eventLoops,
+									 @Nullable Class<? extends Channel> channelType) {
+		Builder builder = new Builder();
 
-        if (eventLoops == null || channelType == null) {
-            builder.closeEventLoops = true;
+		if (eventLoops == null || channelType == null) {
+			builder.closeEventLoops = true;
 
-            DefaultThreadFactory tf =
-                    new DefaultThreadFactory("aerospike-proxy", true /*daemon */);
+			DefaultThreadFactory tf =
+					new DefaultThreadFactory("aerospike-proxy", true /*daemon */);
 
-            // TODO: select number of event loop threads?
-            EventLoopGroup eventLoopGroup;
-            if (Epoll.isAvailable()) {
-                eventLoopGroup = new EpollEventLoopGroup(0, tf);
-                builder.channelType = EpollSocketChannel.class;
-            } else {
-                eventLoopGroup = new NioEventLoopGroup(0, tf);
-                builder.channelType = NioSocketChannel.class;
-            }
+			// TODO: select number of event loop threads?
+			EventLoopGroup eventLoopGroup;
+			if (Epoll.isAvailable()) {
+				eventLoopGroup = new EpollEventLoopGroup(0, tf);
+				builder.channelType = EpollSocketChannel.class;
+			}
+			else {
+				eventLoopGroup = new NioEventLoopGroup(0, tf);
+				builder.channelType = NioSocketChannel.class;
+			}
 
-            builder.eventLoops = StreamSupport.stream(eventLoopGroup.spliterator(),
-                            false)
-                    .map(eventExecutor -> (EventLoop) eventExecutor)
-                    .collect(Collectors.toList());
-        } else {
-            builder.channelType = channelType;
-            builder.eventLoops = eventLoops;
-            builder.closeEventLoops = false;
-        }
+			builder.eventLoops = StreamSupport.stream(eventLoopGroup.spliterator(),
+							false)
+					.map(eventExecutor -> (EventLoop)eventExecutor)
+					.collect(Collectors.toList());
+		}
+		else {
+			builder.channelType = channelType;
+			builder.eventLoops = eventLoops;
+			builder.closeEventLoops = false;
+		}
 
-        // TODO: justify defaults.
-        builder.maxChannels = 8;
+		// TODO: justify defaults.
+		builder.maxChannels = 8;
 
-        // Multiple requests should be sent on a stream at once to enhance
-        // performance. So `maxConcurrentRequestsPerStream` should be the
-        // ideal batch size of the requests.
-        // TODO: maybe these parameters depend on the payload size?
-        builder.maxConcurrentStreamsPerChannel = 8;
-        builder.maxConcurrentRequestsPerStream = builder.totalRequestsPerStream = 128;
+		// Multiple requests should be sent on a stream at once to enhance
+		// performance. So `maxConcurrentRequestsPerStream` should be the
+		// ideal batch size of the requests.
+		// TODO: maybe these parameters depend on the payload size?
+		builder.maxConcurrentStreamsPerChannel = 8;
+		builder.maxConcurrentRequestsPerStream = builder.totalRequestsPerStream = 128;
 
-        builder.connectTimeoutMillis = 5000;
-        builder.terminationWaitMillis = 30000;
+		builder.connectTimeoutMillis = 5000;
+		builder.terminationWaitMillis = 30000;
 
-        builder.tlsPolicy = null;
-        return builder;
-    }
+		builder.tlsPolicy = null;
+		return builder;
+	}
 
-    public static Builder newBuilder(GrpcClientPolicy other) {
-        Builder builder = new Builder();
-        builder.closeEventLoops = other.closeEventLoops;
-        builder.maxChannels = other.maxChannels;
-        builder.maxConcurrentStreamsPerChannel = other.maxConcurrentStreamsPerChannel;
-        builder.maxConcurrentRequestsPerStream = other.maxConcurrentRequestsPerStream;
-        builder.totalRequestsPerStream = other.totalRequestsPerStream;
-        builder.connectTimeoutMillis = other.connectTimeoutMillis;
-        builder.terminationWaitMillis = other.terminationWaitMillis;
-        builder.eventLoops = other.eventLoops;
-        builder.channelType = other.channelType;
-        builder.tlsPolicy = other.tlsPolicy;
-        builder.grpcChannelSelector = other.grpcChannelSelector;
-        builder.grpcStreamSelector = other.grpcStreamSelector;
-        builder.callOptions = other.callOptions;
-        return builder;
-    }
+	public EventLoop nextEventLoop() {
+		int i = eventLoopIndex.getAndIncrement() % eventLoops.size();
+		return eventLoops.get(i);
+	}
 
-    public EventLoop nextEventLoop() {
-        int i = eventLoopIndex.getAndIncrement() % eventLoops.size();
-        return eventLoops.get(i);
-    }
+	public static class Builder {
+		private List<EventLoop> eventLoops;
+		private Class<? extends Channel> channelType;
+		private boolean closeEventLoops;
+		private int maxChannels;
+		private int maxConcurrentStreamsPerChannel;
+		private int maxConcurrentRequestsPerStream;
+		private int totalRequestsPerStream;
+		private int connectTimeoutMillis;
+		@Nullable
+		private TlsPolicy tlsPolicy;
+		@Nullable
+		private GrpcChannelSelector grpcChannelSelector;
+		@Nullable
+		private GrpcStreamSelector grpcStreamSelector;
+		@Nullable
+		private CallOptions callOptions;
+		private long terminationWaitMillis;
 
-    public static class Builder {
-        private List<EventLoop> eventLoops;
-        private Class<? extends Channel> channelType;
-        private boolean closeEventLoops;
-        private int maxChannels;
-        private int maxConcurrentStreamsPerChannel;
-        private int maxConcurrentRequestsPerStream;
-        private int totalRequestsPerStream;
-        private int connectTimeoutMillis;
-        @Nullable
-        private TlsPolicy tlsPolicy;
-        @Nullable
-        private GrpcChannelSelector grpcChannelSelector;
-        @Nullable
-        private GrpcStreamSelector grpcStreamSelector;
-        @Nullable
-        private CallOptions callOptions;
-        private long terminationWaitMillis;
+		private Builder() {
+		}
 
-        private Builder() {
-        }
+		public GrpcClientPolicy build() {
+			if (grpcChannelSelector == null) {
+				// TODO: how should low and high water mark be selected?
+				int hwm =
+						maxConcurrentStreamsPerChannel * maxConcurrentRequestsPerStream;
+				int lwm = Math.max(16, (int)(0.8 * hwm));
+				grpcChannelSelector =
+						new DefaultGrpcChannelSelector(lwm, hwm);
+			}
 
-        public GrpcClientPolicy build() {
-            if (grpcChannelSelector == null) {
-                // TODO: how should low and high water mark be selected?
-                int hwm =
-                        maxConcurrentStreamsPerChannel * maxConcurrentRequestsPerStream;
-                int lwm = Math.max(16, (int) (0.8 * hwm));
-                grpcChannelSelector =
-                        new DefaultGrpcChannelSelector(lwm, hwm);
-            }
+			if (grpcStreamSelector == null) {
+				grpcStreamSelector =
+						new DefaultGrpcStreamSelector(maxConcurrentStreamsPerChannel, maxConcurrentRequestsPerStream);
+			}
 
-            if (grpcStreamSelector == null) {
-                grpcStreamSelector =
-                        new DefaultGrpcStreamSelector(maxConcurrentStreamsPerChannel, maxConcurrentRequestsPerStream);
-            }
+			if (callOptions == null) {
+				callOptions = CallOptions.DEFAULT;
+			}
 
-            if (callOptions == null) {
-                callOptions = CallOptions.DEFAULT;
-            }
+			return new GrpcClientPolicy(maxChannels, maxConcurrentStreamsPerChannel,
+					maxConcurrentRequestsPerStream, totalRequestsPerStream,
+					connectTimeoutMillis, terminationWaitMillis, grpcChannelSelector,
+					grpcStreamSelector, callOptions, eventLoops, channelType,
+					closeEventLoops, tlsPolicy);
+		}
 
-            return new GrpcClientPolicy(maxChannels, maxConcurrentStreamsPerChannel,
-                    maxConcurrentRequestsPerStream, totalRequestsPerStream,
-                    connectTimeoutMillis, terminationWaitMillis, grpcChannelSelector,
-                    grpcStreamSelector, callOptions, eventLoops, channelType,
-                    closeEventLoops, tlsPolicy);
-        }
+		public Builder maxChannels(int maxChannels) {
+			if (maxChannels < 1) {
+				throw new IllegalArgumentException(String.format(
+						"maxChannels=%d < 1", maxChannels
+				));
+			}
+			this.maxChannels = maxChannels;
+			return this;
+		}
 
-        public Builder maxChannels(int maxChannels) {
-            if (maxChannels < 1) {
-                throw new IllegalArgumentException(String.format(
-                        "maxChannels=%d < 1", maxChannels
-                ));
-            }
-            this.maxChannels = maxChannels;
-            return this;
-        }
+		public Builder maxConcurrentStreamsPerChannel(int maxConcurrentStreamsPerChannel) {
+			if (maxConcurrentStreamsPerChannel < 1) {
+				throw new IllegalArgumentException(String.format(
+						"maxConcurrentStreamsPerChannel=%d < 1", maxConcurrentStreamsPerChannel
+				));
+			}
+			this.maxConcurrentStreamsPerChannel = maxConcurrentStreamsPerChannel;
+			return this;
+		}
 
-        public Builder maxConcurrentStreamsPerChannel(int maxConcurrentStreamsPerChannel) {
-            if (maxConcurrentStreamsPerChannel < 1) {
-                throw new IllegalArgumentException(String.format(
-                        "maxConcurrentStreamsPerChannel=%d < 1", maxConcurrentStreamsPerChannel
-                ));
-            }
-            this.maxConcurrentStreamsPerChannel = maxConcurrentStreamsPerChannel;
-            return this;
-        }
+		public Builder maxConcurrentRequestsPerStream(int maxConcurrentRequestsPerStream) {
+			if (maxConcurrentRequestsPerStream < 1) {
+				throw new IllegalArgumentException(String.format(
+						"maxConcurrentRequestsPerStream=%d < 1", maxConcurrentRequestsPerStream
+				));
+			}
+			this.maxConcurrentRequestsPerStream = maxConcurrentRequestsPerStream;
+			return this;
+		}
 
-        public Builder maxConcurrentRequestsPerStream(int maxConcurrentRequestsPerStream) {
-            if (maxConcurrentRequestsPerStream < 1) {
-                throw new IllegalArgumentException(String.format(
-                        "maxConcurrentRequestsPerStream=%d < 1", maxConcurrentRequestsPerStream
-                ));
-            }
-            this.maxConcurrentRequestsPerStream = maxConcurrentRequestsPerStream;
-            return this;
-        }
+		public Builder totalRequestsPerStream(int totalRequestsPerStream) {
+			if (totalRequestsPerStream < 0) {
+				throw new IllegalArgumentException(String.format(
+						"totalRequestsPerStream=%d < 0", totalRequestsPerStream
+				));
+			}
+			this.totalRequestsPerStream = totalRequestsPerStream;
+			return this;
+		}
 
-        public Builder totalRequestsPerStream(int totalRequestsPerStream) {
-            if (totalRequestsPerStream < 0) {
-                throw new IllegalArgumentException(String.format(
-                        "totalRequestsPerStream=%d < 0", totalRequestsPerStream
-                ));
-            }
-            this.totalRequestsPerStream = totalRequestsPerStream;
-            return this;
-        }
+		public Builder connectTimeoutMillis(int connectTimeoutMillis) {
+			if (connectTimeoutMillis < 0) {
+				throw new IllegalArgumentException(String.format(
+						"connectTimeoutMillis=%d < 0", connectTimeoutMillis
+				));
+			}
+			this.connectTimeoutMillis = connectTimeoutMillis;
+			return this;
+		}
 
-        public Builder connectTimeoutMillis(int connectTimeoutMillis) {
-            if (connectTimeoutMillis < 0) {
-                throw new IllegalArgumentException(String.format(
-                        "connectTimeoutMillis=%d < 0", connectTimeoutMillis
-                ));
-            }
-            this.connectTimeoutMillis = connectTimeoutMillis;
-            return this;
-        }
+		public Builder tlsPolicy(@Nullable TlsPolicy tlsPolicy) {
+			this.tlsPolicy = tlsPolicy;
+			return this;
+		}
 
-        public Builder tlsPolicy(@Nullable TlsPolicy tlsPolicy) {
-            this.tlsPolicy = tlsPolicy;
-            return this;
-        }
+		public Builder grpcChannelSelector(GrpcChannelSelector grpcChannelSelector) {
+			this.grpcChannelSelector = grpcChannelSelector;
+			return this;
+		}
 
-        public Builder grpcChannelSelector(GrpcChannelSelector grpcChannelSelector) {
-            this.grpcChannelSelector = grpcChannelSelector;
-            return this;
-        }
+		public Builder grpcStreamSelector(GrpcStreamSelector grpcStreamSelector) {
+			this.grpcStreamSelector = grpcStreamSelector;
+			return this;
+		}
 
-        public Builder grpcStreamSelector(GrpcStreamSelector grpcStreamSelector) {
-            this.grpcStreamSelector = grpcStreamSelector;
-            return this;
-        }
+		public Builder callOptions(@Nullable CallOptions callOptions) {
+			this.callOptions = callOptions;
+			return this;
+		}
 
-        public Builder callOptions(@Nullable CallOptions callOptions) {
-            this.callOptions = callOptions;
-            return this;
-        }
-
-        public Builder terminationWaitMillis(long terminationWaitMillis) {
-            if (terminationWaitMillis < 0) {
-                throw new IllegalArgumentException(String.format(
-                        "terminationWaitMillis=%d < 0", terminationWaitMillis
-                ));
-            }
-            this.terminationWaitMillis = terminationWaitMillis;
-            return this;
-        }
-    }
+		public Builder terminationWaitMillis(long terminationWaitMillis) {
+			if (terminationWaitMillis < 0) {
+				throw new IllegalArgumentException(String.format(
+						"terminationWaitMillis=%d < 0", terminationWaitMillis
+				));
+			}
+			this.terminationWaitMillis = terminationWaitMillis;
+			return this;
+		}
+	}
 }

--- a/proxy/src/com/aerospike/client/proxy/grpc/GrpcStream.java
+++ b/proxy/src/com/aerospike/client/proxy/grpc/GrpcStream.java
@@ -5,19 +5,17 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
-import org.jctools.queues.SpscUnboundedArrayQueue;
-
 import com.aerospike.client.AerospikeException;
 import com.aerospike.client.ResultCode;
 import com.aerospike.proxy.client.Kvs;
 import com.google.protobuf.ByteString;
-
 import io.grpc.CallOptions;
 import io.grpc.ClientCall;
 import io.grpc.MethodDescriptor;
 import io.grpc.stub.ClientCalls;
 import io.grpc.stub.StreamObserver;
 import io.netty.channel.EventLoop;
+import org.jctools.queues.SpscUnboundedArrayQueue;
 
 /**
  * This class executes a single Aerospike API method like get, put, etc.
@@ -35,247 +33,241 @@ import io.netty.channel.EventLoop;
  * <p>TODO: Should the stream be closed if it has been idle for some duration?
  */
 public class GrpcStream implements StreamObserver<Kvs.AerospikeResponsePayload> {
-    /**
-     * Unique stream id in the channel.
-     */
-    private final int id;
-    /**
-     * The event loop within which all of GrpcStream calls are executed.
-     */
-    private final EventLoop eventLoop;
-    /**
-     * The request observer of the stream.
-     */
-    private StreamObserver<Kvs.AerospikeRequestPayload> requestObserver;
-    /**
-     * The gRPC client policy.
-     */
-    private final GrpcClientPolicy grpcClientPolicy;
-    /**
-     * The executor for this stream.
-     */
-    private final GrpcChannelExecutor channelExecutor;
-    /**
-     * The method processed by this stream.
-     */
-    private final MethodDescriptor<Kvs.AerospikeRequestPayload,
-            Kvs.AerospikeResponsePayload> methodDescriptor;
-    /**
-     * Queued calls pending execution.
-     */
-    private final SpscUnboundedArrayQueue<GrpcStreamingUnaryCall> pendingCalls;
+	/**
+	 * Unique stream id in the channel.
+	 */
+	private final int id;
+	/**
+	 * The event loop within which all of GrpcStream calls are executed.
+	 */
+	private final EventLoop eventLoop;
+	/**
+	 * The request observer of the stream.
+	 */
+	private StreamObserver<Kvs.AerospikeRequestPayload> requestObserver;
+	/**
+	 * The gRPC client policy.
+	 */
+	private final GrpcClientPolicy grpcClientPolicy;
+	/**
+	 * The executor for this stream.
+	 */
+	private final GrpcChannelExecutor channelExecutor;
+	/**
+	 * The method processed by this stream.
+	 */
+	private final MethodDescriptor<Kvs.AerospikeRequestPayload,
+			Kvs.AerospikeResponsePayload> methodDescriptor;
+	/**
+	 * Queued calls pending execution.
+	 */
+	private final SpscUnboundedArrayQueue<GrpcStreamingUnaryCall> pendingCalls;
 
-    /**
-     * Map of request id to the calls executing in this stream.
-     */
-    private final Map<Integer, GrpcStreamingUnaryCall> executingCalls =
-            new HashMap<>();
+	/**
+	 * Map of request id to the calls executing in this stream.
+	 */
+	private final Map<Integer, GrpcStreamingUnaryCall> executingCalls =
+			new HashMap<>();
 
-    /**
-     * Is the stream closed. This variable is only accessed from the event
-     * loop thread assigned to this stream and its channel.
-     */
-    private boolean isClosed = false;
+	/**
+	 * Is the stream closed. This variable is only accessed from the event
+	 * loop thread assigned to this stream and its channel.
+	 */
+	private boolean isClosed = false;
 
-    // Stream statistics. These are only accessed from the event loop thread
-    // assigned to this stream and its channel.
-    private long bytesSent;
-    private long bytesReceived;
-    private int requestsSent;
-    private int responsesReceived;
-    private int requestsInFlight;
+	// Stream statistics. These are only accessed from the event loop thread
+	// assigned to this stream and its channel.
+	private long bytesSent;
+	private long bytesReceived;
+	private int requestsSent;
+	private int responsesReceived;
+	private int requestsInFlight;
 
-    public static GrpcStream newInstance(GrpcChannelExecutor channelExecutor,
-                                         MethodDescriptor<Kvs.AerospikeRequestPayload, Kvs.AerospikeResponsePayload> methodDescriptor,
-                                         SpscUnboundedArrayQueue<GrpcStreamingUnaryCall> pendingCalls,
-                                         CallOptions callOptions,
-                                         GrpcClientPolicy grpcClientPolicy,
-                                         int streamIndex, EventLoop eventLoop) {
-        GrpcStream stream = new GrpcStream(channelExecutor, methodDescriptor,
-                pendingCalls, grpcClientPolicy, streamIndex, eventLoop);
-        ClientCall<Kvs.AerospikeRequestPayload, Kvs.AerospikeResponsePayload> call = channelExecutor.getChannel()
-                .newCall(methodDescriptor, callOptions);
-        StreamObserver<Kvs.AerospikeRequestPayload> requestObserver =
-                ClientCalls.asyncBidiStreamingCall(call, stream);
-        stream.setRequestObserver(requestObserver);
-        return stream;
-    }
+	public GrpcStream(GrpcChannelExecutor channelExecutor,
+					  MethodDescriptor<Kvs.AerospikeRequestPayload, Kvs.AerospikeResponsePayload> methodDescriptor,
+					  SpscUnboundedArrayQueue<GrpcStreamingUnaryCall> pendingCalls,
+					  CallOptions callOptions,
+					  GrpcClientPolicy grpcClientPolicy,
+					  int streamIndex, EventLoop eventLoop) {
+		this.channelExecutor = channelExecutor;
+		this.methodDescriptor = methodDescriptor;
+		this.pendingCalls = pendingCalls;
+		this.grpcClientPolicy = grpcClientPolicy;
+		this.id = streamIndex;
+		this.eventLoop = eventLoop;
+		ClientCall<Kvs.AerospikeRequestPayload, Kvs.AerospikeResponsePayload> call = channelExecutor.getChannel()
+				.newCall(methodDescriptor, callOptions);
+		StreamObserver<Kvs.AerospikeRequestPayload> requestObserver =
+				ClientCalls.asyncBidiStreamingCall(call, this);
+		setRequestObserver(requestObserver);
+	}
 
-    private GrpcStream(GrpcChannelExecutor channelExecutor, MethodDescriptor<Kvs.AerospikeRequestPayload, Kvs.AerospikeResponsePayload> methodDescriptor,
-                       SpscUnboundedArrayQueue<GrpcStreamingUnaryCall> pendingCalls,
-                       GrpcClientPolicy grpcClientPolicy,
-                       int id, EventLoop eventLoop) {
-        this.channelExecutor = channelExecutor;
-        this.methodDescriptor = methodDescriptor;
-        this.pendingCalls = pendingCalls;
-        this.grpcClientPolicy = grpcClientPolicy;
-        this.id = id;
-        this.eventLoop = eventLoop;
-    }
+	private void setRequestObserver(StreamObserver<Kvs.AerospikeRequestPayload> requestObserver) {
+		this.requestObserver = requestObserver;
+	}
 
-    private void setRequestObserver(StreamObserver<Kvs.AerospikeRequestPayload> requestObserver) {
-        this.requestObserver = requestObserver;
-    }
+	@Override
+	public void onNext(Kvs.AerospikeResponsePayload aerospikeResponsePayload) {
+		// Invoke callback.
+		int id = aerospikeResponsePayload.getId();
+		GrpcStreamingUnaryCall call = executingCalls.remove(id);
 
-    @Override
-    public void onNext(Kvs.AerospikeResponsePayload aerospikeResponsePayload) {
-        // Invoke callback.
-        int id = aerospikeResponsePayload.getId();
-        GrpcStreamingUnaryCall call = executingCalls.remove(id);
+		// Call might have expired and been cancelled.
+		if (call != null) {
+			call.onSuccess(aerospikeResponsePayload);
+		}
+		else {
+			// TODO: log the expired call?
+		}
 
-        // Call might have expired and been cancelled.
-        if (call != null) {
-            call.onSuccess(aerospikeResponsePayload);
-        } else {
-            // TODO: log the expired call?
-        }
+		// Update stats.
+		requestsInFlight--;
 
-        // Update stats.
-        requestsInFlight--;
+		int payloadSize = aerospikeResponsePayload.getPayload().size();
+		bytesReceived += payloadSize;
+		responsesReceived++;
 
-        int payloadSize = aerospikeResponsePayload.getPayload().size();
-        bytesReceived += payloadSize;
-        responsesReceived++;
+		channelExecutor.responseReceived(payloadSize);
 
-        channelExecutor.responseReceived(payloadSize);
+		// TODO can it ever be greater than?
+		if (responsesReceived >= grpcClientPolicy.totalRequestsPerStream) {
+			// Complete this stream.
+			requestObserver.onCompleted();
+		}
+		else {
+			executeCall();
+		}
+	}
 
-        // TODO can it ever be greater than?
-        if (responsesReceived >= grpcClientPolicy.totalRequestsPerStream) {
-            // Complete this stream.
-            requestObserver.onCompleted();
-        } else {
-            executeCall();
-        }
-    }
+	private void abortExecutingCalls(Throwable throwable) {
+		isClosed = true;
+		for (GrpcStreamingUnaryCall call : executingCalls.values()) {
+			call.onError(throwable);
+			requestsInFlight--;
+		}
 
-    private void abortExecutingCalls(Throwable throwable) {
-        isClosed = true;
-        for (GrpcStreamingUnaryCall call : executingCalls.values()) {
-            call.onError(throwable);
-            requestsInFlight--;
-        }
+		executingCalls.clear();
 
-        executingCalls.clear();
+		channelExecutor.onStreamClosed(this);
+	}
 
-        channelExecutor.onStreamClosed(this);
-    }
+	@Override
+	public void onError(Throwable throwable) {
+		abortExecutingCalls(throwable);
+	}
 
-    @Override
-    public void onError(Throwable throwable) {
-        abortExecutingCalls(throwable);
-    }
+	@Override
+	public void onCompleted() {
+		abortExecutingCalls(new AerospikeException(ResultCode.SERVER_ERROR,
+				"stream completed before all responses have been received"));
+	}
 
-    @Override
-    public void onCompleted() {
-        abortExecutingCalls(new AerospikeException(ResultCode.SERVER_ERROR,
-                "stream completed before all responses have been received"));
-    }
+	SpscUnboundedArrayQueue<GrpcStreamingUnaryCall> getQueue() {
+		return pendingCalls;
+	}
 
-    SpscUnboundedArrayQueue<GrpcStreamingUnaryCall> getQueue() {
-        return pendingCalls;
-    }
+	MethodDescriptor<Kvs.AerospikeRequestPayload,
+			Kvs.AerospikeResponsePayload> getMethodDescriptor() {
+		return methodDescriptor;
+	}
 
-    MethodDescriptor<Kvs.AerospikeRequestPayload,
-            Kvs.AerospikeResponsePayload> getMethodDescriptor() {
-        return methodDescriptor;
-    }
+	int getOngoingRequests() {
+		return requestsInFlight + pendingCalls.size();
+	}
 
-    int getOngoingRequests() {
-        return requestsInFlight + pendingCalls.size();
-    }
+	public int getId() {
+		return id;
+	}
 
-    public int getId() {
-        return id;
-    }
+	public long getBytesSent() {
+		return bytesSent;
+	}
 
-    public long getBytesSent() {
-        return bytesSent;
-    }
+	public long getBytesReceived() {
+		return bytesReceived;
+	}
 
-    public long getBytesReceived() {
-        return bytesReceived;
-    }
+	public int getRequestsSent() {
+		return requestsSent;
+	}
 
-    public int getRequestsSent() {
-        return requestsSent;
-    }
+	public int getResponsesReceived() {
+		return responsesReceived;
+	}
 
-    public int getResponsesReceived() {
-        return responsesReceived;
-    }
+	@Override
+	public String toString() {
+		return "GrpcStream{id=" + id + ", channelExecutor=" + channelExecutor + '}';
+	}
 
-    @Override
-    public String toString() {
-        return "GrpcStream{id=" + id + ", channelExecutor=" + channelExecutor + '}';
-    }
+	public int getTotalExecutedRequests() {
+		return getRequestsSent() + getOngoingRequests();
+	}
 
-    public int getTotalExecutedRequests() {
-        return getRequestsSent() + getOngoingRequests();
-    }
+	public void executeCall() {
+		if (isClosed) {
+			return;
+		}
 
-    public void executeCall() {
-        if (isClosed) {
-            return;
-        }
-
-        pendingCalls.drain(GrpcStream.this::execute, idleCounter -> idleCounter,
-                () -> !pendingCalls.isEmpty() &&
-                        requestsSent < grpcClientPolicy.totalRequestsPerStream &&
-                        requestsInFlight < grpcClientPolicy.maxConcurrentRequestsPerStream);
-    }
+		pendingCalls.drain(GrpcStream.this::execute, idleCounter -> idleCounter,
+				() -> !pendingCalls.isEmpty() &&
+						requestsSent < grpcClientPolicy.totalRequestsPerStream &&
+						requestsInFlight < grpcClientPolicy.maxConcurrentRequestsPerStream);
+	}
 
 
-    private void execute(GrpcStreamingUnaryCall call) {
-        try {
-            if (call.hasExpired()) {
-                call.onError(new AerospikeException.Timeout(call.getPolicy(),
-                        call.getIteration()));
-                return;
-            }
+	private void execute(GrpcStreamingUnaryCall call) {
+		try {
+			if (call.hasExpired()) {
+				call.onError(new AerospikeException.Timeout(call.getPolicy(),
+						call.getIteration()));
+				return;
+			}
 
-            ByteString payload = call.getRequestPayload();
+			ByteString payload = call.getRequestPayload();
 
-            // Update stats.
-            requestsInFlight++;
-            bytesSent += payload.size();
+			// Update stats.
+			requestsInFlight++;
+			bytesSent += payload.size();
 
-            int requestId = requestsSent++;
-            Kvs.AerospikeRequestPayload.Builder requestBuilder = Kvs.AerospikeRequestPayload.newBuilder()
-                    .setPayload(payload)
-                    .setId(requestId)
-                    .setIteration(call.getIteration());
+			int requestId = requestsSent++;
+			Kvs.AerospikeRequestPayload.Builder requestBuilder = Kvs.AerospikeRequestPayload.newBuilder()
+					.setPayload(payload)
+					.setId(requestId)
+					.setIteration(call.getIteration());
 
-            GrpcConversions.setRequestPolicy(call.getPolicy(), requestBuilder);
-            Kvs.AerospikeRequestPayload requestPayload = requestBuilder
-                    .build();
-            executingCalls.put(requestId, call);
+			GrpcConversions.setRequestPolicy(call.getPolicy(), requestBuilder);
+			Kvs.AerospikeRequestPayload requestPayload = requestBuilder
+					.build();
+			executingCalls.put(requestId, call);
 
-            requestObserver.onNext(requestPayload);
+			requestObserver.onNext(requestPayload);
 
-            if (call.hasExpiry()) {
-                // TODO: Is there a need for a more efficient implementation in
-                //  terms of the call cancellation.
-                eventLoop.schedule(() -> onCancelCall(requestId),
-                        call.nanosTillExpiry(), TimeUnit.NANOSECONDS);
-            }
-        } catch (Exception e) {
-            // Failure in scheduling or delegating through request observer.
-            call.onError(e);
-        }
-    }
+			if (call.hasExpiry()) {
+				// TODO: Is there a need for a more efficient implementation in
+				//  terms of the call cancellation.
+				eventLoop.schedule(() -> onCancelCall(requestId),
+						call.nanosTillExpiry(), TimeUnit.NANOSECONDS);
+			}
+		}
+		catch (Exception e) {
+			// Failure in scheduling or delegating through request observer.
+			call.onError(e);
+		}
+	}
 
-    private void onCancelCall(int callId) {
-        GrpcStreamingUnaryCall call = executingCalls.remove(callId);
+	private void onCancelCall(int callId) {
+		GrpcStreamingUnaryCall call = executingCalls.remove(callId);
 
-        // Call might have completed.
-        if (call != null) {
-            call.onError(new AerospikeException.Timeout(call.getPolicy(),
-                    call.getIteration()));
-        }
-    }
+		// Call might have completed.
+		if (call != null) {
+			call.onError(new AerospikeException.Timeout(call.getPolicy(),
+					call.getIteration()));
+		}
+	}
 
-    void enqueue(GrpcStreamingUnaryCall call) {
-        // TODO: can this call fail?
-        pendingCalls.add(call);
-    }
+	void enqueue(GrpcStreamingUnaryCall call) {
+		// TODO: can this call fail?
+		pendingCalls.add(call);
+	}
 }

--- a/proxy/src/com/aerospike/client/proxy/grpc/GrpcStreamingUnaryCall.java
+++ b/proxy/src/com/aerospike/client/proxy/grpc/GrpcStreamingUnaryCall.java
@@ -21,7 +21,6 @@ import java.util.concurrent.TimeUnit;
 import com.aerospike.client.policy.Policy;
 import com.aerospike.proxy.client.Kvs;
 import com.google.protobuf.ByteString;
-
 import io.grpc.MethodDescriptor;
 import io.grpc.stub.StreamObserver;
 
@@ -29,107 +28,108 @@ import io.grpc.stub.StreamObserver;
  * A unary gRPC call that is converted to a streaming call for performance.
  */
 public class GrpcStreamingUnaryCall {
-    /**
-     * The streaming method to execute for this unary call.
-     */
-    private final MethodDescriptor<Kvs.AerospikeRequestPayload,
-            Kvs.AerospikeResponsePayload> methodDescriptor;
+	/**
+	 * The streaming method to execute for this unary call.
+	 */
+	private final MethodDescriptor<Kvs.AerospikeRequestPayload,
+			Kvs.AerospikeResponsePayload> streamingMethodDescriptor;
 
-    /**
-     * The request payload.
-     */
-    private final ByteString requestPayload;
+	/**
+	 * The request payload.
+	 */
+	private final ByteString requestPayload;
 
-    /**
-     * The stream response observer for the call.
-     */
-    private final StreamObserver<Kvs.AerospikeResponsePayload> responseObserver;
+	/**
+	 * The stream response observer for the call.
+	 */
+	private final StreamObserver<Kvs.AerospikeResponsePayload> responseObserver;
 
-    /**
-     * The deadline in nanoseconds w.r.t System.nanoTime().
-     */
-    private final long expiresAtNanos;
+	/**
+	 * The deadline in nanoseconds w.r.t System.nanoTime().
+	 */
+	private final long expiresAtNanos;
 
-    /**
-     * Aerospike client policy for this request.
-     */
-    private final Policy policy;
+	/**
+	 * Aerospike client policy for this request.
+	 */
+	private final Policy policy;
 
-    /**
-     * Iteration number of this request.
-     */
-    private final int iteration;
+	/**
+	 * Iteration number of this request.
+	 */
+	private final int iteration;
 
-    protected GrpcStreamingUnaryCall(GrpcStreamingUnaryCall other) {
-        this(other.methodDescriptor, other.requestPayload, other.getPolicy(),
-                other.iteration, other.responseObserver);
-    }
+	protected GrpcStreamingUnaryCall(GrpcStreamingUnaryCall other) {
+		this(other.streamingMethodDescriptor, other.requestPayload, other.getPolicy(),
+				other.iteration, other.responseObserver);
+	}
 
 
-    public GrpcStreamingUnaryCall(MethodDescriptor<Kvs.AerospikeRequestPayload,
-            Kvs.AerospikeResponsePayload> methodDescriptor,
-                                  ByteString requestPayload,
-                                  Policy policy,
-                                  int iteration,
-                                  StreamObserver<Kvs.AerospikeResponsePayload>
-                                          responseObserver) {
-        this.responseObserver = responseObserver;
-        this.methodDescriptor = methodDescriptor;
-        this.requestPayload = requestPayload;
-        this.iteration = iteration;
-        this.policy = policy;
+	public GrpcStreamingUnaryCall(MethodDescriptor<Kvs.AerospikeRequestPayload,
+			Kvs.AerospikeResponsePayload> streamingMethodDescriptor,
+								  ByteString requestPayload,
+								  Policy policy,
+								  int iteration,
+								  StreamObserver<Kvs.AerospikeResponsePayload>
+										  responseObserver) {
+		this.responseObserver = responseObserver;
+		this.streamingMethodDescriptor = streamingMethodDescriptor;
+		this.requestPayload = requestPayload;
+		this.iteration = iteration;
+		this.policy = policy;
 
-        if (policy.totalTimeout > 0) {
-            this.expiresAtNanos =
-                    System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(policy.totalTimeout);
-        } else {
-            // TODO: should 0 (no timeout) be allowed?
-            this.expiresAtNanos =
-                    System.nanoTime() + TimeUnit.SECONDS.toNanos(30);
-        }
-    }
+		if (policy.totalTimeout > 0) {
+			this.expiresAtNanos =
+					System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(policy.totalTimeout);
+		}
+		else {
+			// TODO: should 0 (no timeout) be allowed?
+			this.expiresAtNanos =
+					System.nanoTime() + TimeUnit.SECONDS.toNanos(30);
+		}
+	}
 
-    public void onSuccess(Kvs.AerospikeResponsePayload payload) {
-        responseObserver.onNext(payload);
-        responseObserver.onCompleted();
-    }
+	public void onSuccess(Kvs.AerospikeResponsePayload payload) {
+		responseObserver.onNext(payload);
+		responseObserver.onCompleted();
+	}
 
-    public void onError(Throwable t) {
-        responseObserver.onError(t);
-    }
+	public void onError(Throwable t) {
+		responseObserver.onError(t);
+	}
 
-    public MethodDescriptor<Kvs.AerospikeRequestPayload, Kvs.AerospikeResponsePayload> getMethodDescriptor() {
-        return methodDescriptor;
-    }
+	public MethodDescriptor<Kvs.AerospikeRequestPayload, Kvs.AerospikeResponsePayload> getStreamingMethodDescriptor() {
+		return streamingMethodDescriptor;
+	}
 
-    /**
-     * @return true if this call has expired.
-     */
-    public boolean hasExpired() {
-        return expiresAtNanos > 0 && System.nanoTime() >= expiresAtNanos;
-    }
+	/**
+	 * @return true if this call has expired.
+	 */
+	public boolean hasExpired() {
+		return expiresAtNanos > 0 && System.nanoTime() >= expiresAtNanos;
+	}
 
-    public boolean hasExpiry() {
-        return expiresAtNanos > 0;
-    }
+	public boolean hasExpiry() {
+		return expiresAtNanos > 0;
+	}
 
-    public long nanosTillExpiry() {
-        if (expiresAtNanos == 0) {
-            return Long.MAX_VALUE;
-        }
-        long nanosTillExpiry = expiresAtNanos - System.nanoTime();
-        return nanosTillExpiry > 0 ? nanosTillExpiry : 0;
-    }
+	public long nanosTillExpiry() {
+		if (expiresAtNanos == 0) {
+			return Long.MAX_VALUE;
+		}
+		long nanosTillExpiry = expiresAtNanos - System.nanoTime();
+		return nanosTillExpiry > 0 ? nanosTillExpiry : 0;
+	}
 
-    public ByteString getRequestPayload() {
-        return requestPayload;
-    }
+	public ByteString getRequestPayload() {
+		return requestPayload;
+	}
 
-    public int getIteration() {
-        return iteration;
-    }
+	public int getIteration() {
+		return iteration;
+	}
 
-    public Policy getPolicy() {
-        return policy;
-    }
+	public Policy getPolicy() {
+		return policy;
+	}
 }


### PR DESCRIPTION
- Using the latest proxy stub with all client APIs exposed
- Command proxy now uses the streaming method descriptor  appropriate to the call  
- Removed sleep in AuthTokenManager set credentials function to prevent event loops for locking up when there are smaller number of event loops
- Re-formatted previous proxy files to use tabs instead of spaces as is the convention 
