### PR TITLE
[CONNECTOR-692] gRPC stream is closed as soon as possible

### DIFF
--- a/proxy/src/com/aerospike/client/proxy/CommandProxy.java
+++ b/proxy/src/com/aerospike/client/proxy/CommandProxy.java
@@ -64,14 +64,16 @@ public abstract class CommandProxy {
 		}
 		else {
 			deadlineNanos = 0; // No total deadline.
-			sendTimeoutMillis = (policy.socketTimeout > 0)? policy.socketTimeout : 10_000;
+			sendTimeoutMillis = Math.max(policy.socketTimeout, 0);
 		}
 
 		executeCommand();
 	}
 
 	private void executeCommand() {
-		long sendDeadlineNanos = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(sendTimeoutMillis);
+		long sendDeadlineNanos =
+			(sendTimeoutMillis > 0) ?
+				System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(sendTimeoutMillis) : 0;
 
 		Kvs.AerospikeRequestPayload.Builder builder = getRequestBuilder();
 

--- a/proxy/src/com/aerospike/client/proxy/grpc/DefaultGrpcStreamSelector.java
+++ b/proxy/src/com/aerospike/client/proxy/grpc/DefaultGrpcStreamSelector.java
@@ -60,7 +60,7 @@ public class DefaultGrpcStreamSelector implements GrpcStreamSelector {
 		List<GrpcStream> filteredStreams = streams.stream()
 			.filter(grpcStream ->
 				grpcStream.getMethodDescriptor().getFullMethodName()
-					.equals(fullMethodName)
+					.equals(fullMethodName) && grpcStream.canEnqueue()
 			)
 			.sorted(Comparator.comparingInt(GrpcStream::getId))
 			.collect(Collectors.toList());
@@ -80,8 +80,8 @@ public class DefaultGrpcStreamSelector implements GrpcStreamSelector {
 		// TODO What is the probability of this occurring? Should some streams
 		//  in a channel be reserved for rarely used API's?
 		if (filteredStreams.isEmpty()) {
-			// Create new stream.
-			return new SelectedStream(maxConcurrentRequestsPerStream, totalRequestsPerStream);
+			// No slots to create a new stream.
+			return null;
 		}
 
 		// Select stream with lowest percent of total requests executed.

--- a/proxy/src/com/aerospike/client/proxy/grpc/GrpcCallExecutor.java
+++ b/proxy/src/com/aerospike/client/proxy/grpc/GrpcCallExecutor.java
@@ -25,7 +25,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.LongAdder;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-
 import javax.annotation.Nullable;
 
 import com.aerospike.client.AerospikeException;
@@ -185,7 +184,7 @@ public class GrpcCallExecutor implements Closeable {
 		// Wait for all executors to terminate.
 		while (true) {
 			boolean allTerminated = executors.stream()
-				.allMatch(executor -> executor.isTerminated());
+				.allMatch(GrpcChannelExecutor::isTerminated);
 
 			if (allTerminated) {
 				return;
@@ -193,6 +192,7 @@ public class GrpcCallExecutor implements Closeable {
 
 			Log.debug("Waiting for executors to shutdown with closeTimeout=" + grpcClientPolicy.closeTimeout);
 			try {
+				//noinspection BusyWait
 				Thread.sleep(1000);
 			}
 			catch (Throwable t) {/* Ignore*/}

--- a/proxy/src/com/aerospike/client/proxy/grpc/GrpcChannelExecutor.java
+++ b/proxy/src/com/aerospike/client/proxy/grpc/GrpcChannelExecutor.java
@@ -24,8 +24,8 @@ import java.security.KeyStore;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.LinkedList;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -122,8 +122,7 @@ public class GrpcChannelExecutor implements Runnable {
 	/**
 	 * Queue of closed streams.
 	 */
-	private final MpscUnboundedArrayQueue<GrpcStream> closedStreams =
-		new MpscUnboundedArrayQueue<>(32);
+	private final List<GrpcStream> closedStreams = new ArrayList<>(32);
 	/**
 	 * Map of stream id to streams.
 	 */
@@ -319,7 +318,7 @@ public class GrpcChannelExecutor implements Runnable {
 			grpcClientPolicy.connectTimeoutMillis);
 		builder.userAgent(AEROSPIKE_CLIENT_USER_AGENT);
 
-		// better to have a receive buffer predictor
+		// TODO: better to have a receive buffer predictor
 		//builder.withOption(ChannelOption.valueOf("receiveBufferSizePredictorFactory"), new AdaptiveReceiveBufferSizePredictorFactory(MIN_PACKET_SIZE, INITIAL_PACKET_SIZE, MAX_PACKET_SIZE))
 
 		//if the server is sending 1000 messages per sec, optimum write buffer watermarks will
@@ -349,6 +348,9 @@ public class GrpcChannelExecutor implements Runnable {
 		}
 		catch (Exception e) {
 			// TODO: signal failure, close channel?
+			if (Log.debugEnabled()) {
+				Log.debug("Uncaught exception in " + this + ":" + e);
+			}
 		}
 	}
 
@@ -417,10 +419,11 @@ public class GrpcChannelExecutor implements Runnable {
 		pendingCalls.drain(this::scheduleCalls, drainLimit);
 
 		// Execute stream calls.
-		streams.values().forEach(GrpcStream::executeCall);
+		streams.values().forEach(GrpcStream::executePendingCalls);
 
 		// Process closed streams.
-		closedStreams.drain(this::processClosedStream, drainLimit);
+		closedStreams.forEach(this::processClosedStream);
+		closedStreams.clear();
 	}
 
 	/**
@@ -465,21 +468,28 @@ public class GrpcChannelExecutor implements Runnable {
 			return;
 		}
 
+		if (call.hasSendDeadlineExpired() || call.hasExpired()) {
+			call.onError(new AerospikeException.Timeout(call.getPolicy(),
+				call.getIteration()));
+			return;
+		}
+
 		// The stream will be close by the selector.
-		//noinspection resource
 		GrpcStreamSelector.SelectedStream selectedStream =
 			grpcClientPolicy.grpcStreamSelector.select(new ArrayList<>(streams.values()), call);
+
+		if (selectedStream == null) {
+			// Requeue
+			pendingCalls.add(call);
+			return;
+		}
 
 		if (selectedStream.useExistingStream()) {
 			selectedStream.getStream().enqueue(call);
 			return;
 		}
 
-		// Create new stream.
-		LinkedList<GrpcStreamingCall> queue = new LinkedList<GrpcStreamingCall>();
-		queue.add(call);
-
-		scheduleCallsOnNewStream(call.getStreamingMethodDescriptor(), queue,
+		scheduleCallsOnNewStream(call.getStreamingMethodDescriptor(), call,
 			selectedStream.getMaxConcurrentRequestsPerStream(),
 			selectedStream.getTotalRequestsPerStream());
 	}
@@ -487,12 +497,11 @@ public class GrpcChannelExecutor implements Runnable {
 	private void processClosedStream(GrpcStream grpcStream) {
 		if (streams.remove(grpcStream.getId()) == null) {
 			// Should never happen.
-			// TODO: throw Exception.
 			return;
 		}
 
 		// Schedule each of the pending calls.
-		grpcStream.getPendingCalls().forEach(this::scheduleCalls);
+		pendingCalls.addAll(grpcStream.getPendingCalls());
 	}
 
 	/**
@@ -500,7 +509,7 @@ public class GrpcChannelExecutor implements Runnable {
 	 */
 	private void scheduleCallsOnNewStream(
 		MethodDescriptor<Kvs.AerospikeRequestPayload, Kvs.AerospikeResponsePayload> methodDescriptor,
-		LinkedList<GrpcStreamingCall> pendingCalls,
+		GrpcStreamingCall call,
 		int maxConcurrentRequestsPerStream, int totalRequestsPerStream
 	) {
 		if (maxConcurrentRequestsPerStream <= 0) { // Should never happen.
@@ -519,38 +528,15 @@ public class GrpcChannelExecutor implements Runnable {
 			catch (Exception e) {
 				AerospikeException aerospikeException =
 					new AerospikeException(ResultCode.NOT_AUTHENTICATED, e);
-				pendingCalls.forEach(call -> call.onError(aerospikeException));
+				call.onError(aerospikeException);
 				return;
 			}
 		}
 
-		// Error out all expired calls. When the proxy server is not
-		// reachable, the pendingCalls cycles between streams. The sequence
-		// of events are
-		// - a new stream is created with pendingCalls
-		// - asyncBidiStream creation on the new stream fails immediately,
-		// onError method on the new stream is invoked
-		// - the onError of the new stream calls GrpcChannelExecutor
-		// .onStreamClosed with the same pendingCalls
-		// - in the next call of GrpcChannelExecutor.processClosedStreams in
-		// an iteration the above steps repeat
-
-		Iterator<GrpcStreamingCall> iterator = pendingCalls.iterator();
-		while (iterator.hasNext()) {
-			GrpcStreamingCall call = iterator.next();
-			if (call.hasSendDeadlineExpired() || call.hasExpired()) {
-				call.onError(new AerospikeException.Timeout(call.getPolicy(),
-					call.getIteration()));
-				iterator.remove(); // Remove expired call from queue.
-			}
-		}
-
-		if (pendingCalls.isEmpty()) {
-			return;
-		}
-
+		LinkedList<GrpcStreamingCall> streamPendingCalls = new LinkedList<>();
+		streamPendingCalls.add(call);
 		GrpcStream stream = new GrpcStream(this, methodDescriptor,
-			pendingCalls, options, nextStreamId(), eventLoop,
+			streamPendingCalls, options, nextStreamId(), eventLoop,
 			maxConcurrentRequestsPerStream, totalRequestsPerStream);
 
 		streams.put(stream.getId(), stream);
@@ -602,7 +588,7 @@ public class GrpcChannelExecutor implements Runnable {
 		}
 		streams.values().forEach(stream -> {
 			try {
-				stream.close();
+				stream.closePendingCalls();
 			}
 			catch (Exception e) {
 				Log.error("Error closing stream " + stream + ": " + e.getMessage());

--- a/proxy/src/com/aerospike/client/proxy/grpc/GrpcStream.java
+++ b/proxy/src/com/aerospike/client/proxy/grpc/GrpcStream.java
@@ -16,8 +16,6 @@
  */
 package com.aerospike.client.proxy.grpc;
 
-import java.io.Closeable;
-import java.io.IOException;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedList;
@@ -49,9 +47,13 @@ import io.netty.channel.EventLoop;
  *     executed on a single event loop</li>
  * </ul>
  * <p>
- * TODO: Should the stream be closed if it has been idle for some duration?
  */
-public class GrpcStream implements StreamObserver<Kvs.AerospikeResponsePayload>, Closeable {
+public class GrpcStream implements StreamObserver<Kvs.AerospikeResponsePayload> {
+	/**
+	 * Idle timeout after which the stream is closed, when no call are pending.
+	 */
+	private static final long IDLE_TIMEOUT = 30_000;
+
 	/**
 	 * Unique stream id in the channel.
 	 */
@@ -90,7 +92,7 @@ public class GrpcStream implements StreamObserver<Kvs.AerospikeResponsePayload>,
 
 	/**
 	 * Queued calls pending execution.
-	 *
+	 * <p>
 	 * <b>WARN</b> Ensure this is always accessed from the {@link #eventLoop}
 	 * thread.
 	 */
@@ -109,8 +111,29 @@ public class GrpcStream implements StreamObserver<Kvs.AerospikeResponsePayload>,
 
 	// Stream statistics. These are only updated from the event loop thread
 	// assigned to this stream and its channel.
+
+	/**
+	 * Number of requests sent on the gRPC stream. This is only updated from
+	 * the event loop thread assigned to this stream and its channel.
+	 */
 	private volatile int requestsSent;
+
+	/**
+	 * Number of requests completed. This is only updated from
+	 * the event loop thread assigned to this stream and its channel.
+	 */
 	private volatile int requestsCompleted;
+
+	/**
+	 * Timer started when this stream has no pending calls.
+	 * There may still be calls executing (in-flight).
+	 */
+	private volatile long streamIdleStartTime;
+
+	/**
+	 * Indicates if the gRPC stream has been half closed from this side.
+	 */
+	private boolean streamHalfClosed;
 
 	public GrpcStream(
 		GrpcChannelExecutor channelExecutor,
@@ -177,14 +200,7 @@ public class GrpcStream implements StreamObserver<Kvs.AerospikeResponsePayload>,
 			}
 		}
 
-		// TODO can it ever be greater than?
-		if (requestsCompleted >= totalRequestsToExecute) {
-			// Complete this stream.
-			requestObserver.onCompleted();
-		}
-		else {
-			executeCall();
-		}
+		executePendingCalls();
 	}
 
 	private void abortCallAtServer(GrpcStreamingCall call, int callId) {
@@ -203,8 +219,23 @@ public class GrpcStream implements StreamObserver<Kvs.AerospikeResponsePayload>,
 		isClosed = true;
 
 		for (GrpcStreamingCall call : executingCalls.values()) {
-			call.onError(throwable);
+			try {
+				call.onError(throwable);
+			}
+			catch (Exception e) {
+				Log.debug("Exception in invoking onError: " + e);
+			}
 		}
+
+		markClosed();
+	}
+
+	/**
+	 * Marks the stream as closed and moves pending calls nack to the channel
+	 * executor.
+	 */
+	private void markClosed() {
+		isClosed = true;
 
 		executingCalls.clear();
 
@@ -219,6 +250,21 @@ public class GrpcStream implements StreamObserver<Kvs.AerospikeResponsePayload>,
 			eventLoop.schedule(() -> onError(throwable), 0,
 				TimeUnit.NANOSECONDS);
 			return;
+		}
+
+		if (executingCalls.isEmpty()) {
+			// gRPC stream creation failed.
+			// Fail all pending calls, otherwise they will keep cycling
+			// through until a stream creation succeeds.
+			for (GrpcStreamingCall call : pendingCalls) {
+				try {
+					call.onError(throwable);
+				}
+				catch (Exception e) {
+					Log.debug("Exception in invoking onError: " + e);
+				}
+			}
+			pendingCalls.clear();
 		}
 
 		abortExecutingCalls(throwable);
@@ -273,8 +319,32 @@ public class GrpcStream implements StreamObserver<Kvs.AerospikeResponsePayload>,
 		return getRequestsCompleted() + getOngoingRequests();
 	}
 
-	public void executeCall() {
+	public void executePendingCalls() {
 		if (isClosed) {
+			return;
+		}
+
+		if (pendingCalls.isEmpty()) {
+			if (streamIdleStartTime == 0) {
+				streamIdleStartTime = System.currentTimeMillis();
+			}
+
+			if (streamIdleStartTime + IDLE_TIMEOUT <= System.currentTimeMillis() && !streamHalfClosed) {
+				streamHalfClosed = true;
+				requestObserver.onCompleted();
+			}
+		}
+		else if (streamIdleStartTime != 0) {
+			streamIdleStartTime = 0;
+		}
+
+		if (streamHalfClosed) {
+			if (executingCalls.isEmpty()) {
+				// All executing calls are over.
+				markClosed();
+			}
+
+			// Should not push any new calls on this stream.
 			return;
 		}
 
@@ -288,10 +358,8 @@ public class GrpcStream implements StreamObserver<Kvs.AerospikeResponsePayload>,
 
 				iterator.remove(); // Remove from pending.
 			}
-			else if (requestsSent < totalRequestsToExecute &&
-				executingCalls.size() < maxConcurrentRequests) {
+			else if (executingCalls.size() < maxConcurrentRequests && requestsSent < totalRequestsToExecute) {
 				execute(call);
-
 				iterator.remove(); // Remove from pending.
 			}
 			else {
@@ -322,6 +390,12 @@ public class GrpcStream implements StreamObserver<Kvs.AerospikeResponsePayload>,
 
 			requestObserver.onNext(requestPayload);
 
+			if (requestsSent >= totalRequestsToExecute) {
+				// Complete this stream.
+				requestObserver.onCompleted();
+				streamHalfClosed = true;
+			}
+
 			if (call.hasExpiry()) {
 				// TODO: Is there a need for a more efficient implementation in
 				//  terms of the call cancellation.
@@ -346,18 +420,25 @@ public class GrpcStream implements StreamObserver<Kvs.AerospikeResponsePayload>,
 		// Cancel call.
 		call.onError(new AerospikeException.Timeout(call.getPolicy(), call.getIteration()));
 
-		// Abort long running calls at server.
+		// Abort long-running calls at server.
 		if (!call.isSingleResponse()) {
 			abortCallAtServer(call, callId);
 		}
 	}
 
+	boolean canEnqueue() {
+		return !isClosed && !streamHalfClosed && requestsSent < totalRequestsToExecute;
+	}
+
+	/**
+	 * Enqueue the call to this stream. Should only be invoked if
+	 * {@link #canEnqueue()} returned true.
+	 */
 	void enqueue(GrpcStreamingCall call) {
 		pendingCalls.add(call);
 	}
 
-	@Override
-	public void close() throws IOException {
+	public void closePendingCalls() {
 		pendingCalls.forEach(call -> {
 			try {
 				call.failIfNotComplete(ResultCode.CLIENT_ERROR);
@@ -380,9 +461,10 @@ public class GrpcStream implements StreamObserver<Kvs.AerospikeResponsePayload>,
 
 		executingCalls.clear();
 
-		// For hygiene close the stream as well.
+		// For hygiene complete the stream as well.
 		try {
 			requestObserver.onCompleted();
+			streamHalfClosed =true;
 		}
 		catch (Throwable t) {
 			// Ignore.

--- a/proxy/src/com/aerospike/client/proxy/grpc/GrpcStreamingCall.java
+++ b/proxy/src/com/aerospike/client/proxy/grpc/GrpcStreamingCall.java
@@ -50,7 +50,8 @@ public class GrpcStreamingCall {
 
 	/**
 	 * The deadline in nanoseconds w.r.t System.nanoTime() for this call to
-	 * be handed to the underlying gRPC sub system.
+	 * be handed to the underlying gRPC sub system. A value of zero indicates
+	 * that the call has no send deadline.
 	 */
 	private final long sendDeadlineNanos;
 
@@ -159,7 +160,7 @@ public class GrpcStreamingCall {
 	 * @return true if the send deadline has expired.
 	 */
 	public boolean hasSendDeadlineExpired() {
-		return (System.nanoTime() - sendDeadlineNanos) >= 0;
+		return sendDeadlineNanos > 0 && (System.nanoTime() - sendDeadlineNanos) >= 0;
 	}
 
 	public boolean hasExpiry() {


### PR DESCRIPTION
- Close the stream when there are no executing calls so that pending calls can be moved immediately to other streams
- Allow sendCallDeadline derived from socketTimeout and totalTimeout to be zero
- On connect error all pending calls are immediately failed
- Requeue if all streams on the channel are exhausted or busy and new streams cannot be created