### PR TITLE
CONNECTOR-536 Each batch response is a Aerospike proto record.

### DIFF
--- a/proxy/src/com/aerospike/client/proxy/BatchProxy.java
+++ b/proxy/src/com/aerospike/client/proxy/BatchProxy.java
@@ -813,7 +813,8 @@ public class BatchProxy {
 
 			// Server errors are checked in response payload in Parser.
 			byte[] bytes = response.getPayload().toByteArray();
-			Parser parser = new Parser(bytes, 5);
+			Parser parser = new Parser(bytes);
+			parser.parseProto();
 			int rc = parser.parseHeader();
 
 			if (hasNext) {

--- a/proxy/src/com/aerospike/client/proxy/Parser.java
+++ b/proxy/src/com/aerospike/client/proxy/Parser.java
@@ -42,11 +42,6 @@ public final class Parser {
         this.buffer = buffer;
     }
 
-    public Parser(byte[] buffer, int offset) {
-        this.buffer = buffer;
-        this.offset = offset;
-    }
-
     public void parseProto() {
 		long sz = Buffer.bytesToLong(buffer, offset);
 		receiveSize = (int)(sz & 0xFFFFFFFFFFFFL);


### PR DESCRIPTION
To accommodate compression of batch responses, each batch response is a complete Aerospike wire protocol record.
 