### PR TITLE
CONNECTOR-758 Set inDoubt flag for all failed records in a batch

### DIFF
--- a/proxy/src/com/aerospike/client/proxy/BatchProxy.java
+++ b/proxy/src/com/aerospike/client/proxy/BatchProxy.java
@@ -98,6 +98,11 @@ public class BatchProxy {
 
 		@Override
 		void onFailure(AerospikeException ae) {
+			for (BatchRecord record : records) {
+				if (record.resultCode == ResultCode.NO_RESPONSE) {
+					record.inDoubt = record.hasWrite && inDoubt;
+				}
+			}
 			listener.onFailure(ae);
 		}
 	}
@@ -142,6 +147,11 @@ public class BatchProxy {
 
 		@Override
 		void onFailure(AerospikeException ae) {
+			for (BatchRecord record : records) {
+				if (record.resultCode == ResultCode.NO_RESPONSE) {
+					record.inDoubt = record.hasWrite && inDoubt;
+				}
+			}
 			listener.onFailure(ae);
 		}
 	}
@@ -187,6 +197,11 @@ public class BatchProxy {
 
 		@Override
 		void onFailure(AerospikeException ae) {
+			for (BatchRecord record : records) {
+				if (record.resultCode == ResultCode.NO_RESPONSE) {
+					record.inDoubt = record.hasWrite && inDoubt;
+				}
+			}
 			listener.onFailure(ae);
 		}
 	}
@@ -452,6 +467,11 @@ public class BatchProxy {
 
 		@Override
 		void onFailure(AerospikeException ae) {
+			for (BatchRecord record : records) {
+				if (record.resultCode == ResultCode.NO_RESPONSE) {
+					record.inDoubt = record.hasWrite && inDoubt;
+				}
+			}
 			listener.onFailure(ae);
 		}
 	}
@@ -512,6 +532,11 @@ public class BatchProxy {
 
 		@Override
 		void onFailure(AerospikeException ae) {
+			for (BatchRecord record : records) {
+				if (record.resultCode == ResultCode.NO_RESPONSE) {
+					record.inDoubt = record.hasWrite && inDoubt;
+				}
+			}
 			listener.onFailure(ae);
 		}
 	}
@@ -712,6 +737,11 @@ public class BatchProxy {
 
 		@Override
 		void onFailure(AerospikeException ae) {
+			for (BatchRecord record : records) {
+				if (record.resultCode == ResultCode.NO_RESPONSE) {
+					record.inDoubt = record.hasWrite && inDoubt;
+				}
+			}
 			listener.onFailure(records, ae);
 		}
 	}

--- a/proxy/src/com/aerospike/client/proxy/BatchProxy.java
+++ b/proxy/src/com/aerospike/client/proxy/BatchProxy.java
@@ -98,11 +98,6 @@ public class BatchProxy {
 
 		@Override
 		void onFailure(AerospikeException ae) {
-			for (BatchRecord record : records) {
-				if (record.resultCode == ResultCode.NO_RESPONSE) {
-					record.inDoubt = record.hasWrite && inDoubt;
-				}
-			}
 			listener.onFailure(ae);
 		}
 	}
@@ -147,11 +142,6 @@ public class BatchProxy {
 
 		@Override
 		void onFailure(AerospikeException ae) {
-			for (BatchRecord record : records) {
-				if (record.resultCode == ResultCode.NO_RESPONSE) {
-					record.inDoubt = record.hasWrite && inDoubt;
-				}
-			}
 			listener.onFailure(ae);
 		}
 	}
@@ -197,11 +187,6 @@ public class BatchProxy {
 
 		@Override
 		void onFailure(AerospikeException ae) {
-			for (BatchRecord record : records) {
-				if (record.resultCode == ResultCode.NO_RESPONSE) {
-					record.inDoubt = record.hasWrite && inDoubt;
-				}
-			}
 			listener.onFailure(ae);
 		}
 	}
@@ -467,9 +452,11 @@ public class BatchProxy {
 
 		@Override
 		void onFailure(AerospikeException ae) {
-			for (BatchRecord record : records) {
-				if (record.resultCode == ResultCode.NO_RESPONSE) {
-					record.inDoubt = record.hasWrite && inDoubt;
+			if (ae.getInDoubt()) {
+				for (BatchRecord record : records) {
+					if (record.resultCode == ResultCode.NO_RESPONSE) {
+						record.inDoubt = record.hasWrite;
+					}
 				}
 			}
 			listener.onFailure(ae);
@@ -532,9 +519,11 @@ public class BatchProxy {
 
 		@Override
 		void onFailure(AerospikeException ae) {
-			for (BatchRecord record : records) {
-				if (record.resultCode == ResultCode.NO_RESPONSE) {
-					record.inDoubt = record.hasWrite && inDoubt;
+			if (ae.getInDoubt()) {
+				for (BatchRecord record : records) {
+					if (record.resultCode == ResultCode.NO_RESPONSE) {
+						record.inDoubt = record.hasWrite;
+					}
 				}
 			}
 			listener.onFailure(ae);
@@ -600,6 +589,13 @@ public class BatchProxy {
 
 		@Override
 		void onFailure(AerospikeException ae) {
+			if (ae.getInDoubt()) {
+				for (BatchRecord record : records) {
+					if (record.resultCode == ResultCode.NO_RESPONSE) {
+						record.inDoubt = record.hasWrite;
+					}
+				}
+			}
 			listener.onFailure(records, ae);
 		}
 	}
@@ -737,9 +733,11 @@ public class BatchProxy {
 
 		@Override
 		void onFailure(AerospikeException ae) {
-			for (BatchRecord record : records) {
-				if (record.resultCode == ResultCode.NO_RESPONSE) {
-					record.inDoubt = record.hasWrite && inDoubt;
+			if (ae.getInDoubt()) {
+				for (BatchRecord record : records) {
+					if (record.resultCode == ResultCode.NO_RESPONSE) {
+						record.inDoubt = record.hasWrite;
+					}
 				}
 			}
 			listener.onFailure(records, ae);


### PR DESCRIPTION
The native Aerospike client also does not set the `resultCode` for all the failed records in the batch, but the `inDoubt` flag is set for all the records. @BrianNichols Is not setting the `resultCode` the expected behavior?