### PR TITLE
[CONNECTOR-698] Fix SSL context creation in proxy fails when OpenSSL is the SSL provider.

### DIFF
--- a/proxy/src/com/aerospike/client/proxy/grpc/GrpcChannelExecutor.java
+++ b/proxy/src/com/aerospike/client/proxy/grpc/GrpcChannelExecutor.java
@@ -23,6 +23,7 @@ import java.net.SocketAddress;
 import java.security.KeyStore;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -192,7 +193,8 @@ public class GrpcChannelExecutor implements Runnable {
 			SslContextBuilder sslContextBuilder = GrpcSslContexts.forClient();
 			Field field = sslContextBuilder.getClass().getDeclaredField("apn");
 			field.setAccessible(true);
-			ApplicationProtocolConfig apn = (ApplicationProtocolConfig)field.get(sslContextBuilder);
+			ApplicationProtocolConfig applicationProtocolConfig = (ApplicationProtocolConfig)field.get(sslContextBuilder);
+
 			if (tlsPolicy.context != null) {
 				CipherSuiteFilter csf = (tlsPolicy.ciphers != null) ? (iterable, list, set) -> {
 					if (tlsPolicy.ciphers != null) {
@@ -200,10 +202,26 @@ public class GrpcChannelExecutor implements Runnable {
 					}
 					return tlsPolicy.context.getSupportedSSLParameters().getCipherSuites();
 				} : IdentityCipherSuiteFilter.INSTANCE;
+
+				// Enforce ALPN in case NPN_AND_ALPN is the supported protocol.
+				// JdkSslContext fails with an exception when the protocol is
+				// NPN_AND_ALPN.
+				ApplicationProtocolConfig apn = applicationProtocolConfig;
+				if (applicationProtocolConfig.protocol() == ApplicationProtocolConfig.Protocol.NPN_AND_ALPN) {
+					// Constructor copied verbatim from package-private field
+					// io.grpc.netty.GrpcSslContexts.ALPN
+					apn = new ApplicationProtocolConfig(
+						ApplicationProtocolConfig.Protocol.ALPN,
+						ApplicationProtocolConfig.SelectorFailureBehavior.NO_ADVERTISE,
+						ApplicationProtocolConfig.SelectedListenerFailureBehavior.ACCEPT,
+						Collections.singletonList("h2"));
+				}
+
 				return new JdkSslContext(tlsPolicy.context, true, null, csf, apn, ClientAuth.NONE, null, false);
 			}
+
 			SslContextBuilder builder = SslContextBuilder.forClient();
-			builder.applicationProtocolConfig(apn);
+			builder.applicationProtocolConfig(applicationProtocolConfig);
 			if (tlsPolicy.protocols != null) {
 				builder.protocols(tlsPolicy.protocols);
 			}


### PR DESCRIPTION
When OpenSSL is available GrpcSslContext builder sets the supported protocols to NPN_AND_ALPN. When a com.aerospike.client.policy.TlsPolicy is passed in with a SSLContext, in proxy client code io.netty.handler.ssl.JdkSslContext is created with the passed in SSLContext being used as the delegate, but io.netty.handler.ssl.JdkSslContext fails with an exception when the supported protocols is NPN_AND_ALPN.

Solution is to create an application protocol config with only ALPN support when NPN_AND_ALPN support is detected.