### PR TITLE
[CONNECTOR-633] Increased incoming message limit and event loop fixes

### DIFF
--- a/benchmarks/src/com/aerospike/benchmarks/Main.java
+++ b/benchmarks/src/com/aerospike/benchmarks/Main.java
@@ -1178,7 +1178,7 @@ public class Main implements Log.Callback {
 					clientPolicy.asyncMaxConnsPerNode = this.asyncMaxCommands;
 				}
 
-				IAerospikeClient client = useProxyClient?
+				IAerospikeClient client = useProxyClient ?
 					new AerospikeClientProxy(clientPolicy, hosts) :
 					new AerospikeClient(clientPolicy, hosts);
 
@@ -1200,7 +1200,9 @@ public class Main implements Log.Callback {
 			}
 		}
 		else {
-			IAerospikeClient client = new AerospikeClient(clientPolicy, hosts);
+			IAerospikeClient client = useProxyClient ?
+				new AerospikeClientProxy(clientPolicy, hosts) :
+				new AerospikeClient(clientPolicy, hosts);
 
 			try {
 				if (initialize) {
@@ -1226,8 +1228,8 @@ public class Main implements Log.Callback {
 		long rem = this.nKeys - (keysPerTask * ntasks);
 		long start = this.startKey;
 
-		for (long i = 0 ; i < ntasks; i++) {
-			long keyCount = (i < rem)? keysPerTask + 1 : keysPerTask;
+		for (long i = 0; i < ntasks; i++) {
+			long keyCount = (i < rem) ? keysPerTask + 1 : keysPerTask;
 			InsertTaskSync it = new InsertTaskSync(client, args, counters, start, keyCount);
 			es.execute(it);
 			start += keyCount;
@@ -1254,7 +1256,7 @@ public class Main implements Log.Callback {
 
 		for (int i = 0; i < maxConcurrentCommands; i++) {
 			// Allocate separate tasks for each seed command and reuse them in callbacks.
-			long keyCount = (i < keysRem)? keysPerCommand + 1 : keysPerCommand;
+			long keyCount = (i < keysRem) ? keysPerCommand + 1 : keysPerCommand;
 
 			// Start seed commands on random event loops.
 			EventLoop eventLoop = this.eventLoops.next();

--- a/proxy/src/com/aerospike/client/proxy/grpc/GrpcChannelExecutor.java
+++ b/proxy/src/com/aerospike/client/proxy/grpc/GrpcChannelExecutor.java
@@ -80,10 +80,10 @@ public class GrpcChannelExecutor implements Runnable {
 	 * in TLS verification of the proxy server.
 	 */
 	public static final String OVERRIDE_AUTHORITY = "com.aerospike.client" +
-			".overrideAuthority";
+		".overrideAuthority";
 
 	private static final String AEROSPIKE_CLIENT_USER_AGENT =
-			"AerospikeClientJava/" + AerospikeClientProxy.Version;
+		"AerospikeClientJava/" + AerospikeClientProxy.Version;
 
 	/**
 	 * Call queue initial chunk size.
@@ -96,6 +96,7 @@ public class GrpcChannelExecutor implements Runnable {
 	 * TODO: how to select interval of execution?
 	 */
 	private static final long ITERATION_DELAY_MICROS = 250;
+
 	/**
 	 * Unique executor ids.
 	 */
@@ -124,12 +125,12 @@ public class GrpcChannelExecutor implements Runnable {
 	 * Queued unary calls awaiting execution.
 	 */
 	private final MpscUnboundedArrayQueue<GrpcStreamingCall> pendingCalls =
-			new MpscUnboundedArrayQueue<>(32);
+		new MpscUnboundedArrayQueue<>(32);
 	/**
 	 * Queue of closed streams.
 	 */
 	private final MpscUnboundedArrayQueue<GrpcStream> closedStreams =
-			new MpscUnboundedArrayQueue<>(32);
+		new MpscUnboundedArrayQueue<>(32);
 	/**
 	 * Map of stream id to streams.
 	 */
@@ -178,18 +179,18 @@ public class GrpcChannelExecutor implements Runnable {
 
 		this.grpcClientPolicy = grpcClientPolicy;
 		this.drainLimit =
-				this.grpcClientPolicy.maxConcurrentStreamsPerChannel * grpcClientPolicy.maxConcurrentRequestsPerStream;
+			this.grpcClientPolicy.maxConcurrentStreamsPerChannel * grpcClientPolicy.maxConcurrentRequestsPerStream;
 		this.authTokenManager = authTokenManager;
 		this.id = executorIdIndex.getAndIncrement();
 		ChannelAndEventLoop channelAndEventLoop =
-				createGrpcChannel(channelTypeAndEventLoop.getEventLoop()
-						, channelTypeAndEventLoop.getChannelType(), hosts);
+			createGrpcChannel(channelTypeAndEventLoop.getEventLoop()
+				, channelTypeAndEventLoop.getChannelType(), hosts);
 		this.channel = channelAndEventLoop.managedChannel;
 		this.eventLoop = channelAndEventLoop.eventLoop;
 
 		ScheduledFuture<?> future =
-				channelAndEventLoop.eventLoop.scheduleAtFixedRate(this, 0,
-						ITERATION_DELAY_MICROS, TimeUnit.MICROSECONDS);
+			channelAndEventLoop.eventLoop.scheduleAtFixedRate(this, 0,
+				ITERATION_DELAY_MICROS, TimeUnit.MICROSECONDS);
 		setScheduledFuture(future);
 	}
 
@@ -257,44 +258,48 @@ public class GrpcChannelExecutor implements Runnable {
 		else {
 			// Setup round-robin load balancing.
 			NameResolver.Factory nameResolverFactory = new MultiAddressNameResolverFactory(
-					Arrays.stream(hosts)
-							.map((host) -> new InetSocketAddress(host.name, host.port))
-							.collect(
-									Collectors.<SocketAddress>toList()));
+				Arrays.stream(hosts)
+					.map((host) -> new InetSocketAddress(host.name, host.port))
+					.collect(
+						Collectors.<SocketAddress>toList()));
 			builder = NettyChannelBuilder.forTarget(String.format("%s:%d",
-					hosts[0].name, hosts[0].port));
+				hosts[0].name, hosts[0].port));
 			builder.nameResolverFactory(nameResolverFactory);
 			builder.defaultLoadBalancingPolicy("round_robin");
 		}
 
 		SingleEventLoopGroup eventLoopGroup = new SingleEventLoopGroup(eventLoop);
 		builder
-				.eventLoopGroup(eventLoopGroup)
-				.perRpcBufferLimit(128 * 1024 * 1024)
-				.channelType(channelType)
-				.negotiationType(NegotiationType.PLAINTEXT)
+			.eventLoopGroup(eventLoopGroup)
+			.perRpcBufferLimit(128 * 1024 * 1024)
+			.channelType(channelType)
+			.negotiationType(NegotiationType.PLAINTEXT)
 
-				// Execute callbacks in the assigned event loop.
-				// GrpcChannelExecutor.iterate and all of GrpcStream works on
-				// this assumption.
-				.directExecutor()
+			// Have a very large limit because this response is coming from
+			// the proxy server.
+			.maxInboundMessageSize(128 * 1024 * 1024)
 
-				// Retry logic is part of the client code.
-				.disableRetry()
+			// Execute callbacks in the assigned event loop.
+			// GrpcChannelExecutor.iterate and all of GrpcStream works on
+			// this assumption.
+			.directExecutor()
 
-				// Server and client flow control policy should be in sync.
-				.flowControlWindow(2 * 1024 * 1024)
+			// Retry logic is part of the client code.
+			.disableRetry()
 
-				// TODO: is this beneficial? See https://github.com/grpc/grpc-java/issues/8260
-				//  for discussion.
-				// Enabling this feature create too many pings and the server
-				// sends GO_AWAY response.
-				// .initialFlowControlWindow(1024 * 1024)
+			// Server and client flow control policy should be in sync.
+			.flowControlWindow(2 * 1024 * 1024)
 
-				// TODO: Should these be part of GrpcClientPolicy?
-				.keepAliveWithoutCalls(true)
-				.keepAliveTime(25, TimeUnit.SECONDS)
-				.keepAliveTimeout(1, TimeUnit.MINUTES);
+			// TODO: is this beneficial? See https://github.com/grpc/grpc-java/issues/8260
+			//  for discussion.
+			// Enabling this feature create too many pings and the server
+			// sends GO_AWAY response.
+			// .initialFlowControlWindow(1024 * 1024)
+
+			// TODO: Should these be part of GrpcClientPolicy?
+			.keepAliveWithoutCalls(true)
+			.keepAliveTime(25, TimeUnit.SECONDS)
+			.keepAliveTimeout(1, TimeUnit.MINUTES);
 
 		if (grpcClientPolicy.tlsPolicy != null) {
 			builder.sslContext(getSslContext(grpcClientPolicy.tlsPolicy));
@@ -308,7 +313,7 @@ public class GrpcChannelExecutor implements Runnable {
 		// target IP for TLS verification. A simpler way than adding a DNS
 		// entry in the hosts file.
 		String authorityProperty =
-				System.getProperty(OVERRIDE_AUTHORITY);
+			System.getProperty(OVERRIDE_AUTHORITY);
 		if (authorityProperty != null && !authorityProperty.trim().isEmpty()) {
 			builder.overrideAuthority(authorityProperty);
 		}
@@ -318,7 +323,7 @@ public class GrpcChannelExecutor implements Runnable {
 		builder.withOption(ChannelOption.SO_RCVBUF, 1048576);
 		builder.withOption(ChannelOption.TCP_NODELAY, true);
 		builder.withOption(ChannelOption.CONNECT_TIMEOUT_MILLIS,
-				grpcClientPolicy.connectTimeoutMillis);
+			grpcClientPolicy.connectTimeoutMillis);
 		builder.userAgent(AEROSPIKE_CLIENT_USER_AGENT);
 
 		// better to have a receive buffer predictor
@@ -327,7 +332,7 @@ public class GrpcChannelExecutor implements Runnable {
 		//if the server is sending 1000 messages per sec, optimum write buffer watermarks will
 		//prevent unnecessary throttling, Check NioSocketChannelConfig doc
 		builder.withOption(ChannelOption.WRITE_BUFFER_WATER_MARK,
-				new WriteBufferWaterMark(32 * 1024, 64 * 1024));
+			new WriteBufferWaterMark(32 * 1024, 64 * 1024));
 
 		ManagedChannel channel = builder.build();
 		// TODO: ensure it is a single threaded event loop.
@@ -390,7 +395,7 @@ public class GrpcChannelExecutor implements Runnable {
 		pendingCalls.forEach(call -> {
 			if (!call.hasCompleted() && call.hasExpired()) {
 				call.onError(new AerospikeException.Timeout(call.getPolicy(),
-						call.getIteration()));
+					call.getIteration()));
 			}
 		});
 
@@ -419,8 +424,10 @@ public class GrpcChannelExecutor implements Runnable {
 		bytesSent += payload.size();
 		requestsSent++;
 
+		// The stream will be close by the selector.
+		//noinspection resource
 		GrpcStream stream =
-				grpcClientPolicy.grpcStreamSelector.select(new ArrayList<>(streams.values()), call.getStreamingMethodDescriptor());
+			grpcClientPolicy.grpcStreamSelector.select(new ArrayList<>(streams.values()), call.getStreamingMethodDescriptor());
 		if (stream != null) {
 			// TODO: what if add fails
 			stream.enqueue(call);
@@ -429,7 +436,7 @@ public class GrpcChannelExecutor implements Runnable {
 
 		// Create new stream.
 		SpscUnboundedArrayQueue<GrpcStreamingCall> queue =
-				new SpscUnboundedArrayQueue<>(CALL_QUEUE_CHUNK_SIZE);
+			new SpscUnboundedArrayQueue<>(CALL_QUEUE_CHUNK_SIZE);
 		queue.add(call);
 
 		scheduleCallsOnNewStream(call.getStreamingMethodDescriptor(), queue);
@@ -469,7 +476,7 @@ public class GrpcChannelExecutor implements Runnable {
 			}
 			catch (Exception e) {
 				AerospikeException aerospikeException =
-						new AerospikeException(ResultCode.NOT_AUTHENTICATED, e);
+					new AerospikeException(ResultCode.NOT_AUTHENTICATED, e);
 				for (GrpcStreamingCall call = pendingCalls.poll();
 					 call != null;
 					 call = pendingCalls.poll()) {
@@ -491,12 +498,12 @@ public class GrpcChannelExecutor implements Runnable {
 		// - in the next call of GrpcChannelExecutor.processClosedStreams in
 		// an iteration the above steps repeat
 		SpscUnboundedArrayQueue<GrpcStreamingCall> activeCalls =
-				new SpscUnboundedArrayQueue<>(CALL_QUEUE_CHUNK_SIZE);
+			new SpscUnboundedArrayQueue<>(CALL_QUEUE_CHUNK_SIZE);
 		for (GrpcStreamingCall call = pendingCalls.poll(); call != null;
 			 call = pendingCalls.poll()) {
 			if (call.hasExpired()) {
 				call.onError(new AerospikeException.Timeout(call.getPolicy(),
-						call.getIteration()));
+					call.getIteration()));
 			}
 			else {
 				activeCalls.add(call);
@@ -508,7 +515,7 @@ public class GrpcChannelExecutor implements Runnable {
 		}
 
 		GrpcStream stream = new GrpcStream(this, methodDescriptor,
-				activeCalls, options, grpcClientPolicy, nextStreamId(), eventLoop);
+			activeCalls, options, grpcClientPolicy, nextStreamId(), eventLoop);
 
 		streams.put(stream.getId(), stream);
 		streamsOpen++;
@@ -560,7 +567,7 @@ public class GrpcChannelExecutor implements Runnable {
 		do {
 			try {
 				terminated = channel.awaitTermination(terminationWaitMillis,
-						TimeUnit.MILLISECONDS);
+					TimeUnit.MILLISECONDS);
 				break;
 			}
 			catch (InterruptedException e) {
@@ -584,16 +591,16 @@ public class GrpcChannelExecutor implements Runnable {
 	}
 
 
-    @SuppressWarnings("NonAtomicOperationOnVolatileField")
-    void onRequestCompleted() {
-        responsesReceived++;
-        ongoingRequests.getAndDecrement();
-    }
+	@SuppressWarnings("NonAtomicOperationOnVolatileField")
+	void onRequestCompleted() {
+		responsesReceived++;
+		ongoingRequests.getAndDecrement();
+	}
 
-    @SuppressWarnings("NonAtomicOperationOnVolatileField")
-    void onPayloadReceived(int size) {
-        bytesReceived += size;
-    }
+	@SuppressWarnings("NonAtomicOperationOnVolatileField")
+	void onPayloadReceived(int size) {
+		bytesReceived += size;
+	}
 
 	public long getBytesSent() {
 		return bytesSent;
@@ -616,7 +623,6 @@ public class GrpcChannelExecutor implements Runnable {
 	}
 
 	public void onStreamClosed(GrpcStream grpcStream) {
-		// TODO: will element always be added?
 		closedStreams.add(grpcStream);
 	}
 
@@ -632,15 +638,15 @@ public class GrpcChannelExecutor implements Runnable {
 		return streamsOpen;
 	}
 
-    private static class ChannelAndEventLoop {
-        final ManagedChannel managedChannel;
-        final EventLoop eventLoop;
+	private static class ChannelAndEventLoop {
+		final ManagedChannel managedChannel;
+		final EventLoop eventLoop;
 
-        private ChannelAndEventLoop(ManagedChannel managedChannel, EventLoop eventLoop) {
-            this.managedChannel = managedChannel;
-            this.eventLoop = eventLoop;
-        }
-    }
+		private ChannelAndEventLoop(ManagedChannel managedChannel, EventLoop eventLoop) {
+			this.managedChannel = managedChannel;
+			this.eventLoop = eventLoop;
+		}
+	}
 
 	public static class ChannelTypeAndEventLoop {
 		private final Class<? extends Channel> channelType;

--- a/proxy/src/com/aerospike/client/proxy/grpc/GrpcStream.java
+++ b/proxy/src/com/aerospike/client/proxy/grpc/GrpcStream.java
@@ -116,9 +116,9 @@ public class GrpcStream implements StreamObserver<Kvs.AerospikeResponsePayload>,
 		this.id = streamIndex;
 		this.eventLoop = eventLoop;
 		ClientCall<Kvs.AerospikeRequestPayload, Kvs.AerospikeResponsePayload> call = channelExecutor.getChannel()
-				.newCall(methodDescriptor, callOptions);
+			.newCall(methodDescriptor, callOptions);
 		StreamObserver<Kvs.AerospikeRequestPayload> requestObserver =
-				ClientCalls.asyncBidiStreamingCall(call, this);
+			ClientCalls.asyncBidiStreamingCall(call, this);
 		setRequestObserver(requestObserver);
 	}
 
@@ -126,49 +126,58 @@ public class GrpcStream implements StreamObserver<Kvs.AerospikeResponsePayload>,
 		this.requestObserver = requestObserver;
 	}
 
-    @Override
-    public void onNext(Kvs.AerospikeResponsePayload aerospikeResponsePayload) {
-        // Invoke callback.
-        int id = aerospikeResponsePayload.getId();
-        GrpcStreamingCall call;
+	@Override
+	public void onNext(Kvs.AerospikeResponsePayload aerospikeResponsePayload) {
+		if (!eventLoop.inEventLoop()) {
+			// This call is not within the event loop thread. For some reason
+			// gRPC invokes some callbacks from a different thread.
+			eventLoop.schedule(() -> onNext(aerospikeResponsePayload), 0,
+				TimeUnit.NANOSECONDS);
+			return;
+		}
 
-        int payloadSize = aerospikeResponsePayload.getPayload().size();
-        bytesReceived += payloadSize;
-        channelExecutor.onPayloadReceived(payloadSize);
+		// Invoke callback.
+		int id = aerospikeResponsePayload.getId();
+		GrpcStreamingCall call;
 
-        if(aerospikeResponsePayload.getHasNext()) {
-            call = executingCalls.get(id);
-        } else {
-            call = executingCalls.remove(id);
+		int payloadSize = aerospikeResponsePayload.getPayload().size();
+		bytesReceived += payloadSize;
+		channelExecutor.onPayloadReceived(payloadSize);
 
-            // Update stats.
-            requestsInFlight--;
-            responsesReceived++;
-            channelExecutor.onRequestCompleted();
-        }
+		if (aerospikeResponsePayload.getHasNext()) {
+			call = executingCalls.get(id);
+		}
+		else {
+			call = executingCalls.remove(id);
+
+			// Update stats.
+			requestsInFlight--;
+			responsesReceived++;
+			channelExecutor.onRequestCompleted();
+		}
 
 		// Call might have expired and been cancelled.
 		if (call != null) {
 			call.onSuccess(aerospikeResponsePayload);
-		} else {
-			// TODO: log the expired call?
 		}
 
-        // TODO can it ever be greater than?
-        if (responsesReceived >= grpcClientPolicy.totalRequestsPerStream) {
-            // Complete this stream.
-            requestObserver.onCompleted();
-        } else {
-            executeCall();
-        }
-    }
+		// TODO can it ever be greater than?
+		if (responsesReceived >= grpcClientPolicy.totalRequestsPerStream) {
+			// Complete this stream.
+			requestObserver.onCompleted();
+		}
+		else {
+			executeCall();
+		}
+	}
 
-    private void abortExecutingCalls(Throwable throwable) {
-        isClosed = true;
-        for (GrpcStreamingCall call : executingCalls.values()) {
-            call.onError(throwable);
-            requestsInFlight--;
-        }
+	private void abortExecutingCalls(Throwable throwable) {
+		isClosed = true;
+
+		for (GrpcStreamingCall call : executingCalls.values()) {
+			call.onError(throwable);
+			requestsInFlight--;
+		}
 
 		executingCalls.clear();
 
@@ -177,21 +186,29 @@ public class GrpcStream implements StreamObserver<Kvs.AerospikeResponsePayload>,
 
 	@Override
 	public void onError(Throwable throwable) {
+		if (!eventLoop.inEventLoop()) {
+			// This call is not within the event loop thread. For some reason
+			// gRPC invokes error callback from a different thread.
+			eventLoop.schedule(() -> onError(throwable), 0,
+				TimeUnit.NANOSECONDS);
+			return;
+		}
+
 		abortExecutingCalls(throwable);
 	}
 
 	@Override
 	public void onCompleted() {
 		abortExecutingCalls(new AerospikeException(ResultCode.SERVER_ERROR,
-				"stream completed before all responses have been received"));
+			"stream completed before all responses have been received"));
 	}
 
-    SpscUnboundedArrayQueue<GrpcStreamingCall> getQueue() {
-        return pendingCalls;
-    }
+	SpscUnboundedArrayQueue<GrpcStreamingCall> getQueue() {
+		return pendingCalls;
+	}
 
 	MethodDescriptor<Kvs.AerospikeRequestPayload,
-			Kvs.AerospikeResponsePayload> getMethodDescriptor() {
+		Kvs.AerospikeResponsePayload> getMethodDescriptor() {
 		return methodDescriptor;
 	}
 
@@ -234,19 +251,19 @@ public class GrpcStream implements StreamObserver<Kvs.AerospikeResponsePayload>,
 		}
 
 		pendingCalls.drain(GrpcStream.this::execute, idleCounter -> idleCounter,
-				() -> !pendingCalls.isEmpty() &&
-						requestsSent < grpcClientPolicy.totalRequestsPerStream &&
-						requestsInFlight < grpcClientPolicy.maxConcurrentRequestsPerStream);
+			() -> !pendingCalls.isEmpty() &&
+				requestsSent < grpcClientPolicy.totalRequestsPerStream &&
+				requestsInFlight < grpcClientPolicy.maxConcurrentRequestsPerStream);
 	}
 
 
-    private void execute(GrpcStreamingCall call) {
-        try {
-            if (call.hasExpired()) {
-                call.onError(new AerospikeException.Timeout(call.getPolicy(),
-                        call.getIteration()));
-                return;
-            }
+	private void execute(GrpcStreamingCall call) {
+		try {
+			if (call.hasExpired()) {
+				call.onError(new AerospikeException.Timeout(call.getPolicy(),
+					call.getIteration()));
+				return;
+			}
 
 			ByteString payload = call.getRequestPayload();
 
@@ -256,13 +273,13 @@ public class GrpcStream implements StreamObserver<Kvs.AerospikeResponsePayload>,
 
 			int requestId = requestsSent++;
 			Kvs.AerospikeRequestPayload.Builder requestBuilder = Kvs.AerospikeRequestPayload.newBuilder()
-					.setPayload(payload)
-					.setId(requestId)
-					.setIteration(call.getIteration());
+				.setPayload(payload)
+				.setId(requestId)
+				.setIteration(call.getIteration());
 
 			GrpcConversions.setRequestPolicy(call.getPolicy(), requestBuilder);
 			Kvs.AerospikeRequestPayload requestPayload = requestBuilder
-					.build();
+				.build();
 			executingCalls.put(requestId, call);
 
 			requestObserver.onNext(requestPayload);
@@ -306,12 +323,12 @@ public class GrpcStream implements StreamObserver<Kvs.AerospikeResponsePayload>,
 			}
 		}
 		executingCalls.values().forEach(call -> {
-			try {
-				call.failIfNotComplete(ResultCode.CLIENT_ERROR);
-			}
-			catch (Exception e) {
-				Log.error("Error shutting down " + this.getClass() + ": " + e.getMessage());
-			}
+				try {
+					call.failIfNotComplete(ResultCode.CLIENT_ERROR);
+				}
+				catch (Exception e) {
+					Log.error("Error shutting down " + this.getClass() + ": " + e.getMessage());
+				}
 			}
 		);
 	}

--- a/proxy/src/com/aerospike/client/proxy/grpc/GrpcStreamSelector.java
+++ b/proxy/src/com/aerospike/client/proxy/grpc/GrpcStreamSelector.java
@@ -1,18 +1,20 @@
 package com.aerospike.client.proxy.grpc;
 
-import com.aerospike.proxy.client.Kvs;
-import io.grpc.MethodDescriptor;
-
 import java.util.List;
+
+import com.aerospike.proxy.client.Kvs;
+
+import io.grpc.MethodDescriptor;
 
 /**
  * A selector of streams within a channel to execute Aerospike proxy gRPC calls.
  */
 public interface GrpcStreamSelector {
     /**
-     * Select a stream for the gRPC method.
+     * Select a stream for the gRPC method. All streams created by the
+     * selector should be close when the selector is closed.
      *
-     * @param streams streams to select from.
+     * @param streams          streams to select from.
      * @param methodDescriptor the method description of the request.
      * @return the selected stream, <code>null</code> when no stream is
      * selected.


### PR DESCRIPTION
- Increased the incoming payload size to 128MB
- onError and onNext were at times called from non-event loop threads. Scheduled these calls on event loop to ensure thread safety.
- minor formatting change
- allowed sync calls from benchmarks
- minor formatting fixes