### PR TITLE
Propagate the original LuaC compile() exception details in AerospikeExceptions thrown by LuaCache.

### DIFF
--- a/client/src/com/aerospike/client/lua/LuaCache.java
+++ b/client/src/com/aerospike/client/lua/LuaCache.java
@@ -63,7 +63,7 @@ public final class LuaCache {
 				Packages.put(packageName, prototype);
 			}
 			catch (Throwable e) {
-				throw new AerospikeException("Failed to read file: " + source.getAbsolutePath());
+				throw new AerospikeException("Failed to read file: " + source.getAbsolutePath(), e);
 			}
 		}
 		return prototype;
@@ -81,7 +81,7 @@ public final class LuaCache {
 				Packages.put(packageName, prototype);
 			}
 			catch (Throwable e) {
-				throw new AerospikeException("Failed to read resource: " + resourcePath);
+				throw new AerospikeException("Failed to read resource: " + resourcePath, e);
 			}
 		}
 		return prototype;
@@ -94,7 +94,7 @@ public final class LuaCache {
 			return LuaC.instance.compile(bis, packageName);
 		}
 		catch (Throwable e) {
-			throw new AerospikeException("Failed to compile: " + packageName);
+			throw new AerospikeException("Failed to compile: " + packageName, e);
 		}
 	}
 


### PR DESCRIPTION
Issue #315 
The LuaC.instance.compile() method throws an exception which states the exact error and token it errored on. The java client catches that exception and throws a more generic "failed to read" exception message.
Currently a client user must set breakpoints to see the actual error, the client should instead wrap the original exception instead of simply discarding it.
This will preserve the original error details in the stack trace.


