### PR TITLE
Renamed get and put to read and write respectively

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,12 +8,12 @@
   <version>6.1.7-SNAPSHOT</version>
   <packaging>pom</packaging>
   <url>https://github.com/aerospike/aerospike-client-java</url>
-  
+
   <organization>
     <name>Aerospike Inc.</name>
     <url>https://www.aerospike.com</url>
   </organization>
-  
+
   <licenses>
     <license>
       <name>The Apache License, Version 2.0</name>
@@ -41,7 +41,7 @@
 
     <netty.version>4.1.87.Final</netty.version>
     <netty.tcnative.version>2.0.54.Final</netty.tcnative.version>
-    <grpc.version>1.52.1</grpc.version>
+    <grpc.version>1.53.0</grpc.version>
     <luaj-jse.version>3.0.1</luaj-jse.version>
     <jbcrypt.version>0.4</jbcrypt.version>
     <commons-cli.version>1.5.0</commons-cli.version>

--- a/proxy/src/com/aerospike/client/proxy/ReadCommandProxy.java
+++ b/proxy/src/com/aerospike/client/proxy/ReadCommandProxy.java
@@ -42,7 +42,7 @@ public class ReadCommandProxy extends CommandProxy {
 		Key key,
 		String[] binNames
 	) {
-		super(KVSGrpc.getGetStreamingMethod(), executor, policy);
+		super(KVSGrpc.getReadStreamingMethod(), executor, policy);
 		this.listener = listener;
 		this.key = key;
 		this.binNames = binNames;

--- a/proxy/src/com/aerospike/client/proxy/WriteCommandProxy.java
+++ b/proxy/src/com/aerospike/client/proxy/WriteCommandProxy.java
@@ -42,7 +42,7 @@ public final class WriteCommandProxy extends CommandProxy {
 		Bin[] bins,
 		Operation.Type type
 	) {
-		super(KVSGrpc.getPutStreamingMethod(), executor, writePolicy);
+		super(KVSGrpc.getWriteStreamingMethod(), executor, writePolicy);
 		this.listener = listener;
 		this.writePolicy = writePolicy;
 		this.key = key;


### PR DESCRIPTION
 - handled rename of get and put gRPC calls to read and write respectively
 - upgraded gRPC version to 1.53.0