### PR TITLE
 [CONNECTOR-660] Honour deadline and on timeout cancel long running commands on server

### DIFF
--- a/proxy/src/com/aerospike/client/proxy/BatchProxy.java
+++ b/proxy/src/com/aerospike/client/proxy/BatchProxy.java
@@ -843,7 +843,13 @@ public class BatchProxy {
 			return parser.parseRecord(isOperation);
 		}
 
+		@Override
+		boolean isSingle() {
+			return false;
+		}
+
 		abstract void parse(Parser parser, int resultCode);
+
 		abstract void onSuccess();
 	}
 

--- a/proxy/src/com/aerospike/client/proxy/MultiCommandProxy.java
+++ b/proxy/src/com/aerospike/client/proxy/MultiCommandProxy.java
@@ -134,5 +134,10 @@ public abstract class MultiCommandProxy extends CommandProxy {
 		throw new AerospikeException(code, message);
 	}
 
+	@Override
+	boolean isSingle() {
+		return false;
+	}
+
 	abstract void parseResult(Parser parser);
 }

--- a/proxy/src/com/aerospike/client/proxy/SingleCommandProxy.java
+++ b/proxy/src/com/aerospike/client/proxy/SingleCommandProxy.java
@@ -49,5 +49,10 @@ public abstract class SingleCommandProxy extends CommandProxy {
 		parseResult(parser);
 	}
 
+	@Override
+	boolean isSingle() {
+		return true;
+	}
+
 	abstract void parseResult(Parser parser);
 }

--- a/proxy/src/com/aerospike/client/proxy/grpc/GrpcChannelExecutor.java
+++ b/proxy/src/com/aerospike/client/proxy/grpc/GrpcChannelExecutor.java
@@ -557,7 +557,7 @@ public class GrpcChannelExecutor implements Runnable {
 		SpscUnboundedArrayQueue<GrpcStreamingCall> activeCalls = new SpscUnboundedArrayQueue<>(CALL_QUEUE_CHUNK_SIZE);
 
 		for (GrpcStreamingCall call = pendingCalls.poll(); call != null; call = pendingCalls.poll()) {
-			if (call.hasExpired()) {
+			if (call.hasConnectTimeoutExpired() || call.hasExpired()) {
 				call.onError(new AerospikeException.Timeout(call.getPolicy(),
 					call.getIteration()));
 			}

--- a/proxy/src/com/aerospike/client/proxy/grpc/GrpcChannelExecutor.java
+++ b/proxy/src/com/aerospike/client/proxy/grpc/GrpcChannelExecutor.java
@@ -557,7 +557,7 @@ public class GrpcChannelExecutor implements Runnable {
 		SpscUnboundedArrayQueue<GrpcStreamingCall> activeCalls = new SpscUnboundedArrayQueue<>(CALL_QUEUE_CHUNK_SIZE);
 
 		for (GrpcStreamingCall call = pendingCalls.poll(); call != null; call = pendingCalls.poll()) {
-			if (call.hasConnectTimeoutExpired() || call.hasExpired()) {
+			if (call.hasSendDeadlineExpired() || call.hasExpired()) {
 				call.onError(new AerospikeException.Timeout(call.getPolicy(),
 					call.getIteration()));
 			}


### PR DESCRIPTION
Handle calls with no deadline, but fail them if corresponding gRPC call has not been sent to the server for connect timeout milliseconds. When a call is cancelled due to exceeding a timeout, abort the call on the  proxy server if it is a call with multiple responses like batch, scan and query.
