### PR TITLE
Build and upload proxy client to JFrog

### DIFF
--- a/.github/workflows/build-proxy.yml
+++ b/.github/workflows/build-proxy.yml
@@ -1,0 +1,30 @@
+name: Build and upload proxy client to JFrog
+
+on:
+  push:
+    branches:
+      - stage
+      # TODO: remove this once proxy branch is removed
+      - proxy
+  # TODO: remove this once we verify that this workflow works
+  pull_request:
+    branches:
+      - proxy
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Java client
+      uses: actions/checkout@v2
+
+    - name: Set up settings.xml for Maven
+      uses: s4u/maven-settings-action@v2.8.0
+      with:
+        servers: '[{"id": "snapshots_private", "username": "${{ secrets.JFROG_USERNAME }}", "password": "${{ secrets.JFROG_MAVEN_TOKEN }}"}]'
+
+    - name: Build Java client
+      run: mvn install
+
+    - name: Upload to JFrog
+      run: mvn deploy

--- a/.github/workflows/build-proxy.yml
+++ b/.github/workflows/build-proxy.yml
@@ -6,10 +6,6 @@ on:
       - stage
       # TODO: remove this once proxy branch is removed
       - proxy
-  # TODO: remove this once we verify that this workflow works
-  pull_request:
-    branches:
-      - proxy
 
 jobs:
   build:

--- a/pom.xml
+++ b/pom.xml
@@ -175,11 +175,11 @@
   </build>
 
   <repositories>
-    <repository>
+    <snapshotRepository>
       <id>snapshots_private</id>
       <name>aerospike-maven-dev</name>
       <url>https://aerospike.jfrog.io/artifactory/aerospike-maven-dev</url>
-    </repository>
+    </snapshotRepository>
     <repository>
       <id>oss-sonatype</id>
       <url>${oss.sonatype.url}</url>

--- a/pom.xml
+++ b/pom.xml
@@ -176,6 +176,11 @@
 
   <repositories>
     <repository>
+      <id>snapshots_private</id>
+      <name>aerospike-maven-dev</name>
+      <url>https://aerospike.jfrog.io/artifactory/aerospike-maven-dev</url>
+    </repository>
+    <repository>
       <id>oss-sonatype</id>
       <url>${oss.sonatype.url}</url>
     </repository>

--- a/pom.xml
+++ b/pom.xml
@@ -175,11 +175,6 @@
   </build>
 
   <repositories>
-    <snapshotRepository>
-      <id>snapshots_private</id>
-      <name>aerospike-maven-dev</name>
-      <url>https://aerospike.jfrog.io/artifactory/aerospike-maven-dev</url>
-    </snapshotRepository>
     <repository>
       <id>oss-sonatype</id>
       <url>${oss.sonatype.url}</url>
@@ -193,10 +188,11 @@
       <url>${github.packages.url}</url>
     </repository>
 
-    <!-- For now snapshots are in maven central snapshots -->
+    <!-- Upload snapshots to internal JFrog maven repo -->
     <snapshotRepository>
-      <id>oss-sonatype</id>
-      <url>${oss.sonatype.url}</url>
+      <id>snapshots_private</id>
+      <name>aerospike-maven-dev</name>
+      <url>https://aerospike.jfrog.io/artifactory/aerospike-maven-dev</url>
     </snapshotRepository>
   </distributionManagement>
 


### PR DESCRIPTION
Proof that workflow successfully uploads a build of the Proxy client to JFrog: https://github.com/aerospike/aerospike-client-java/actions/runs/5327702296/jobs/9651451724

Each proxy client build seems to be labelled automatically by Maven, with the above build labelled as `20230620.214820-7`: https://aerospike.jfrog.io/ui/native/aerospike-maven-dev/com/aerospike/aerospike-proxy-client/6.1.9-SNAPSHOT/

Note: The sources jar wasn't uploaded to JFrog