### PR TITLE
[CONNECTOR-538] Partial scan and query API implementation

### DIFF
--- a/client/src/com/aerospike/client/async/AsyncMultiExecutor.java
+++ b/client/src/com/aerospike/client/async/AsyncMultiExecutor.java
@@ -137,7 +137,7 @@ public abstract class AsyncMultiExecutor {
 
 	final void childFailure(AerospikeException ae) {
 		// There is no need to stop commands if all commands have already completed.
-		if (! done) {
+		if (!done) {
 			done = true;
 
 			// Send stop signal to all commands.

--- a/client/src/com/aerospike/client/policy/QueryPolicy.java
+++ b/client/src/com/aerospike/client/policy/QueryPolicy.java
@@ -40,7 +40,8 @@ public class QueryPolicy extends Policy {
 
 	/**
 	 * Maximum number of concurrent requests to server nodes at any point in time.
-	 * If there are 16 nodes in the cluster and maxConcurrentNodes is 8, then queries
+	 * If there are 16 nodes in the cluster and
+	 * maxConcurrentNodes is 8, then queries
 	 * will be made to 8 nodes in parallel.  When a query completes, a new query will
 	 * be issued until all 16 nodes have been queried.
 	 * <p>

--- a/client/src/com/aerospike/client/query/Filter.java
+++ b/client/src/com/aerospike/client/query/Filter.java
@@ -210,12 +210,17 @@ public final class Filter {
 	private final Value end;
 
 	private Filter(String name, IndexCollectionType colType, int valType, Value begin, Value end, CTX[] ctx) {
+		this(name, colType, valType, begin, end, (ctx != null && ctx.length > 0) ? Pack.pack(ctx) : null);
+	}
+
+	Filter(String name, IndexCollectionType colType, int valType, Value begin
+		, Value end, byte[] packagedCtx) {
 		this.name = name;
 		this.colType = colType;
 		this.valType = valType;
 		this.begin = begin;
 		this.end = end;
-		this.packedCtx = (ctx != null && ctx.length > 0)? Pack.pack(ctx) : null;
+		this.packedCtx = packagedCtx;
 	}
 
 	/**
@@ -259,6 +264,46 @@ public final class Filter {
 	 */
 	public IndexCollectionType getCollectionType() {
 		return colType;
+	}
+
+	/**
+	 * Filter name.
+	 * For internal use only.
+	 */
+	public String getName() {
+		return name;
+	}
+
+	/**
+	 * Index collection type.
+	 * For internal use only.
+	 */
+	public IndexCollectionType getColType() {
+		return colType;
+	}
+
+	/**
+	 * Filter begin value.
+	 * For internal use only.
+	 */
+	public Value getBegin() {
+		return begin;
+	}
+
+	/**
+	 * Filter begin value.
+	 * For internal use only.
+	 */
+	public Value getEnd() {
+		return end;
+	}
+
+	/**
+	 * Filter Value type.
+	 * For internal use only.
+	 */
+	public int getValType() {
+		return valType;
 	}
 
 	/**

--- a/client/src/com/aerospike/client/query/PartitionFilter.java
+++ b/client/src/com/aerospike/client/query/PartitionFilter.java
@@ -63,11 +63,22 @@ public final class PartitionFilter implements Serializable {
 	/**
 	 * Filter by partition range.
 	 *
-	 * @param begin		start partition id (0 - 4095)
-	 * @param count		number of partitions
+	 * @param begin start partition id (0 - 4095)
+	 * @param count number of partitions
 	 */
 	public static PartitionFilter range(int begin, int count) {
 		return new PartitionFilter(begin, count);
+	}
+
+	/**
+	 * Return records after the digest in partition containing the digest.
+	 * Note that digest order is not the same as userKey order. This method
+	 * only works for scan or query with null filter.
+	 *
+	 * @param digest return records after this digest
+	 */
+	static PartitionFilter after(byte[] digest) {
+		return new PartitionFilter(digest);
 	}
 
 	final int begin;

--- a/client/src/com/aerospike/client/query/PartitionTracker.java
+++ b/client/src/com/aerospike/client/query/PartitionTracker.java
@@ -51,23 +51,33 @@ public final class PartitionTracker {
 	private long deadline;
 
 	public PartitionTracker(ScanPolicy policy, Node[] nodes) {
-		this((Policy)policy, nodes);
+		this((Policy)policy, nodes.length);
+		setMaxRecords(policy.maxRecords);
+	}
+
+	public PartitionTracker(ScanPolicy policy, int nodeCapacity) {
+		this((Policy)policy, nodeCapacity);
 		setMaxRecords(policy.maxRecords);
 	}
 
 	public PartitionTracker(QueryPolicy policy, Statement stmt, Node[] nodes) {
-		this((Policy)policy, nodes);
+		this((Policy)policy, nodes.length);
 		setMaxRecords(policy, stmt);
 	}
 
-	private PartitionTracker(Policy policy, Node[] nodes) {
+	public PartitionTracker(QueryPolicy policy, Statement stmt, int nodeCapacity) {
+		this((Policy)policy, nodeCapacity);
+		setMaxRecords(policy, stmt);
+	}
+
+	private PartitionTracker(Policy policy, int nodeCapacity) {
 		this.partitionBegin = 0;
-		this.nodeCapacity = nodes.length;
+		this.nodeCapacity = nodeCapacity;
 		this.nodeFilter = null;
 		this.partitionFilter = null;
 
 		// Create initial partition capacity for each node as average + 25%.
-		int ppn = Node.PARTITIONS / nodes.length;
+		int ppn = Node.PARTITIONS / nodeCapacity;
 		ppn += ppn >>> 2;
 		this.partitionsCapacity = ppn;
 		this.partitions = initPartitions(Node.PARTITIONS, null);
@@ -98,17 +108,33 @@ public final class PartitionTracker {
 		this((Policy)policy, nodes, filter, policy.maxRecords);
 	}
 
+	public PartitionTracker(ScanPolicy policy, int nodeCapacity,
+							PartitionFilter filter) {
+		this((Policy)policy, nodeCapacity, filter, policy.maxRecords);
+	}
+
 	public PartitionTracker(QueryPolicy policy, Statement stmt, Node[] nodes, PartitionFilter filter) {
-		this((Policy)policy, nodes, filter, (stmt.maxRecords > 0)? stmt.maxRecords : policy.maxRecords);
+		this((Policy)policy, nodes, filter, (stmt.maxRecords > 0) ? stmt.maxRecords : policy.maxRecords);
+	}
+
+	public PartitionTracker(QueryPolicy policy, Statement stmt, int nodeCapacity,
+							PartitionFilter filter) {
+		this((Policy)policy, nodeCapacity, filter, (stmt.maxRecords > 0) ?
+			stmt.maxRecords : policy.maxRecords);
 	}
 
 	private PartitionTracker(Policy policy, Node[] nodes, PartitionFilter filter, long maxRecords) {
+		this(policy, nodes.length, filter, maxRecords);
+	}
+
+	private PartitionTracker(Policy policy, int nodeCapacity, PartitionFilter filter,
+							 long maxRecords) {
 		// Validate here instead of initial PartitionFilter constructor because total number of
 		// cluster partitions may change on the server and PartitionFilter will never have access
 		// to Cluster instance.  Use fixed number of partitions for now.
-		if (! (filter.begin >= 0 && filter.begin < Node.PARTITIONS)) {
+		if (!(filter.begin >= 0 && filter.begin < Node.PARTITIONS)) {
 			throw new AerospikeException(ResultCode.PARAMETER_ERROR, "Invalid partition begin " + filter.begin +
-				". Valid range: 0-" + (Node.PARTITIONS-1));
+				". Valid range: 0-" + (Node.PARTITIONS - 1));
 		}
 
 		if (filter.count <= 0) {
@@ -122,7 +148,7 @@ public final class PartitionTracker {
 
 		setMaxRecords(maxRecords);
 		this.partitionBegin = filter.begin;
-		this.nodeCapacity = nodes.length;
+		this.nodeCapacity = nodeCapacity;
 		this.nodeFilter = null;
 		this.partitionsCapacity = filter.count;
 
@@ -322,12 +348,14 @@ public final class PartitionTracker {
 	 * Internal use only.
 	 *
 	 * @param partitionId partition id
+	 * @param digest      the record digest
 	 * @param bval        the last seen value.
 	 */
-	void setLast(int partitionId, long bval) {
+	void setLast(int partitionId, byte[] digest, long bval) {
 		for (PartitionStatus ps : partitions) {
 			if (ps.id == partitionId) {
 				ps.bval = bval;
+				ps.digest = digest;
 			}
 		}
 	}

--- a/client/src/com/aerospike/client/query/PartitionTracker.java
+++ b/client/src/com/aerospike/client/query/PartitionTracker.java
@@ -296,10 +296,40 @@ public final class PartitionTracker {
 		nodePartitions.partsUnavailable++;
 	}
 
+	/**
+	 * Update the last seen digest for a partition.
+	 * Internal use only.
+	 *
+	 * @param partitionId partition id
+	 * @param digest      the last seen digest.
+	 */
+	void setDigest(int partitionId, byte[] digest) {
+		for (PartitionStatus ps : partitions) {
+			if (ps.id == partitionId) {
+				ps.digest = digest;
+			}
+		}
+	}
+
 	public void setDigest(NodePartitions nodePartitions, Key key) {
 		int partitionId = Partition.getPartitionId(key.digest);
 		partitions[partitionId - partitionBegin].digest = key.digest;
 		nodePartitions.recordCount++;
+	}
+
+	/**
+	 * Update the last seen value for a partition.
+	 * Internal use only.
+	 *
+	 * @param partitionId partition id
+	 * @param bval        the last seen value.
+	 */
+	void setLast(int partitionId, long bval) {
+		for (PartitionStatus ps : partitions) {
+			if (ps.id == partitionId) {
+				ps.bval = bval;
+			}
+		}
 	}
 
 	public void setLast(NodePartitions nodePartitions, Key key, long bval) {

--- a/client/src/com/aerospike/client/query/QueryAggregateExecutor.java
+++ b/client/src/com/aerospike/client/query/QueryAggregateExecutor.java
@@ -33,7 +33,7 @@ import com.aerospike.client.lua.LuaInstance;
 import com.aerospike.client.lua.LuaOutputStream;
 import com.aerospike.client.policy.QueryPolicy;
 
-public final class QueryAggregateExecutor extends QueryExecutor implements Runnable {
+public class QueryAggregateExecutor extends QueryExecutor implements Runnable {
 
 	private final BlockingQueue<LuaValue> inputQueue;
 	private final ResultSet resultSet;

--- a/client/src/com/aerospike/client/task/ExecuteTask.java
+++ b/client/src/com/aerospike/client/task/ExecuteTask.java
@@ -26,7 +26,7 @@ import com.aerospike.client.query.Statement;
 /**
  * Task used to poll for long running server execute job completion.
  */
-public final class ExecuteTask extends Task {
+public class ExecuteTask extends Task {
 	private final long taskId;
 	private final boolean scan;
 
@@ -34,9 +34,30 @@ public final class ExecuteTask extends Task {
 	 * Initialize task with fields needed to query server nodes.
 	 */
 	public ExecuteTask(Cluster cluster, Policy policy, Statement statement, long taskId) {
+		this(cluster, policy, taskId, statement.isScan());
+	}
+
+	/**
+	 * Initialize task with fields needed to query server nodes.
+	 */
+	public ExecuteTask(Cluster cluster, Policy policy, long taskId,
+					   boolean isScan) {
 		super(cluster, policy);
 		this.taskId = taskId;
-		this.scan = statement.isScan();
+		this.scan = isScan;
+	}
+
+
+	/**
+	 * Initialize task with fields needed to query server nodes.
+	 * <p>
+	 * Internal use only.
+	 */
+	protected ExecuteTask(long taskId,
+						  boolean isScan) {
+		super(null, new Policy());
+		this.taskId = taskId;
+		this.scan = isScan;
 	}
 
 	/**

--- a/client/src/com/aerospike/client/task/ExecuteTask.java
+++ b/client/src/com/aerospike/client/task/ExecuteTask.java
@@ -24,7 +24,7 @@ import com.aerospike.client.policy.Policy;
 import com.aerospike.client.query.Statement;
 
 /**
- * Task used to poll for long running server execute job completion.
+ * Task used to poll for long-running server execute job completion.
  */
 public class ExecuteTask extends Task {
 	private final long taskId;

--- a/examples/src/com/aerospike/examples/AsyncQuery.java
+++ b/examples/src/com/aerospike/examples/AsyncQuery.java
@@ -67,7 +67,11 @@ public class AsyncQuery extends AsyncExample {
 
 		try {
 			IndexTask task = client.createIndex(policy, params.namespace, params.set, indexName, binName, IndexType.NUMERIC);
-			task.waitTillComplete();
+			if (task != null) {
+				// Task is not null for regular aerospike client, it will be
+				// null for proxy.
+				task.waitTillComplete();
+			}
 		}
 		catch (AerospikeException ae) {
 			if (ae.getResultCode() != ResultCode.INDEX_ALREADY_EXISTS) {

--- a/examples/src/com/aerospike/examples/QueryAverage.java
+++ b/examples/src/com/aerospike/examples/QueryAverage.java
@@ -56,8 +56,13 @@ public class QueryAverage extends Example {
 	}
 
 	private void register(IAerospikeClient client, Parameters params) throws Exception {
-		RegisterTask task = client.register(params.policy, "udf/average_example.lua", "average_example.lua", Language.LUA);
-		task.waitTillComplete();
+		try {
+			RegisterTask task = client.register(params.policy, "udf/average_example.lua", "average_example.lua", Language.LUA);
+			task.waitTillComplete();
+		}
+		catch (AerospikeException e) {
+			// Ignore for proxy.
+		}
 	}
 
 	private void createIndex(
@@ -74,7 +79,9 @@ public class QueryAverage extends Example {
 
 		try {
 			IndexTask task = client.createIndex(policy, params.namespace, params.set, indexName, binName, IndexType.NUMERIC);
-			task.waitTillComplete();
+			if (task != null) {
+				task.waitTillComplete();
+			}
 		}
 		catch (AerospikeException ae) {
 			if (ae.getResultCode() != ResultCode.INDEX_ALREADY_EXISTS) {

--- a/proxy/src/com/aerospike/client/proxy/AerospikeClientProxy.java
+++ b/proxy/src/com/aerospike/client/proxy/AerospikeClientProxy.java
@@ -1240,6 +1240,12 @@ public class AerospikeClientProxy implements IAerospikeClient, Closeable {
 
 	@Override
 	public void query(EventLoop eventLoop, RecordSequenceListener listener, QueryPolicy policy, Statement statement) {
+		if (policy == null) {
+			policy = queryPolicyDefault;
+		}
+		QueryCommandProxy command = new QueryCommandProxy(executor, policy,
+			statement, listener);
+		command.execute();
 	}
 
 	@Override

--- a/proxy/src/com/aerospike/client/proxy/BatchProxy.java
+++ b/proxy/src/com/aerospike/client/proxy/BatchProxy.java
@@ -829,7 +829,7 @@ public class BatchProxy {
 		}
 
 		@Override
-		protected final void parseResult(Parser parser) {
+		protected final void parseResult(Parser parser, boolean isLast) {
 		}
 
 		final Record parseRecord(Parser parser) {

--- a/proxy/src/com/aerospike/client/proxy/BatchProxy.java
+++ b/proxy/src/com/aerospike/client/proxy/BatchProxy.java
@@ -51,8 +51,9 @@ public class BatchProxy {
 	//-------------------------------------------------------
 
 	public interface BatchListListenerSync {
-		public void onSuccess(List<BatchRead> records, boolean status);
-		public void onFailure(AerospikeException ae);
+		void onSuccess(List<BatchRead> records, boolean status);
+
+		void onFailure(AerospikeException ae);
 	}
 
 	public static final class ReadListCommandSync extends BaseCommand {
@@ -73,7 +74,7 @@ public class BatchProxy {
 		}
 
 		@Override
-		void writeCommand(Command command) {
+		protected void writeCommand(Command command) {
 			BatchRecordIterProxy iter = new BatchRecordIterProxy(records);
 			command.setBatchOperate(batchPolicy, iter);
 		}
@@ -97,7 +98,7 @@ public class BatchProxy {
 		}
 
 		@Override
-		void onFailure(AerospikeException ae) {
+		protected void onFailure(AerospikeException ae) {
 			listener.onFailure(ae);
 		}
 	}
@@ -118,7 +119,7 @@ public class BatchProxy {
 		}
 
 		@Override
-		void writeCommand(Command command) {
+		protected void writeCommand(Command command) {
 			BatchRecordIterProxy iter = new BatchRecordIterProxy(records);
 			command.setBatchOperate(batchPolicy, iter);
 		}
@@ -141,7 +142,7 @@ public class BatchProxy {
 		}
 
 		@Override
-		void onFailure(AerospikeException ae) {
+		protected void onFailure(AerospikeException ae) {
 			listener.onFailure(ae);
 		}
 	}
@@ -162,7 +163,7 @@ public class BatchProxy {
 		}
 
 		@Override
-		void writeCommand(Command command) {
+		protected void writeCommand(Command command) {
 			BatchRecordIterProxy iter = new BatchRecordIterProxy(records);
 			command.setBatchOperate(batchPolicy, iter);
 		}
@@ -186,7 +187,7 @@ public class BatchProxy {
 		}
 
 		@Override
-		void onFailure(AerospikeException ae) {
+		protected void onFailure(AerospikeException ae) {
 			listener.onFailure(ae);
 		}
 	}
@@ -223,7 +224,7 @@ public class BatchProxy {
 		}
 
 		@Override
-		void writeCommand(Command command) {
+		protected void writeCommand(Command command) {
 			BatchAttr attr = new BatchAttr(batchPolicy, readAttr, ops);
 			KeyIterProxy iter = new KeyIterProxy(keys);
 			command.setBatchOperate(batchPolicy, iter, binNames, ops, attr);
@@ -242,7 +243,7 @@ public class BatchProxy {
 		}
 
 		@Override
-		void onFailure(AerospikeException ae) {
+		protected void onFailure(AerospikeException ae) {
 			listener.onFailure(ae);
 		}
 	}
@@ -273,7 +274,7 @@ public class BatchProxy {
 		}
 
 		@Override
-		void writeCommand(Command command) {
+		protected void writeCommand(Command command) {
 			BatchAttr attr = new BatchAttr(batchPolicy, readAttr, ops);
 			KeyIterProxy iter = new KeyIterProxy(keys);
 			command.setBatchOperate(batchPolicy, iter, binNames, ops, attr);
@@ -298,7 +299,7 @@ public class BatchProxy {
 		}
 
 		@Override
-		void onFailure(AerospikeException ae) {
+		protected void onFailure(AerospikeException ae) {
 			listener.onFailure(ae);
 		}
 	}
@@ -325,7 +326,7 @@ public class BatchProxy {
 		}
 
 		@Override
-		void writeCommand(Command command) {
+		protected void writeCommand(Command command) {
 			BatchAttr attr = new BatchAttr(batchPolicy, Command.INFO1_READ | Command.INFO1_NOBINDATA);
 			KeyIterProxy iter = new KeyIterProxy(keys);
 			command.setBatchOperate(batchPolicy, iter, null, null, attr);
@@ -345,7 +346,7 @@ public class BatchProxy {
 		}
 
 		@Override
-		void onFailure(AerospikeException ae) {
+		protected void onFailure(AerospikeException ae) {
 			listener.onFailure(ae);
 		}
 	}
@@ -366,7 +367,7 @@ public class BatchProxy {
 		}
 
 		@Override
-		void writeCommand(Command command) {
+		protected void writeCommand(Command command) {
 			BatchAttr attr = new BatchAttr(batchPolicy, Command.INFO1_READ | Command.INFO1_NOBINDATA);
 			KeyIterProxy iter = new KeyIterProxy(keys);
 			command.setBatchOperate(batchPolicy, iter, null, null, attr);
@@ -386,7 +387,7 @@ public class BatchProxy {
 		}
 
 		@Override
-		void onFailure(AerospikeException ae) {
+		protected void onFailure(AerospikeException ae) {
 			listener.onFailure(ae);
 		}
 	}
@@ -413,7 +414,7 @@ public class BatchProxy {
 		}
 
 		@Override
-		void writeCommand(Command command) {
+		protected void writeCommand(Command command) {
 			BatchRecordIterProxy iter = new BatchRecordIterProxy(records);
 			command.setBatchOperate(batchPolicy, iter);
 		}
@@ -451,7 +452,7 @@ public class BatchProxy {
 		}
 
 		@Override
-		void onFailure(AerospikeException ae) {
+		protected void onFailure(AerospikeException ae) {
 			listener.onFailure(ae);
 		}
 	}
@@ -472,7 +473,7 @@ public class BatchProxy {
 		}
 
 		@Override
-		void writeCommand(Command command) {
+		protected void writeCommand(Command command) {
 			BatchRecordIterProxy iter = new BatchRecordIterProxy(records);
 			command.setBatchOperate(batchPolicy, iter);
 		}
@@ -511,7 +512,7 @@ public class BatchProxy {
 		}
 
 		@Override
-		void onFailure(AerospikeException ae) {
+		protected void onFailure(AerospikeException ae) {
 			listener.onFailure(ae);
 		}
 	}
@@ -550,7 +551,7 @@ public class BatchProxy {
 		}
 
 		@Override
-		void writeCommand(Command command) {
+		protected void writeCommand(Command command) {
 			KeyIterProxy iter = new KeyIterProxy(keys);
 			command.setBatchOperate(batchPolicy, iter, null, ops, attr);
 		}
@@ -574,7 +575,7 @@ public class BatchProxy {
 		}
 
 		@Override
-		void onFailure(AerospikeException ae) {
+		protected void onFailure(AerospikeException ae) {
 			listener.onFailure(records, ae);
 		}
 	}
@@ -601,7 +602,7 @@ public class BatchProxy {
 		}
 
 		@Override
-		void writeCommand(Command command) {
+		protected void writeCommand(Command command) {
 			KeyIterProxy iter = new KeyIterProxy(keys);
 			command.setBatchOperate(batchPolicy, iter, null, ops, attr);
 		}
@@ -627,7 +628,7 @@ public class BatchProxy {
 		}
 
 		@Override
-		void onFailure(AerospikeException ae) {
+		protected void onFailure(AerospikeException ae) {
 			listener.onFailure(ae);
 		}
 	}
@@ -673,7 +674,7 @@ public class BatchProxy {
 		}
 
 		@Override
-		void writeCommand(Command command) {
+		protected void writeCommand(Command command) {
 			KeyIterProxy iter = new KeyIterProxy(keys);
 			command.setBatchUDF(batchPolicy, iter, packageName, functionName, argBytes, attr);
 		}
@@ -711,7 +712,7 @@ public class BatchProxy {
 		}
 
 		@Override
-		void onFailure(AerospikeException ae) {
+		protected void onFailure(AerospikeException ae) {
 			listener.onFailure(records, ae);
 		}
 	}
@@ -744,7 +745,7 @@ public class BatchProxy {
 		}
 
 		@Override
-		void writeCommand(Command command) {
+		protected void writeCommand(Command command) {
 			KeyIterProxy iter = new KeyIterProxy(keys);
 			command.setBatchUDF(batchPolicy, iter, packageName, functionName, argBytes, attr);
 		}
@@ -781,7 +782,7 @@ public class BatchProxy {
 		}
 
 		@Override
-		void onFailure(AerospikeException ae) {
+		protected void onFailure(AerospikeException ae) {
 			listener.onFailure(ae);
 		}
 	}
@@ -828,7 +829,7 @@ public class BatchProxy {
 		}
 
 		@Override
-		final void parseResult(Parser parser) {
+		protected final void parseResult(Parser parser) {
 		}
 
 		final Record parseRecord(Parser parser) {

--- a/proxy/src/com/aerospike/client/proxy/CommandProxy.java
+++ b/proxy/src/com/aerospike/client/proxy/CommandProxy.java
@@ -38,7 +38,7 @@ import io.grpc.StatusRuntimeException;
 import io.grpc.stub.StreamObserver;
 
 public abstract class CommandProxy {
-	final Policy policy;
+	protected final Policy policy;
 	private final GrpcCallExecutor executor;
 	private final MethodDescriptor<Kvs.AerospikeRequestPayload, Kvs.AerospikeResponsePayload> methodDescriptor;
 	private long deadline;
@@ -112,7 +112,7 @@ public abstract class CommandProxy {
 		byte[] bytes = response.getPayload().toByteArray();
 		Parser parser = new Parser(bytes);
 		parser.parseProto();
-		parseResult(parser);
+		parseResult(parser, !response.getHasNext());
 	}
 
 	private boolean retry() {
@@ -335,7 +335,7 @@ public abstract class CommandProxy {
 
 	protected abstract void writeCommand(Command command);
 
-	protected abstract void parseResult(Parser parser);
+	protected abstract void parseResult(Parser parser, boolean isLast);
 
 	protected abstract void onFailure(AerospikeException ae);
 }

--- a/proxy/src/com/aerospike/client/proxy/CommandProxy.java
+++ b/proxy/src/com/aerospike/client/proxy/CommandProxy.java
@@ -258,7 +258,7 @@ public abstract class CommandProxy {
 	 * @param parseBVal   indicates if bVal should be parsed
 	 * @return proxy record
 	 */
-	protected final ProxyRecord parseRecordResult(Parser parser,
+	protected final RecordProxy parseRecordResult(Parser parser,
 												  boolean isOperation, boolean parseKey,
 												  boolean parseBVal) {
 		Record record = null;
@@ -303,7 +303,7 @@ public abstract class CommandProxy {
 				throw new AerospikeException(resultCode);
 		}
 
-		return new ProxyRecord(resultCode, key, record, bVal);
+		return new RecordProxy(resultCode, key, record, bVal);
 	}
 
 	protected void handleNotFound(int resultCode) {

--- a/proxy/src/com/aerospike/client/proxy/CommandProxy.java
+++ b/proxy/src/com/aerospike/client/proxy/CommandProxy.java
@@ -93,6 +93,8 @@ public abstract class CommandProxy {
 					}
 					catch (Throwable t) {
 						onFailure(t, response.getInDoubt());
+						// Re-throw to abort at the proxy/
+						throw t;
 					}
 				}
 

--- a/proxy/src/com/aerospike/client/proxy/DeleteCommandProxy.java
+++ b/proxy/src/com/aerospike/client/proxy/DeleteCommandProxy.java
@@ -43,12 +43,12 @@ public final class DeleteCommandProxy extends CommandProxy {
 	}
 
 	@Override
-	void writeCommand(Command command) {
+	protected void writeCommand(Command command) {
 		command.setDelete(writePolicy, key);
 	}
 
 	@Override
-	void parseResult(Parser parser) {
+	protected void parseResult(Parser parser) {
 		int resultCode = parser.parseResultCode();
 		boolean existed;
 
@@ -81,7 +81,7 @@ public final class DeleteCommandProxy extends CommandProxy {
 	}
 
 	@Override
-	void onFailure(AerospikeException ae) {
+	protected void onFailure(AerospikeException ae) {
 		listener.onFailure(ae);
 	}
 }

--- a/proxy/src/com/aerospike/client/proxy/DeleteCommandProxy.java
+++ b/proxy/src/com/aerospike/client/proxy/DeleteCommandProxy.java
@@ -48,7 +48,7 @@ public final class DeleteCommandProxy extends CommandProxy {
 	}
 
 	@Override
-	protected void parseResult(Parser parser) {
+	protected void parseResult(Parser parser, boolean isLast) {
 		int resultCode = parser.parseResultCode();
 		boolean existed;
 

--- a/proxy/src/com/aerospike/client/proxy/ExecuteCommandProxy.java
+++ b/proxy/src/com/aerospike/client/proxy/ExecuteCommandProxy.java
@@ -61,8 +61,8 @@ public final class ExecuteCommandProxy extends ReadCommandProxy {
 
 	@Override
 	protected void parseResult(Parser parser, boolean isLast) {
-		ProxyRecord proxyRecord = parseRecordResult(parser, false, false, false);
-		Object obj = parseEndResult(proxyRecord.record);
+		RecordProxy recordProxy = parseRecordResult(parser, false, false, false);
+		Object obj = parseEndResult(recordProxy.record);
 
 		try {
 			executeListener.onSuccess(key, obj);

--- a/proxy/src/com/aerospike/client/proxy/ExecuteCommandProxy.java
+++ b/proxy/src/com/aerospike/client/proxy/ExecuteCommandProxy.java
@@ -55,14 +55,14 @@ public final class ExecuteCommandProxy extends ReadCommandProxy {
 	}
 
 	@Override
-	void writeCommand(Command command) {
+	protected void writeCommand(Command command) {
 		command.setUdf(writePolicy, key, packageName, functionName, args);
 	}
 
 	@Override
-	void parseResult(Parser parser) {
-		Record record = parseRecordResult(parser);
-		Object obj = parseEndResult(record);
+	protected void parseResult(Parser parser) {
+		ProxyRecord proxyRecord = parseRecordResult(parser, false, false, false);
+		Object obj = parseEndResult(proxyRecord.record);
 
 		try {
 			executeListener.onSuccess(key, obj);
@@ -104,7 +104,7 @@ public final class ExecuteCommandProxy extends ReadCommandProxy {
 	}
 
 	@Override
-	void onFailure(AerospikeException ae) {
+	protected void onFailure(AerospikeException ae) {
 		executeListener.onFailure(ae);
 	}
 }

--- a/proxy/src/com/aerospike/client/proxy/ExecuteCommandProxy.java
+++ b/proxy/src/com/aerospike/client/proxy/ExecuteCommandProxy.java
@@ -60,7 +60,7 @@ public final class ExecuteCommandProxy extends ReadCommandProxy {
 	}
 
 	@Override
-	protected void parseResult(Parser parser) {
+	protected void parseResult(Parser parser, boolean isLast) {
 		ProxyRecord proxyRecord = parseRecordResult(parser, false, false, false);
 		Object obj = parseEndResult(proxyRecord.record);
 

--- a/proxy/src/com/aerospike/client/proxy/ExecuteTaskProxy.java
+++ b/proxy/src/com/aerospike/client/proxy/ExecuteTaskProxy.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2012-2023 Aerospike, Inc.
+ *
+ * Portions may be licensed to Aerospike, Inc. under one or more contributor
+ * license agreements WHICH ARE COMPATIBLE WITH THE APACHE LICENSE, VERSION 2.0.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.aerospike.client.proxy;
+
+import java.util.concurrent.CompletableFuture;
+
+import com.aerospike.client.AerospikeException;
+import com.aerospike.client.policy.WritePolicy;
+import com.aerospike.client.proxy.grpc.GrpcCallExecutor;
+import com.aerospike.client.task.ExecuteTask;
+
+public class ExecuteTaskProxy extends ExecuteTask {
+	private final long taskId;
+	private final boolean scan;
+	private final GrpcCallExecutor callExecutor;
+
+	/**
+	 * Initialize task with fields needed to query server nodes.
+	 */
+	public ExecuteTaskProxy(GrpcCallExecutor executor, long taskId,
+							boolean isScan) {
+		super(taskId, isScan);
+		this.callExecutor = executor;
+		this.taskId = taskId;
+		this.scan = isScan;
+	}
+
+	/**
+	 * Return task id.
+	 */
+	public long getTaskId() {
+		return taskId;
+	}
+
+	/**
+	 * Query all nodes for task completion status.
+	 */
+	@Override
+	public int queryStatus() throws AerospikeException {
+		CompletableFuture<Integer> future = new CompletableFuture<>();
+		ExecuteTaskStatusCommandProxy command = new ExecuteTaskStatusCommandProxy(callExecutor,
+			new WritePolicy(), taskId, scan, future);
+		command.execute();
+		return AerospikeClientProxy.getFuture(future);
+	}
+}

--- a/proxy/src/com/aerospike/client/proxy/ExecuteTaskStatusCommandProxy.java
+++ b/proxy/src/com/aerospike/client/proxy/ExecuteTaskStatusCommandProxy.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2012-2023 Aerospike, Inc.
+ *
+ * Portions may be licensed to Aerospike, Inc. under one or more contributor
+ * license agreements WHICH ARE COMPATIBLE WITH THE APACHE LICENSE, VERSION 2.0.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.aerospike.client.proxy;
+
+import java.util.concurrent.CompletableFuture;
+
+import com.aerospike.client.AerospikeException;
+import com.aerospike.client.ResultCode;
+import com.aerospike.client.command.Command;
+import com.aerospike.client.policy.WritePolicy;
+import com.aerospike.client.proxy.grpc.GrpcCallExecutor;
+import com.aerospike.proxy.client.Kvs;
+import com.aerospike.proxy.client.QueryGrpc;
+
+/**
+ * Fetch status for a background task.
+ */
+public class ExecuteTaskStatusCommandProxy extends CommandProxy {
+	private final long taskId;
+	private final boolean isScan;
+	private final CompletableFuture<Integer> future;
+	private int status;
+
+	/**
+	 * @param executor    the gRPC call executor
+	 * @param writePolicy corresponding query write policy
+	 * @param taskId      the query statement task id
+	 * @param isScan      indicates the statement is a scan
+	 * @param future      future to get task status
+	 */
+	public ExecuteTaskStatusCommandProxy(GrpcCallExecutor executor,
+										 WritePolicy writePolicy,
+										 long taskId,
+										 boolean isScan,
+										 CompletableFuture<Integer> future) {
+		super(QueryGrpc.getBackgroundTaskStatusStreamingMethod(), executor, writePolicy);
+		this.taskId = taskId;
+		this.isScan = isScan;
+		this.future = future;
+	}
+
+	@Override
+	protected void writeCommand(Command command) {
+		// Nothing to do since there is no Aerospike payload.
+	}
+
+	@Override
+	protected void parseResult(Parser parser, boolean isLast) {
+		RecordProxy recordProxy = parseRecordResult(parser, false, true,
+			false);
+
+		// Only on response is expected.
+		if (recordProxy.resultCode != ResultCode.OK) {
+			throw new AerospikeException(recordProxy.resultCode);
+		}
+
+		// Status has been set in onResponse
+		future.complete(status);
+	}
+
+	@Override
+	void onResponse(Kvs.AerospikeResponsePayload response) {
+		// Set the value but do not report the result until the resultcode
+		// is computed in parseResult
+		if (!response.hasField(response.getDescriptorForType().findFieldByName(
+			"backgroundTaskStatus"))) {
+			throw new AerospikeException.Parse("missing task status field");
+		}
+		status = response.getBackgroundTaskStatusValue();
+		super.onResponse(response);
+	}
+
+	@Override
+	protected void onFailure(AerospikeException ae) {
+		future.completeExceptionally(ae);
+	}
+
+	@Override
+	protected Kvs.AerospikeRequestPayload.Builder getRequestBuilder() {
+		// Set the query parameters in the Aerospike request payload.
+		Kvs.AerospikeRequestPayload.Builder builder = Kvs.AerospikeRequestPayload.newBuilder();
+		Kvs.BackgroundTaskStatusRequest.Builder statusRequestBuilder =
+			Kvs.BackgroundTaskStatusRequest.newBuilder();
+		statusRequestBuilder.setTaskId(taskId);
+		statusRequestBuilder.setIsScan(isScan);
+
+		builder.setBackgroundTaskStatusRequest(statusRequestBuilder.build());
+		return builder;
+	}
+}

--- a/proxy/src/com/aerospike/client/proxy/ExistsCommandProxy.java
+++ b/proxy/src/com/aerospike/client/proxy/ExistsCommandProxy.java
@@ -46,7 +46,7 @@ public final class ExistsCommandProxy extends CommandProxy {
 	}
 
 	@Override
-	protected void parseResult(Parser parser) {
+	protected void parseResult(Parser parser, boolean isLast) {
 		int resultCode = parser.parseResultCode();
 		boolean exists;
 

--- a/proxy/src/com/aerospike/client/proxy/ExistsCommandProxy.java
+++ b/proxy/src/com/aerospike/client/proxy/ExistsCommandProxy.java
@@ -41,12 +41,12 @@ public final class ExistsCommandProxy extends CommandProxy {
 	}
 
 	@Override
-	void writeCommand(Command command) {
+	protected void writeCommand(Command command) {
 		command.setExists(policy, key);
 	}
 
 	@Override
-	void parseResult(Parser parser) {
+	protected void parseResult(Parser parser) {
 		int resultCode = parser.parseResultCode();
 		boolean exists;
 
@@ -79,7 +79,7 @@ public final class ExistsCommandProxy extends CommandProxy {
 	}
 
 	@Override
-	void onFailure(AerospikeException ae) {
+	protected void onFailure(AerospikeException ae) {
 		listener.onFailure(ae);
 	}
 }

--- a/proxy/src/com/aerospike/client/proxy/OperateCommandProxy.java
+++ b/proxy/src/com/aerospike/client/proxy/OperateCommandProxy.java
@@ -40,7 +40,7 @@ public final class OperateCommandProxy extends ReadCommandProxy {
 	}
 
 	@Override
-	void writeCommand(Command command) {
+	protected void writeCommand(Command command) {
 		command.setOperate(args.writePolicy, key, args);
 	}
 

--- a/proxy/src/com/aerospike/client/proxy/ProxyRecord.java
+++ b/proxy/src/com/aerospike/client/proxy/ProxyRecord.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2012-2023 Aerospike, Inc.
+ *
+ * Portions may be licensed to Aerospike, Inc. under one or more contributor
+ * license agreements WHICH ARE COMPATIBLE WITH THE APACHE LICENSE, VERSION 2.0.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.aerospike.client.proxy;
+
+import com.aerospike.client.Key;
+import com.aerospike.client.Record;
+import com.aerospike.client.query.BVal;
+
+public class ProxyRecord {
+	/**
+	 * Optional Key.
+	 */
+	public final Key key;
+
+	/**
+	 * Optional Record result after command has completed.
+	 */
+	public final Record record;
+
+	/**
+	 * Optional bVal.
+	 */
+	public final BVal bVal;
+
+	/**
+	 * The result code from proxy server.
+	 */
+	public final int resultCode;
+
+	public ProxyRecord(int resultCode, Key key, Record record, BVal bVal) {
+		this.resultCode = resultCode;
+		this.key = key;
+		this.record = record;
+		this.bVal = bVal;
+	}
+}

--- a/proxy/src/com/aerospike/client/proxy/ProxyResultSet.java
+++ b/proxy/src/com/aerospike/client/proxy/ProxyResultSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2022 Aerospike, Inc.
+ * Copyright 2012-2023 Aerospike, Inc.
  *
  * Portions may be licensed to Aerospike, Inc. under one or more contributor
  * license agreements WHICH ARE COMPATIBLE WITH THE APACHE LICENSE, VERSION 2.0.
@@ -14,7 +14,7 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-package com.aerospike.client.query;
+package com.aerospike.client.proxy;
 
 import java.io.Closeable;
 import java.util.Iterator;
@@ -23,34 +23,28 @@ import java.util.concurrent.BlockingQueue;
 
 import com.aerospike.client.AerospikeException;
 import com.aerospike.client.Log;
+import com.aerospike.client.query.ResultSet;
 
 /**
  * This class manages result retrieval from queries.
  * Multiple threads will retrieve results from the server nodes and put these results on the queue.
  * The single user thread consumes these results from the queue.
  */
-public class ResultSet implements Iterable<Object>, Closeable {
-	public static final Object END = new Object();
+public class ProxyResultSet extends ResultSet {
+	private final QueryAggregateCommandProxy queryAggregateCommand;
 
-	private final QueryAggregateExecutor executor;
 	private final BlockingQueue<Object> queue;
-	private Object row;
+
 	private volatile boolean valid = true;
+
+	private Object row;
 
 	/**
 	 * Initialize result set with underlying producer/consumer queue.
 	 */
-	protected ResultSet(QueryAggregateExecutor executor, int capacity) {
-		this.executor = executor;
-		this.queue = new ArrayBlockingQueue<Object>(capacity);
-	}
-
-	/**
-	 * For internal use only.
-	 */
-	protected ResultSet() {
-		this.executor = null;
-		this.queue = null;
+	protected ProxyResultSet(QueryAggregateCommandProxy queryAggregateCommand, int capacity) {
+		this.queryAggregateCommand = queryAggregateCommand;
+		this.queue = new ArrayBlockingQueue<>(capacity);
 	}
 
 	//-------------------------------------------------------
@@ -63,9 +57,9 @@ public class ResultSet implements Iterable<Object>, Closeable {
 	 *
 	 * @return whether result exists - if false, no more results are available
 	 */
-	public boolean next() throws AerospikeException {
+	public final boolean next() throws AerospikeException {
 		if (!valid) {
-			executor.checkForException();
+			queryAggregateCommand.checkForException();
 			return false;
 		}
 
@@ -76,14 +70,15 @@ public class ResultSet implements Iterable<Object>, Closeable {
 			valid = false;
 
 			if (Log.debugEnabled()) {
-				Log.debug("ResultSet " + executor.statement.taskId + " take interrupted");
+				Log.debug("ResultSet " + queryAggregateCommand.getTaskId() + " take " +
+					"interrupted");
 			}
 			return false;
 		}
 
 		if (row == END) {
 			valid = false;
-			executor.checkForException();
+			queryAggregateCommand.checkForException();
 			return false;
 		}
 		return true;
@@ -92,13 +87,13 @@ public class ResultSet implements Iterable<Object>, Closeable {
 	/**
 	 * Close query.
 	 */
-	public void close() {
+	public final void close() {
 		valid = false;
 
 		// Check if more results are available.
 		if (row != END && queue.poll() != END) {
 			// Some query threads may still be running. Stop these threads.
-			executor.stopThreads(new AerospikeException.QueryTerminated());
+			queryAggregateCommand.stop(new AerospikeException.QueryTerminated());
 		}
 	}
 
@@ -117,7 +112,7 @@ public class ResultSet implements Iterable<Object>, Closeable {
 	/**
 	 * Get result.
 	 */
-	public Object getObject() {
+	public final Object getObject() {
 		return row;
 	}
 
@@ -128,7 +123,7 @@ public class ResultSet implements Iterable<Object>, Closeable {
 	/**
 	 * Put object on the queue.
 	 */
-	public boolean put(Object object) {
+	public final boolean put(Object object) {
 		if (!valid) {
 			return false;
 		}
@@ -140,7 +135,8 @@ public class ResultSet implements Iterable<Object>, Closeable {
 		}
 		catch (InterruptedException ie) {
 			if (Log.debugEnabled()) {
-				Log.debug("ResultSet " + executor.statement.taskId + " put interrupted");
+				Log.debug("ResultSet " + queryAggregateCommand.getTaskId() + " put " +
+					"interrupted");
 			}
 
 			// Valid may have changed.  Check again.
@@ -154,7 +150,7 @@ public class ResultSet implements Iterable<Object>, Closeable {
 	/**
 	 * Abort retrieval with end token.
 	 */
-	protected void abort() {
+	public final void abort() {
 		valid = false;
 		queue.clear();
 
@@ -165,7 +161,9 @@ public class ResultSet implements Iterable<Object>, Closeable {
 			if (queue.poll() == null) {
 				// Can't offer or poll.  Nothing further can be done.
 				if (Log.debugEnabled()) {
-					Log.debug("ResultSet " + executor.statement.taskId + " both offer and poll failed on abort");
+					Log.debug("ResultSet " + queryAggregateCommand.getTaskId() + " both" +
+						" " +
+						"offer and poll failed on abort");
 				}
 				break;
 			}
@@ -175,12 +173,12 @@ public class ResultSet implements Iterable<Object>, Closeable {
 	/**
 	 * Support standard iteration interface for RecordSet.
 	 */
-	private class ResultSetIterator implements Iterator<Object>, Closeable {
+	private static class ResultSetIterator implements Iterator<Object>, Closeable {
 
-		private final ResultSet resultSet;
+		private final ProxyResultSet resultSet;
 		private boolean more;
 
-		ResultSetIterator(ResultSet resultSet) {
+		ResultSetIterator(ProxyResultSet resultSet) {
 			this.resultSet = resultSet;
 			more = this.resultSet.next();
 		}

--- a/proxy/src/com/aerospike/client/proxy/QueryAggregateCommandProxy.java
+++ b/proxy/src/com/aerospike/client/proxy/QueryAggregateCommandProxy.java
@@ -46,7 +46,7 @@ import com.aerospike.proxy.client.QueryGrpc;
  */
 public final class QueryAggregateCommandProxy extends CommandProxy implements Runnable {
 	private final BlockingQueue<LuaValue> inputQueue;
-	private final ProxyResultSet resultSet;
+	private final ResultSetProxy resultSet;
 	private final LuaInstance lua;
 	private final Statement statement;
 	private final AtomicBoolean done;
@@ -59,7 +59,7 @@ public final class QueryAggregateCommandProxy extends CommandProxy implements Ru
 		super(QueryGrpc.getQueryStreamingMethod(), executor, queryPolicy);
 		this.statement = statement;
 		this.inputQueue = new ArrayBlockingQueue<>(500);
-		this.resultSet = new ProxyResultSet(this, queryPolicy.recordQueueSize);
+		this.resultSet = new ResultSetProxy(this, queryPolicy.recordQueueSize);
 		this.done = new AtomicBoolean();
 
 		// Work around luaj LuaInteger static initialization bug.

--- a/proxy/src/com/aerospike/client/proxy/QueryAggregateCommandProxy.java
+++ b/proxy/src/com/aerospike/client/proxy/QueryAggregateCommandProxy.java
@@ -1,0 +1,246 @@
+/*
+ * Copyright 2012-2023 Aerospike, Inc.
+ *
+ * Portions may be licensed to Aerospike, Inc. under one or more contributor
+ * license agreements WHICH ARE COMPATIBLE WITH THE APACHE LICENSE, VERSION 2.0.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.aerospike.client.proxy;
+
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.luaj.vm2.LuaInteger;
+import org.luaj.vm2.LuaValue;
+
+import com.aerospike.client.AerospikeException;
+import com.aerospike.client.Log;
+import com.aerospike.client.ResultCode;
+import com.aerospike.client.Value;
+import com.aerospike.client.command.Command;
+import com.aerospike.client.lua.LuaCache;
+import com.aerospike.client.lua.LuaInputStream;
+import com.aerospike.client.lua.LuaInstance;
+import com.aerospike.client.lua.LuaOutputStream;
+import com.aerospike.client.policy.QueryPolicy;
+import com.aerospike.client.proxy.grpc.GrpcCallExecutor;
+import com.aerospike.client.proxy.grpc.GrpcConversions;
+import com.aerospike.client.query.ResultSet;
+import com.aerospike.client.query.Statement;
+import com.aerospike.proxy.client.Kvs;
+import com.aerospike.proxy.client.QueryGrpc;
+
+/**
+ * Query aggregation command for the proxy.
+ */
+public final class QueryAggregateCommandProxy extends CommandProxy implements Runnable {
+	private final BlockingQueue<LuaValue> inputQueue;
+	private final ProxyResultSet resultSet;
+	private final LuaInstance lua;
+	private final Statement statement;
+	private final AtomicBoolean done;
+	private volatile Exception exception;
+
+	public QueryAggregateCommandProxy(GrpcCallExecutor executor,
+									  ExecutorService threadPool,
+									  QueryPolicy queryPolicy,
+									  Statement statement) {
+		super(QueryGrpc.getQueryStreamingMethod(), executor, queryPolicy);
+		this.statement = statement;
+		this.inputQueue = new ArrayBlockingQueue<>(500);
+		this.resultSet = new ProxyResultSet(this, queryPolicy.recordQueueSize);
+		this.done = new AtomicBoolean();
+
+		// Work around luaj LuaInteger static initialization bug.
+		// Calling LuaInteger.valueOf(long) is required because LuaValue.valueOf() does not have
+		// a method that takes in a long parameter.  The problem is directly calling
+		// LuaInteger.valueOf(long) results in a static initialization error.
+		//
+		// If LuaValue.valueOf() is called before any luaj calls, then the static initializer in
+		// LuaInteger will be initialized properly.
+		LuaValue.valueOf(0);
+
+		// Retrieve lua instance from cache.
+		lua = LuaCache.getInstance();
+
+		try {
+			// Start Lua thread which reads from a queue, applies aggregate function and
+			// writes to a result set.
+			threadPool.execute(this);
+		}
+		catch (RuntimeException re) {
+			// Put the lua instance back if thread creation fails.
+			LuaCache.putInstance(lua);
+			throw re;
+		}
+	}
+
+	@Override
+	protected void writeCommand(Command command) {
+		// Nothing to do since there is no Aerospike payload.
+	}
+
+	@Override
+	protected void parseResult(Parser parser, boolean isLast) {
+		int resultCode = parser.parseHeader();
+		parser.skipKey();
+
+		if (resultCode != 0) {
+			// Aggregation scans (with null query filter) will return KEY_NOT_FOUND_ERROR
+			// when the set does not exist on the target node.
+			if (resultCode == ResultCode.KEY_NOT_FOUND_ERROR) {
+				// Non-fatal error.
+				return;
+			}
+			throw new AerospikeException(resultCode);
+		}
+
+		if (isLast) {
+			sendCompleted();
+			return;
+		}
+
+		if (parser.opCount != 1) {
+			throw new AerospikeException("Query aggregate expected exactly " +
+				"one bin.  Received " + parser.opCount);
+		}
+
+		LuaValue aggregateValue = parser.getLuaAggregateValue(lua);
+
+		if (done.get()) {
+			throw new AerospikeException.QueryTerminated();
+		}
+
+		if (aggregateValue != null) {
+			try {
+				inputQueue.put(aggregateValue);
+			}
+			catch (InterruptedException ie) {
+				// Ignore
+			}
+		}
+	}
+
+	@Override
+	protected void onFailure(AerospikeException ae) {
+		stop(ae);
+	}
+
+	@Override
+	protected Kvs.AerospikeRequestPayload.Builder getRequestBuilder() {
+		// Set the query parameters in the Aerospike request payload.
+		Kvs.AerospikeRequestPayload.Builder builder = Kvs.AerospikeRequestPayload.newBuilder();
+		Kvs.QueryRequest.Builder queryRequestBuilder =
+			Kvs.QueryRequest.newBuilder();
+
+		queryRequestBuilder.setQueryPolicy(GrpcConversions.toGrpc((QueryPolicy)policy));
+
+		queryRequestBuilder.setStatement(GrpcConversions.toGrpc(statement));
+		builder.setQueryRequest(queryRequestBuilder.build());
+		return builder;
+	}
+
+	public void stop(Exception cause) {
+		// There is no need to stop threads if all threads have already completed.
+		if (done.compareAndSet(false, true)) {
+			exception = cause;
+			sendCancel();
+		}
+	}
+
+	private void sendCompleted() {
+		// Send end command to lua thread.
+		// It's critical that the end put succeeds.
+		// Loop through all interrupts.
+		while (true) {
+			try {
+				inputQueue.put(LuaValue.NIL);
+				break;
+			}
+			catch (InterruptedException ie) {
+				if (Log.debugEnabled()) {
+					Log.debug("Lua input queue " + statement.getTaskId() + " put " +
+						"interrupted");
+				}
+			}
+		}
+	}
+
+	private void sendCancel() {
+		// Clear lua input queue to ensure cancel is accepted.
+		inputQueue.clear();
+		resultSet.abort();
+
+		// Send end command to lua input queue.
+		// It's critical that the end offer succeeds.
+		while (!inputQueue.offer(LuaValue.NIL)) {
+			// Queue must be full. Remove one item to make room.
+			if (inputQueue.poll() == null) {
+				// Can't offer or poll.  Nothing further can be done.
+				if (Log.debugEnabled()) {
+					Log.debug("Lua input queue " + statement.getTaskId() + " both " +
+						"offer and poll failed on abort");
+				}
+				break;
+			}
+		}
+	}
+
+	public void checkForException() {
+		// Throw an exception if an error occurred.
+		if (exception != null) {
+			if (exception instanceof AerospikeException) {
+				throw (AerospikeException)exception;
+			}
+			else {
+				throw new AerospikeException(exception);
+			}
+		}
+	}
+
+	public void run() {
+		try {
+			lua.loadPackage(statement);
+
+			LuaValue[] args = new LuaValue[4 + statement.getFunctionArgs().length];
+			args[0] = lua.getFunction(statement.getFunctionName());
+			args[1] = LuaInteger.valueOf(2);
+			args[2] = new LuaInputStream(inputQueue);
+			args[3] = new LuaOutputStream(resultSet);
+			int count = 4;
+
+			for (Value value : statement.getFunctionArgs()) {
+				args[count++] = value.getLuaValue(lua);
+			}
+			lua.call("apply_stream", args);
+		}
+		catch (Exception e) {
+			stop(e);
+		}
+		finally {
+			// Send end command to user's result set.
+			// If query was already cancelled, this put will be ignored.
+			resultSet.put(ResultSet.END);
+			LuaCache.putInstance(lua);
+		}
+	}
+
+	long getTaskId() {
+		return statement.getTaskId();
+	}
+
+	public ResultSet getResultSet() {
+		return resultSet;
+	}
+}

--- a/proxy/src/com/aerospike/client/proxy/QueryCommandProxy.java
+++ b/proxy/src/com/aerospike/client/proxy/QueryCommandProxy.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2012-2023 Aerospike, Inc.
+ *
+ * Portions may be licensed to Aerospike, Inc. under one or more contributor
+ * license agreements WHICH ARE COMPATIBLE WITH THE APACHE LICENSE, VERSION 2.0.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.aerospike.client.proxy;
+
+import com.aerospike.client.AerospikeException;
+import com.aerospike.client.ResultCode;
+import com.aerospike.client.command.Command;
+import com.aerospike.client.listener.RecordSequenceListener;
+import com.aerospike.client.policy.QueryPolicy;
+import com.aerospike.client.proxy.grpc.GrpcCallExecutor;
+import com.aerospike.client.proxy.grpc.GrpcConversions;
+import com.aerospike.client.query.Statement;
+import com.aerospike.proxy.client.Kvs;
+import com.aerospike.proxy.client.QueryGrpc;
+
+public class QueryCommandProxy extends CommandProxy {
+
+	private final Statement statement;
+
+	private final RecordSequenceListener listener;
+
+	public QueryCommandProxy(GrpcCallExecutor executor,
+							 QueryPolicy queryPolicy,
+							 Statement statement,
+							 RecordSequenceListener listener
+	) {
+		super(QueryGrpc.getQueryStreamingMethod(), executor, queryPolicy);
+		this.statement = statement;
+		this.listener = listener;
+	}
+
+	@Override
+	protected void writeCommand(Command command) {
+		// Nothing to do since there is no Aerospike payload.
+	}
+
+	@Override
+	protected void parseResult(Parser parser) {
+		ProxyRecord proxyRecord = parseRecordResult(parser, false, true,
+			false);
+
+		if (proxyRecord.resultCode == ResultCode.OK && proxyRecord.key == null) {
+			// This is the end of query marker record.
+			listener.onSuccess();
+			return;
+		}
+
+		try {
+			listener.onRecord(proxyRecord.key, proxyRecord.record);
+		}
+		catch (Throwable t) {
+			// Exception thrown from the server.
+			// TODO: sent a request to the proxy server to abort the scan.
+			logOnSuccessError(t);
+		}
+	}
+
+	@Override
+	protected void onFailure(AerospikeException ae) {
+		listener.onFailure(ae);
+	}
+
+	@Override
+	protected Kvs.AerospikeRequestPayload.Builder getRequestBuilder() {
+		// Set the query parameters in the Aerospike request payload.
+		Kvs.AerospikeRequestPayload.Builder builder = Kvs.AerospikeRequestPayload.newBuilder();
+		Kvs.QueryRequest.Builder queryRequestBuilder =
+			Kvs.QueryRequest.newBuilder();
+
+		queryRequestBuilder.setQueryPolicy(GrpcConversions.toGrpc((QueryPolicy)policy));
+
+		queryRequestBuilder.setStatement(GrpcConversions.toGrpc(statement));
+		builder.setQueryRequest(queryRequestBuilder.build());
+		return builder;
+	}
+}

--- a/proxy/src/com/aerospike/client/proxy/ReadCommandProxy.java
+++ b/proxy/src/com/aerospike/client/proxy/ReadCommandProxy.java
@@ -68,7 +68,7 @@ public class ReadCommandProxy extends CommandProxy {
 	}
 
 	@Override
-	protected void parseResult(Parser parser) {
+	protected void parseResult(Parser parser, boolean isLast) {
 		ProxyRecord proxyRecord = parseRecordResult(parser, isOperation,
 			false, false);
 

--- a/proxy/src/com/aerospike/client/proxy/ReadCommandProxy.java
+++ b/proxy/src/com/aerospike/client/proxy/ReadCommandProxy.java
@@ -69,11 +69,11 @@ public class ReadCommandProxy extends CommandProxy {
 
 	@Override
 	protected void parseResult(Parser parser, boolean isLast) {
-		ProxyRecord proxyRecord = parseRecordResult(parser, isOperation,
+		RecordProxy recordProxy = parseRecordResult(parser, isOperation,
 			false, false);
 
 		try {
-			listener.onSuccess(key, proxyRecord.record);
+			listener.onSuccess(key, recordProxy.record);
 		}
 		catch (Throwable t) {
 			logOnSuccessError(t);

--- a/proxy/src/com/aerospike/client/proxy/ReadHeaderCommandProxy.java
+++ b/proxy/src/com/aerospike/client/proxy/ReadHeaderCommandProxy.java
@@ -47,7 +47,7 @@ public final class ReadHeaderCommandProxy extends CommandProxy {
 	}
 
 	@Override
-	protected void parseResult(Parser parser) {
+	protected void parseResult(Parser parser, boolean isLast) {
 		Record record = null;
 		int resultCode = parser.parseHeader();
 

--- a/proxy/src/com/aerospike/client/proxy/ReadHeaderCommandProxy.java
+++ b/proxy/src/com/aerospike/client/proxy/ReadHeaderCommandProxy.java
@@ -42,12 +42,12 @@ public final class ReadHeaderCommandProxy extends CommandProxy {
 	}
 
 	@Override
-	void writeCommand(Command command) {
+	protected void writeCommand(Command command) {
 		command.setReadHeader(policy, key);
 	}
 
 	@Override
-	void parseResult(Parser parser) {
+	protected void parseResult(Parser parser) {
 		Record record = null;
 		int resultCode = parser.parseHeader();
 
@@ -78,7 +78,7 @@ public final class ReadHeaderCommandProxy extends CommandProxy {
 	}
 
 	@Override
-	void onFailure(AerospikeException ae) {
+	protected void onFailure(AerospikeException ae) {
 		listener.onFailure(ae);
 	}
 }

--- a/proxy/src/com/aerospike/client/proxy/RecordProxy.java
+++ b/proxy/src/com/aerospike/client/proxy/RecordProxy.java
@@ -21,7 +21,7 @@ import com.aerospike.client.Key;
 import com.aerospike.client.Record;
 import com.aerospike.client.query.BVal;
 
-public class ProxyRecord {
+public class RecordProxy {
 	/**
 	 * Optional Key.
 	 */
@@ -42,7 +42,7 @@ public class ProxyRecord {
 	 */
 	public final int resultCode;
 
-	public ProxyRecord(int resultCode, Key key, Record record, BVal bVal) {
+	public RecordProxy(int resultCode, Key key, Record record, BVal bVal) {
 		this.resultCode = resultCode;
 		this.key = key;
 		this.record = record;

--- a/proxy/src/com/aerospike/client/proxy/ResultSetProxy.java
+++ b/proxy/src/com/aerospike/client/proxy/ResultSetProxy.java
@@ -30,7 +30,7 @@ import com.aerospike.client.query.ResultSet;
  * Multiple threads will retrieve results from the server nodes and put these results on the queue.
  * The single user thread consumes these results from the queue.
  */
-public class ProxyResultSet extends ResultSet {
+public class ResultSetProxy extends ResultSet {
 	private final QueryAggregateCommandProxy queryAggregateCommand;
 
 	private final BlockingQueue<Object> queue;
@@ -42,7 +42,7 @@ public class ProxyResultSet extends ResultSet {
 	/**
 	 * Initialize result set with underlying producer/consumer queue.
 	 */
-	protected ProxyResultSet(QueryAggregateCommandProxy queryAggregateCommand, int capacity) {
+	protected ResultSetProxy(QueryAggregateCommandProxy queryAggregateCommand, int capacity) {
 		this.queryAggregateCommand = queryAggregateCommand;
 		this.queue = new ArrayBlockingQueue<>(capacity);
 	}
@@ -175,10 +175,10 @@ public class ProxyResultSet extends ResultSet {
 	 */
 	private static class ResultSetIterator implements Iterator<Object>, Closeable {
 
-		private final ProxyResultSet resultSet;
+		private final ResultSetProxy resultSet;
 		private boolean more;
 
-		ResultSetIterator(ProxyResultSet resultSet) {
+		ResultSetIterator(ResultSetProxy resultSet) {
 			this.resultSet = resultSet;
 			more = this.resultSet.next();
 		}

--- a/proxy/src/com/aerospike/client/proxy/ScanCommandProxy.java
+++ b/proxy/src/com/aerospike/client/proxy/ScanCommandProxy.java
@@ -65,17 +65,17 @@ public class ScanCommandProxy extends CommandProxy {
 
 	@Override
 	protected void parseResult(Parser parser, boolean isLast) {
-		ProxyRecord proxyRecord = parseRecordResult(parser, false, true,
+		RecordProxy recordProxy = parseRecordResult(parser, false, true,
 			false);
 
-		if (proxyRecord.resultCode == ResultCode.OK && proxyRecord.key == null) {
+		if (recordProxy.resultCode == ResultCode.OK && recordProxy.key == null) {
 			// This is the end of scan marker record.
 			listener.onSuccess();
 			return;
 		}
 
 		try {
-			listener.onRecord(proxyRecord.key, proxyRecord.record);
+			listener.onRecord(recordProxy.key, recordProxy.record);
 		}
 		catch (Throwable t) {
 			// Exception thrown from the server.

--- a/proxy/src/com/aerospike/client/proxy/TouchCommandProxy.java
+++ b/proxy/src/com/aerospike/client/proxy/TouchCommandProxy.java
@@ -43,12 +43,12 @@ public final class TouchCommandProxy extends CommandProxy {
 	}
 
 	@Override
-	void writeCommand(Command command) {
+	protected void writeCommand(Command command) {
 		command.setTouch(writePolicy, key);
 	}
 
 	@Override
-	void parseResult(Parser parser) {
+	protected void parseResult(Parser parser) {
 		int resultCode = parser.parseResultCode();
 
 		switch (resultCode) {
@@ -74,7 +74,7 @@ public final class TouchCommandProxy extends CommandProxy {
 	}
 
 	@Override
-	void onFailure(AerospikeException ae) {
+	protected void onFailure(AerospikeException ae) {
 		listener.onFailure(ae);
 	}
 }

--- a/proxy/src/com/aerospike/client/proxy/TouchCommandProxy.java
+++ b/proxy/src/com/aerospike/client/proxy/TouchCommandProxy.java
@@ -48,7 +48,7 @@ public final class TouchCommandProxy extends CommandProxy {
 	}
 
 	@Override
-	protected void parseResult(Parser parser) {
+	protected void parseResult(Parser parser, boolean isLast) {
 		int resultCode = parser.parseResultCode();
 
 		switch (resultCode) {

--- a/proxy/src/com/aerospike/client/proxy/WriteCommandProxy.java
+++ b/proxy/src/com/aerospike/client/proxy/WriteCommandProxy.java
@@ -51,12 +51,12 @@ public final class WriteCommandProxy extends CommandProxy {
 	}
 
 	@Override
-	void writeCommand(Command command) {
+	protected void writeCommand(Command command) {
 		command.setWrite(writePolicy, type, key, bins);
 	}
 
 	@Override
-	void parseResult(Parser parser) {
+	protected void parseResult(Parser parser) {
 		int resultCode = parser.parseResultCode();
 
 		switch (resultCode) {
@@ -82,7 +82,7 @@ public final class WriteCommandProxy extends CommandProxy {
 	}
 
 	@Override
-	void onFailure(AerospikeException ae) {
+	protected void onFailure(AerospikeException ae) {
 		listener.onFailure(ae);
 	}
 }

--- a/proxy/src/com/aerospike/client/proxy/WriteCommandProxy.java
+++ b/proxy/src/com/aerospike/client/proxy/WriteCommandProxy.java
@@ -56,7 +56,7 @@ public final class WriteCommandProxy extends CommandProxy {
 	}
 
 	@Override
-	protected void parseResult(Parser parser) {
+	protected void parseResult(Parser parser, boolean isLast) {
 		int resultCode = parser.parseResultCode();
 
 		switch (resultCode) {

--- a/proxy/src/com/aerospike/client/proxy/grpc/GrpcChannelExecutor.java
+++ b/proxy/src/com/aerospike/client/proxy/grpc/GrpcChannelExecutor.java
@@ -46,7 +46,6 @@ import com.aerospike.client.proxy.AerospikeClientProxy;
 import com.aerospike.client.proxy.auth.AuthTokenManager;
 import com.aerospike.client.util.Util;
 import com.aerospike.proxy.client.Kvs;
-import com.google.protobuf.ByteString;
 
 import io.grpc.CallOptions;
 import io.grpc.ManagedChannel;
@@ -151,7 +150,7 @@ public class GrpcChannelExecutor implements Runnable {
 
 	/**
 	 * A lock and its {@link Condition} to wait on for all ongoing streams
-	 * to finish before we shutdown the channel.
+	 * to finish before we shut down the channel.
 	 */
 	private final ReentrantLock shutdownLock = new ReentrantLock();
 	private final Condition shutdownCondition = shutdownLock.newCondition();
@@ -462,8 +461,7 @@ public class GrpcChannelExecutor implements Runnable {
 		}
 
 		// Update stats.
-		ByteString payload = call.getRequestPayload();
-		bytesSent += payload.size();
+		bytesSent += call.getRequestBuilder().getPayload().size();
 		requestsSent++;
 
 		// The stream will be close by the selector.

--- a/proxy/src/com/aerospike/client/proxy/grpc/GrpcConversions.java
+++ b/proxy/src/com/aerospike/client/proxy/grpc/GrpcConversions.java
@@ -239,4 +239,36 @@ public class GrpcConversions {
         }
         return builder.build();
     }
+
+    public static Kvs.BackgroundExecutePolicy toGrpc(WritePolicy writePolicy) {
+        // Base policy fields.
+        Kvs.BackgroundExecutePolicy.Builder queryPolicyBuilder = Kvs.BackgroundExecutePolicy.newBuilder();
+        Kvs.ReadModeAP readModeAP =
+            Kvs.ReadModeAP.valueOf(writePolicy.readModeAP.name());
+        queryPolicyBuilder.setReadModeAP(readModeAP);
+        Kvs.ReadModeSC readModeSC =
+            Kvs.ReadModeSC.valueOf(writePolicy.readModeSC.name());
+        queryPolicyBuilder.setReadModeSC(readModeSC);
+        Kvs.Replica replica =
+            Kvs.Replica.valueOf(writePolicy.replica.name());
+        queryPolicyBuilder.setReplica(replica);
+        if (writePolicy.filterExp != null) {
+            queryPolicyBuilder.setExpression(ByteString.copyFrom(writePolicy.filterExp.getBytes()));
+        }
+
+        queryPolicyBuilder.setTotalTimeout(writePolicy.totalTimeout);
+        queryPolicyBuilder.setCompress(writePolicy.compress);
+        queryPolicyBuilder.setSendKey(writePolicy.sendKey);
+
+        // Query policy specific fields
+        queryPolicyBuilder.setRecordExistsAction(Kvs.RecordExistsAction.valueOf(writePolicy.recordExistsAction.name()));
+        queryPolicyBuilder.setGenerationPolicy(Kvs.GenerationPolicy.valueOf(writePolicy.generationPolicy.name()));
+        queryPolicyBuilder.setCommitLevel(Kvs.CommitLevel.valueOf(writePolicy.commitLevel.name()));
+        queryPolicyBuilder.setGeneration(writePolicy.generation);
+        queryPolicyBuilder.setExpiration(writePolicy.expiration);
+        queryPolicyBuilder.setRespondAllOps(writePolicy.respondAllOps);
+        queryPolicyBuilder.setDurableDelete(writePolicy.durableDelete);
+        queryPolicyBuilder.setXdr(writePolicy.xdr);
+        return queryPolicyBuilder.build();
+    }
 }

--- a/proxy/src/com/aerospike/client/proxy/grpc/GrpcConversions.java
+++ b/proxy/src/com/aerospike/client/proxy/grpc/GrpcConversions.java
@@ -1,8 +1,17 @@
 package com.aerospike.client.proxy.grpc;
 
+import com.aerospike.client.Operation;
+import com.aerospike.client.Value;
 import com.aerospike.client.policy.Policy;
+import com.aerospike.client.policy.QueryPolicy;
+import com.aerospike.client.policy.ScanPolicy;
 import com.aerospike.client.policy.WritePolicy;
+import com.aerospike.client.query.Filter;
+import com.aerospike.client.query.PartitionFilter;
+import com.aerospike.client.query.Statement;
+import com.aerospike.client.util.Packer;
 import com.aerospike.proxy.client.Kvs;
+import com.google.protobuf.ByteString;
 
 /**
  * Conversions from native client objects to Grpc objects.
@@ -12,31 +21,222 @@ public class GrpcConversions {
                                         Kvs.AerospikeRequestPayload.Builder requestBuilder) {
         if (policy instanceof WritePolicy) {
             Kvs.WritePolicy.Builder writePolicyBuilder =
-                    Kvs.WritePolicy.newBuilder();
+                Kvs.WritePolicy.newBuilder();
             Kvs.ReadModeAP readModeAP =
-                    Kvs.ReadModeAP.valueOf(policy.readModeAP.name());
+                Kvs.ReadModeAP.valueOf(policy.readModeAP.name());
             writePolicyBuilder.setReadModeAP(readModeAP);
             Kvs.ReadModeSC readModeSC =
-                    Kvs.ReadModeSC.valueOf(policy.readModeSC.name());
+                Kvs.ReadModeSC.valueOf(policy.readModeSC.name());
             writePolicyBuilder.setReadModeSC(readModeSC);
             Kvs.Replica replica =
-                    Kvs.Replica.valueOf(policy.replica.name());
+                Kvs.Replica.valueOf(policy.replica.name());
             writePolicyBuilder.setReplica(replica);
             requestBuilder.setWritePolicy(writePolicyBuilder.build());
-        } else {
-            // TODO: Add cases for query and batch policies
+        }
+        else {
             Kvs.ReadPolicy.Builder readPolicyBuilder =
-                    Kvs.ReadPolicy.newBuilder();
+                Kvs.ReadPolicy.newBuilder();
             Kvs.ReadModeAP readModeAP =
-                    Kvs.ReadModeAP.valueOf(policy.readModeAP.name());
+                Kvs.ReadModeAP.valueOf(policy.readModeAP.name());
             readPolicyBuilder.setReadModeAP(readModeAP);
             Kvs.ReadModeSC readModeSC =
-                    Kvs.ReadModeSC.valueOf(policy.readModeSC.name());
+                Kvs.ReadModeSC.valueOf(policy.readModeSC.name());
             readPolicyBuilder.setReadModeSC(readModeSC);
             Kvs.Replica replica =
-                    Kvs.Replica.valueOf(policy.replica.name());
+                Kvs.Replica.valueOf(policy.replica.name());
             readPolicyBuilder.setReplica(replica);
             requestBuilder.setReadPolicy(readPolicyBuilder.build());
         }
+    }
+
+    public static Kvs.ScanPolicy toGrpc(ScanPolicy scanPolicy) {
+        // Base policy fields.
+        Kvs.ScanPolicy.Builder scanPolicyBuilder =
+            Kvs.ScanPolicy.newBuilder();
+        Kvs.ReadModeAP readModeAP =
+            Kvs.ReadModeAP.valueOf(scanPolicy.readModeAP.name());
+        scanPolicyBuilder.setReadModeAP(readModeAP);
+        Kvs.ReadModeSC readModeSC =
+            Kvs.ReadModeSC.valueOf(scanPolicy.readModeSC.name());
+        scanPolicyBuilder.setReadModeSC(readModeSC);
+        Kvs.Replica replica =
+            Kvs.Replica.valueOf(scanPolicy.replica.name());
+        scanPolicyBuilder.setReplica(replica);
+        if (scanPolicy.filterExp != null) {
+            scanPolicyBuilder.setExpression(ByteString.copyFrom(scanPolicy.filterExp.getBytes()));
+        }
+
+        scanPolicyBuilder.setTotalTimeout(scanPolicy.totalTimeout);
+        scanPolicyBuilder.setCompress(scanPolicy.compress);
+
+
+        // Scan policy specific fields
+        scanPolicyBuilder.setMaxRecords(scanPolicy.maxRecords);
+        scanPolicyBuilder.setRecordsPerSecond(scanPolicy.recordsPerSecond);
+        scanPolicyBuilder.setMaxConcurrentNodes(scanPolicy.maxConcurrentNodes);
+        scanPolicyBuilder.setConcurrentNodes(scanPolicy.concurrentNodes);
+        scanPolicyBuilder.setIncludeBinData(scanPolicy.includeBinData);
+
+        return scanPolicyBuilder.build();
+    }
+
+    public static Kvs.QueryPolicy toGrpc(QueryPolicy queryPolicy) {
+        // Base policy fields.
+        Kvs.QueryPolicy.Builder queryPolicyBuilder =
+            Kvs.QueryPolicy.newBuilder();
+        Kvs.ReadModeAP readModeAP =
+            Kvs.ReadModeAP.valueOf(queryPolicy.readModeAP.name());
+        queryPolicyBuilder.setReadModeAP(readModeAP);
+        Kvs.ReadModeSC readModeSC =
+            Kvs.ReadModeSC.valueOf(queryPolicy.readModeSC.name());
+        queryPolicyBuilder.setReadModeSC(readModeSC);
+        Kvs.Replica replica =
+            Kvs.Replica.valueOf(queryPolicy.replica.name());
+        queryPolicyBuilder.setReplica(replica);
+        if (queryPolicy.filterExp != null) {
+            queryPolicyBuilder.setExpression(ByteString.copyFrom(queryPolicy.filterExp.getBytes()));
+        }
+
+        queryPolicyBuilder.setTotalTimeout(queryPolicy.totalTimeout);
+        queryPolicyBuilder.setCompress(queryPolicy.compress);
+        queryPolicyBuilder.setSendKey(queryPolicy.sendKey);
+
+        // Query policy specific fields
+        queryPolicyBuilder.setMaxConcurrentNodes(queryPolicy.maxConcurrentNodes);
+        queryPolicyBuilder.setRecordQueueSize(queryPolicy.recordQueueSize);
+        queryPolicyBuilder.setIncludeBinData(queryPolicy.includeBinData);
+        queryPolicyBuilder.setFailOnClusterChange(queryPolicy.failOnClusterChange);
+        queryPolicyBuilder.setShortQuery(queryPolicy.shortQuery);
+
+        return queryPolicyBuilder.build();
+    }
+
+
+    /**
+     * Convert a value to packed bytes.
+     *
+     * @param value the value to pack
+     * @return the packed bytes.
+     */
+    public static ByteString valueToByteString(Value value) {
+        // TODO: @Brian is there a better way to convert value to bytes?
+        // This involves two copies. One when returning bytes Packer
+        // and one for the byte string.
+        Packer packer = new Packer();
+        value.pack(packer);
+        return ByteString.copyFrom(packer.toByteArray());
+    }
+
+    public static Kvs.Filter toGrpc(Filter filter) {
+        Kvs.Filter.Builder builder = Kvs.Filter.newBuilder();
+
+        builder.setName(filter.getName());
+        builder.setValType(filter.getValType());
+
+        if (filter.getBegin() != null) {
+            // TODO: @Brian is there a better way to convert value to bytes?
+            // This involves two copies. One when returning bytes Packer
+            // and one for the byte string.
+            Packer packer = new Packer();
+            filter.getBegin().pack(packer);
+            builder.setBegin(ByteString.copyFrom(packer.toByteArray()));
+        }
+
+        if (filter.getBegin() != null) {
+            builder.setBegin(valueToByteString(filter.getBegin()));
+        }
+
+        if (filter.getEnd() != null) {
+            builder.setEnd(valueToByteString(filter.getEnd()));
+        }
+
+        if (filter.getPackedCtx() != null) {
+            builder.setPackedCtx(ByteString.copyFrom(filter.getPackedCtx()));
+        }
+
+        builder.setColType(Kvs.IndexCollectionType.valueOf(filter.getColType().name()));
+        return builder.build();
+    }
+
+    public static Kvs.Operation toGrpc(Operation operation) {
+        Kvs.Operation.Builder builder = Kvs.Operation.newBuilder();
+        builder.setType(Kvs.OperationType.valueOf(operation.type.name()));
+
+        if (operation.binName != null) {
+            builder.setBinName(operation.binName);
+        }
+
+        if (operation.value != null) {
+            builder.setValue(valueToByteString(operation.value));
+        }
+
+        return builder.build();
+    }
+
+
+    /**
+     * @param statement Aerospike client statement
+     * @return equivalent gRPC {@link com.aerospike.proxy.client.Kvs.Statement}
+     */
+    public static Kvs.Statement toGrpc(Statement statement) {
+        Kvs.Statement.Builder statementBuilder = Kvs.Statement.newBuilder();
+        statementBuilder.setNamespace(statement.getNamespace());
+        if (statement.getSetName() != null) {
+            statementBuilder.setSetName(statement.getSetName());
+        }
+        if (statement.getIndexName() != null) {
+            statementBuilder.setIndexName(statement.getIndexName());
+        }
+        if (statement.getBinNames() != null) {
+            for (String binName : statement.getBinNames()) {
+                statementBuilder.addBinNames(binName);
+            }
+        }
+
+        if (statement.getFilter() != null) {
+            statementBuilder.setFilter(toGrpc(statement.getFilter()));
+        }
+
+
+        if (statement.getPackageName() != null) {
+            statementBuilder.setPackageName(statement.getPackageName());
+        }
+
+        if (statement.getFunctionName() != null) {
+            statementBuilder.setFunctionName(statement.getFunctionName());
+        }
+
+        if (statement.getFunctionArgs() != null) {
+            for (Value arg : statement.getFunctionArgs()) {
+                statementBuilder.addFunctionArgs(valueToByteString(arg));
+            }
+        }
+
+        if (statement.getOperations() != null) {
+            for (Operation operation : statement.getOperations()) {
+                statementBuilder.addOperations(toGrpc(operation));
+            }
+        }
+
+        if (statement.getTaskId() != 0) {
+            statementBuilder.setTaskId(statement.getTaskId());
+        }
+
+        statementBuilder.setMaxRecords(statement.getMaxRecords());
+        statementBuilder.setRecordsPerSecond(statement.getRecordsPerSecond());
+
+        return statementBuilder.build();
+    }
+
+    public static Kvs.PartitionFilter toGrpc(PartitionFilter partitionFilter) {
+        Kvs.PartitionFilter.Builder builder = Kvs.PartitionFilter.newBuilder();
+        builder.setBegin(partitionFilter.getBegin());
+        builder.setCount(partitionFilter.getCount());
+
+        byte[] digest = partitionFilter.getDigest();
+        if (digest != null && digest.length > 0) {
+            builder.setDigest(ByteString.copyFrom(digest));
+        }
+        return builder.build();
     }
 }

--- a/proxy/src/com/aerospike/client/proxy/grpc/GrpcConversions.java
+++ b/proxy/src/com/aerospike/client/proxy/grpc/GrpcConversions.java
@@ -8,6 +8,7 @@ import com.aerospike.client.policy.ScanPolicy;
 import com.aerospike.client.policy.WritePolicy;
 import com.aerospike.client.query.Filter;
 import com.aerospike.client.query.PartitionFilter;
+import com.aerospike.client.query.PartitionStatus;
 import com.aerospike.client.query.Statement;
 import com.aerospike.client.util.Packer;
 import com.aerospike.proxy.client.Kvs;
@@ -228,6 +229,16 @@ public class GrpcConversions {
         return statementBuilder.build();
     }
 
+    public static Kvs.PartitionStatus toGrpc(PartitionStatus ps) {
+        Kvs.PartitionStatus.Builder builder = Kvs.PartitionStatus.newBuilder();
+        builder.setId(ps.id);
+        builder.setBVal(ps.bval);
+        if (ps.digest != null) {
+            builder.setDigest(ByteString.copyFrom(ps.digest));
+        }
+        return builder.build();
+    }
+
     public static Kvs.PartitionFilter toGrpc(PartitionFilter partitionFilter) {
         Kvs.PartitionFilter.Builder builder = Kvs.PartitionFilter.newBuilder();
         builder.setBegin(partitionFilter.getBegin());
@@ -236,6 +247,12 @@ public class GrpcConversions {
         byte[] digest = partitionFilter.getDigest();
         if (digest != null && digest.length > 0) {
             builder.setDigest(ByteString.copyFrom(digest));
+        }
+
+        if (partitionFilter.getPartitions() != null) {
+            for (PartitionStatus ps : partitionFilter.getPartitions()) {
+                builder.addPartitionStatuses(toGrpc(ps));
+            }
         }
         return builder.build();
     }

--- a/proxy/src/com/aerospike/client/proxy/grpc/GrpcConversions.java
+++ b/proxy/src/com/aerospike/client/proxy/grpc/GrpcConversions.java
@@ -105,6 +105,7 @@ public class GrpcConversions {
         // Query policy specific fields
         queryPolicyBuilder.setMaxConcurrentNodes(queryPolicy.maxConcurrentNodes);
         queryPolicyBuilder.setRecordQueueSize(queryPolicy.recordQueueSize);
+        queryPolicyBuilder.setInfoTimeout(queryPolicy.infoTimeout);
         queryPolicyBuilder.setIncludeBinData(queryPolicy.includeBinData);
         queryPolicyBuilder.setFailOnClusterChange(queryPolicy.failOnClusterChange);
         queryPolicyBuilder.setShortQuery(queryPolicy.shortQuery);

--- a/proxy/src/com/aerospike/client/proxy/grpc/GrpcStreamingCall.java
+++ b/proxy/src/com/aerospike/client/proxy/grpc/GrpcStreamingCall.java
@@ -57,16 +57,23 @@ public class GrpcStreamingCall {
 	 * Iteration number of this request.
 	 */
 	private final int iteration;
+
 	/**
 	 * Indicates if this call completed (successfully or unsuccessfully).
 	 */
 	private volatile boolean completed;
+
+	/**
+	 * Indicates if this call aborted due to an application exception..
+	 */
+	private volatile boolean aborted;
 
 	protected GrpcStreamingCall(GrpcStreamingCall other) {
 		this(other.methodDescriptor, other.requestBuilder, other.getPolicy(),
 			other.iteration, other.expiresAtNanos,
 			other.responseObserver);
 		completed = other.completed;
+		aborted = other.aborted;
 	}
 
 	public GrpcStreamingCall(MethodDescriptor<Kvs.AerospikeRequestPayload,
@@ -155,5 +162,14 @@ public class GrpcStreamingCall {
 
 	public Policy getPolicy() {
 		return policy;
+	}
+
+	public void markAborted() {
+		this.aborted = true;
+		this.completed = true;
+	}
+
+	public boolean isAborted() {
+		return aborted;
 	}
 }

--- a/proxy/src/com/aerospike/client/proxy/grpc/GrpcStreamingCall.java
+++ b/proxy/src/com/aerospike/client/proxy/grpc/GrpcStreamingCall.java
@@ -19,7 +19,6 @@ package com.aerospike.client.proxy.grpc;
 import com.aerospike.client.AerospikeException;
 import com.aerospike.client.policy.Policy;
 import com.aerospike.proxy.client.Kvs;
-import com.google.protobuf.ByteString;
 
 import io.grpc.MethodDescriptor;
 import io.grpc.stub.StreamObserver;
@@ -35,9 +34,9 @@ public class GrpcStreamingCall {
             Kvs.AerospikeResponsePayload> methodDescriptor;
 
 	/**
-	 * The request payload.
+	 * The request builder populated with command call specific parameters.
 	 */
-	private final ByteString requestPayload;
+	private final Kvs.AerospikeRequestPayload.Builder requestBuilder;
 
 	/**
 	 * The stream response observer for the call.
@@ -63,33 +62,34 @@ public class GrpcStreamingCall {
 	 */
 	private volatile boolean completed;
 
-    protected GrpcStreamingCall(GrpcStreamingCall other) {
-        this(other.methodDescriptor, other.requestPayload, other.getPolicy(),
-                other.iteration, other.expiresAtNanos,
-                other.responseObserver);
+	protected GrpcStreamingCall(GrpcStreamingCall other) {
+		this(other.methodDescriptor, other.requestBuilder, other.getPolicy(),
+			other.iteration, other.expiresAtNanos,
+			other.responseObserver);
 		completed = other.completed;
-    }
-
-    public GrpcStreamingCall(MethodDescriptor<Kvs.AerospikeRequestPayload,
-            Kvs.AerospikeResponsePayload> methodDescriptor,
-                             ByteString requestPayload, Policy policy,
-                             int iteration,
-                             long expiresAtNanos,
-                             StreamObserver<Kvs.AerospikeResponsePayload> responseObserver) {
-        this.responseObserver = responseObserver;
-        this.methodDescriptor = methodDescriptor;
-        this.requestPayload = requestPayload;
-        this.iteration = iteration;
-        this.policy = policy;
-
-        if(expiresAtNanos == 0) {
-            throw new IllegalArgumentException("call has to have an expiry");
-        }
-
-        this.expiresAtNanos = expiresAtNanos;
 	}
 
-    public void onNext(Kvs.AerospikeResponsePayload payload) {
+	public GrpcStreamingCall(MethodDescriptor<Kvs.AerospikeRequestPayload,
+		Kvs.AerospikeResponsePayload> methodDescriptor,
+							 Kvs.AerospikeRequestPayload.Builder requestBuilder,
+							 Policy policy,
+							 int iteration,
+							 long expiresAtNanos,
+							 StreamObserver<Kvs.AerospikeResponsePayload> responseObserver) {
+		this.responseObserver = responseObserver;
+		this.methodDescriptor = methodDescriptor;
+		this.requestBuilder = requestBuilder;
+		this.iteration = iteration;
+		this.policy = policy;
+
+		if (expiresAtNanos == 0) {
+			throw new IllegalArgumentException("call has to have an expiry");
+		}
+
+		this.expiresAtNanos = expiresAtNanos;
+	}
+
+	public void onNext(Kvs.AerospikeResponsePayload payload) {
 		responseObserver.onNext(payload);
 		if (!payload.getHasNext()) {
 			completed = true;
@@ -126,27 +126,27 @@ public class GrpcStreamingCall {
 		return methodDescriptor;
 	}
 
-    /**
-     * @return true if this call has expired.
-     */
-    public boolean hasExpired() {
-        return hasExpiry() && (System.nanoTime() - expiresAtNanos) >= 0;
-    }
+	/**
+	 * @return true if this call has expired.
+	 */
+	public boolean hasExpired() {
+		return hasExpiry() && (System.nanoTime() - expiresAtNanos) >= 0;
+	}
 
-    public boolean hasExpiry() {
-        return expiresAtNanos != 0;
-    }
+	public boolean hasExpiry() {
+		return expiresAtNanos != 0;
+	}
 
-    public long nanosTillExpiry() {
-        if (!hasExpiry()) {
-            throw new IllegalStateException("call does not expire");
-        }
-        long nanosTillExpiry = expiresAtNanos - System.nanoTime();
-        return nanosTillExpiry > 0 ? nanosTillExpiry : 0;
-    }
+	public long nanosTillExpiry() {
+		if (!hasExpiry()) {
+			throw new IllegalStateException("call does not expire");
+		}
+		long nanosTillExpiry = expiresAtNanos - System.nanoTime();
+		return nanosTillExpiry > 0 ? nanosTillExpiry : 0;
+	}
 
-	public ByteString getRequestPayload() {
-		return requestPayload;
+	public Kvs.AerospikeRequestPayload.Builder getRequestBuilder() {
+		return requestBuilder;
 	}
 
 	public int getIteration() {


### PR DESCRIPTION
- Scan async version with and without partition filter
- Query async versions  
- Background execute
- Scan abort on application error
- node specific queries throw unsupported exception

TODO:
- Scan/Query retries potentially with separate executors.
- Sync versions of scan and query