### PR TITLE
CLIENT-2843 Add getter for record field of RecordSet and RecordSequenceRecordSet

### DIFF
--- a/client/src/com/aerospike/client/query/RecordSet.java
+++ b/client/src/com/aerospike/client/query/RecordSet.java
@@ -131,6 +131,13 @@ public class RecordSet implements Iterable<KeyRecord>, Closeable {
 		return record.record;
 	}
 
+	/**
+	 * Get KeyRecord.
+	 */
+	public KeyRecord getKeyRecord() {
+		return record;
+	}
+
 	//-------------------------------------------------------
 	// Methods for internal use only.
 	//-------------------------------------------------------
@@ -206,7 +213,7 @@ public class RecordSet implements Iterable<KeyRecord>, Closeable {
 
 		@Override
 		public KeyRecord next() {
-			KeyRecord kr = recordSet.record;
+			KeyRecord kr = recordSet.getKeyRecord();
 			more = recordSet.next();
 			return kr;
 		}

--- a/proxy/src/com/aerospike/client/proxy/RecordSequenceRecordSet.java
+++ b/proxy/src/com/aerospike/client/proxy/RecordSequenceRecordSet.java
@@ -34,7 +34,7 @@ public class RecordSequenceRecordSet extends RecordSet implements RecordSequence
 	private final long taskId;
 	private volatile boolean valid = true;
 	private final BlockingQueue<KeyRecord> queue;
-	private volatile KeyRecord record;
+	protected volatile KeyRecord record;
 	private volatile AerospikeException exception;
 
 	public RecordSequenceRecordSet(long taskId, int capacity) {
@@ -107,6 +107,11 @@ public class RecordSequenceRecordSet extends RecordSet implements RecordSequence
 	@Override
 	public Record getRecord() {
 		return record.record;
+	}
+
+	@Override
+	public KeyRecord getKeyRecord() {
+		return record;
 	}
 
 	@Override


### PR DESCRIPTION
When running with proxy client, the RecordSet.RecordSetIterator's next() method tries to access recordSet.record which returns null. It is because recordSet in this case is RecordSequenceRecordSet where record is a private field.