### PR TITLE
Checking the emptiness of binNames field before setting into command

### DIFF
--- a/client/src/com/aerospike/client/BatchRead.java
+++ b/client/src/com/aerospike/client/BatchRead.java
@@ -57,7 +57,11 @@ public final class BatchRead extends BatchRecord {
 	public BatchRead(Key key, String[] binNames) {
 		super(key, false);
 		this.policy = null;
-		this.binNames = binNames;
+		if (binNames == null || binNames.length == 0) {
+			this.binNames = null;
+		} else {
+			this.binNames = binNames;
+		}
 		this.ops = null;
 		this.readAllBins = false;
 	}
@@ -90,7 +94,11 @@ public final class BatchRead extends BatchRecord {
 	public BatchRead(BatchReadPolicy policy, Key key, String[] binNames) {
 		super(key, false);
 		this.policy = policy;
-		this.binNames = binNames;
+		if (binNames == null || binNames.length == 0) {
+			this.binNames = null;
+		} else {
+			this.binNames = binNames;
+		}
 		this.ops = null;
 		this.readAllBins = false;
 	}

--- a/client/src/com/aerospike/client/async/AsyncBatch.java
+++ b/client/src/com/aerospike/client/async/AsyncBatch.java
@@ -16,7 +16,6 @@
  */
 package com.aerospike.client.async;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import com.aerospike.client.AerospikeClient;
@@ -175,7 +174,11 @@ public final class AsyncBatch {
 		) {
 			super(parent, batch, batchPolicy, isOperation);
 			this.keys = keys;
-			this.binNames = binNames;
+			if (binNames == null || binNames.length == 0) {
+				this.binNames = null;
+			} else {
+				this.binNames = binNames;
+			}
 			this.ops = ops;
 			this.records = records;
 			this.readAttr = readAttr;
@@ -236,7 +239,11 @@ public final class AsyncBatch {
 		) {
 			super(parent, batch, batchPolicy, isOperation);
 			this.keys = keys;
-			this.binNames = binNames;
+			if (binNames == null || binNames.length == 0) {
+				this.binNames = null;
+			} else {
+				this.binNames = binNames;
+			}
 			this.ops = ops;
 			this.listener = listener;
 			this.readAttr = readAttr;
@@ -963,7 +970,7 @@ public final class AsyncBatch {
 			// This can cause an exponential number of commands.
 			List<BatchNode> batchNodes = generateBatchNodes();
 
-			if (batchNodes.size() == 0 || (batchNodes.size() == 1 && batchNodes.get(0).node == batch.node)) {
+			if (batchNodes.isEmpty() || (batchNodes.size() == 1 && batchNodes.getFirst().node == batch.node)) {
 				// Go through normal retry.
 				return false;
 			}

--- a/client/src/com/aerospike/client/async/AsyncBatchSingle.java
+++ b/client/src/com/aerospike/client/async/AsyncBatchSingle.java
@@ -63,7 +63,7 @@ public final class AsyncBatchSingle {
 		}
 
 		@Override
-		protected final boolean parseResult() {
+		protected boolean parseResult() {
 			super.parseResult();
 
 			try {
@@ -181,7 +181,11 @@ public final class AsyncBatchSingle {
 			boolean isOperation
 		) {
 			super(executor, cluster, policy, key, node, false);
-			this.binNames = binNames;
+			if (binNames == null || binNames.length == 0) {
+				this.binNames = null;
+			} else {
+				this.binNames = binNames;
+			}
 			this.records = records;
 			this.index = index;
 			this.isOperation = isOperation;
@@ -242,7 +246,11 @@ public final class AsyncBatchSingle {
 		) {
 			super(executor, cluster, policy, key, node, false);
 			this.listener = listener;
-			this.binNames = binNames;
+			if (binNames == null || binNames.length == 0) {
+				this.binNames = null;
+			} else {
+				this.binNames = binNames;
+			}
 			this.isOperation = isOperation;
 		}
 

--- a/client/src/com/aerospike/client/async/AsyncRead.java
+++ b/client/src/com/aerospike/client/async/AsyncRead.java
@@ -41,7 +41,11 @@ public class AsyncRead extends AsyncCommand {
 		super(policy, true);
 		this.listener = listener;
 		this.key = key;
-		this.binNames = binNames;
+		if (binNames == null || binNames.length == 0) {
+			this.binNames = null;
+		} else {
+			this.binNames = binNames;
+		}
 		this.isOperation = false;
 		this.partition = Partition.read(cluster, policy, key);
 		cluster.addTran();
@@ -126,7 +130,7 @@ public class AsyncRead extends AsyncCommand {
 		// Do nothing in default case. Record will be null.
 	}
 
-	private final void handleUdfError(int resultCode) {
+	private void handleUdfError(int resultCode) {
 		String ret = (String)record.bins.get("FAILURE");
 
 		if (ret == null) {

--- a/client/src/com/aerospike/client/async/AsyncScanPartition.java
+++ b/client/src/com/aerospike/client/async/AsyncScanPartition.java
@@ -54,7 +54,11 @@ public final class AsyncScanPartition extends AsyncMultiCommand {
 		this.listener = listener;
 		this.namespace = namespace;
 		this.setName = setName;
-		this.binNames = binNames;
+		if (binNames == null || binNames.length == 0) {
+			this.binNames = null;
+		} else {
+			this.binNames = binNames;
+		}
 		this.taskId = taskId;
 		this.tracker = tracker;
 		this.nodePartitions = nodePartitions;

--- a/client/src/com/aerospike/client/async/AsyncScanPartitionExecutor.java
+++ b/client/src/com/aerospike/client/async/AsyncScanPartitionExecutor.java
@@ -51,7 +51,11 @@ public final class AsyncScanPartitionExecutor extends AsyncMultiExecutor {
 		this.listener = listener;
 		this.namespace = namespace;
 		this.setName = setName;
-		this.binNames = binNames;
+		if (binNames == null || binNames.length == 0) {
+			this.binNames = null;
+		} else {
+			this.binNames = binNames;
+		}
 		this.tracker = tracker;
 		this.random = new RandomShift();
 

--- a/client/src/com/aerospike/client/command/Batch.java
+++ b/client/src/com/aerospike/client/command/Batch.java
@@ -115,7 +115,11 @@ public final class Batch {
 		) {
 			super(cluster, batch, policy, status, isOperation);
 			this.keys = keys;
-			this.binNames = binNames;
+			if (binNames == null || binNames.length == 0) {
+				this.binNames = null;
+			} else {
+				this.binNames = binNames;
+			}
 			this.ops = ops;
 			this.records = records;
 			this.readAttr = readAttr;
@@ -554,7 +558,7 @@ public final class Batch {
 			// This is both recursive and exponential.
 			List<BatchNode> batchNodes = generateBatchNodes();
 
-			if (batchNodes.size() == 1 && batchNodes.get(0).node == batch.node) {
+			if (batchNodes.size() == 1 && batchNodes.getFirst().node == batch.node) {
 				// Batch node is the same.  Go through normal retry.
 				return false;
 			}
@@ -562,7 +566,7 @@ public final class Batch {
 			splitRetry = true;
 
 			// Run batch retries in parallel using virtual threads.
-			try (ExecutorService es = Executors.newThreadPerTaskExecutor(cluster.threadFactory);) {
+			try (ExecutorService es = Executors.newThreadPerTaskExecutor(cluster.threadFactory)) {
 				for (BatchNode batchNode : batchNodes) {
 					BatchCommand command = createCommand(batchNode);
 					command.sequenceAP = sequenceAP;

--- a/client/src/com/aerospike/client/command/BatchSingle.java
+++ b/client/src/com/aerospike/client/command/BatchSingle.java
@@ -78,7 +78,11 @@ public final class BatchSingle {
 		) {
 			super(cluster, policy, status, key, node, false);
 			this.key = key;
-			this.binNames = binNames;
+			if (binNames == null || binNames.length == 0) {
+				this.binNames = null;
+			} else {
+				this.binNames = binNames;
+			}
 			this.records = records;
 			this.index = index;
 			this.isOperation = isOperation;

--- a/client/src/com/aerospike/client/command/ReadCommand.java
+++ b/client/src/com/aerospike/client/command/ReadCommand.java
@@ -48,7 +48,11 @@ public class ReadCommand extends SyncCommand {
 	public ReadCommand(Cluster cluster, Policy policy, Key key, String[] binNames) {
 		super(cluster, policy);
 		this.key = key;
-		this.binNames = binNames;
+		if (binNames == null || binNames.length == 0) {
+			this.binNames = null;
+		} else {
+			this.binNames = binNames;
+		}
 		this.partition = Partition.read(cluster, policy, key);
 		this.isOperation = false;
 		cluster.addTran();

--- a/client/src/com/aerospike/client/command/ScanPartitionCommand.java
+++ b/client/src/com/aerospike/client/command/ScanPartitionCommand.java
@@ -49,7 +49,11 @@ public final class ScanPartitionCommand extends MultiCommand {
 		super(cluster, scanPolicy, nodePartitions.node, namespace, tracker.socketTimeout, tracker.totalTimeout);
 		this.scanPolicy = scanPolicy;
 		this.setName = setName;
-		this.binNames = binNames;
+		if (binNames == null || binNames.length == 0) {
+			this.binNames = null;
+		} else {
+			this.binNames = binNames;
+		}
 		this.callback = callback;
 		this.taskId = taskId;
 		this.tracker = tracker;

--- a/client/src/com/aerospike/client/query/Statement.java
+++ b/client/src/com/aerospike/client/query/Statement.java
@@ -89,7 +89,11 @@ public final class Statement {
 	 * Set query bin names.
 	 */
 	public void setBinNames(String... binNames) {
-		this.binNames = binNames;
+		if (binNames == null || binNames.length == 0) {
+			this.binNames = null;
+		} else {
+			this.binNames = binNames;
+		}
 	}
 
 	/**

--- a/proxy/src/com/aerospike/client/proxy/BatchProxy.java
+++ b/proxy/src/com/aerospike/client/proxy/BatchProxy.java
@@ -51,8 +51,8 @@ public class BatchProxy {
 	//-------------------------------------------------------
 
 	public interface BatchListListenerSync {
-		public void onSuccess(List<BatchRead> records, boolean status);
-		public void onFailure(AerospikeException ae);
+		void onSuccess(List<BatchRead> records, boolean status);
+		void onFailure(AerospikeException ae);
 	}
 
 	public static final class ReadListCommandSync extends BaseCommand {
@@ -217,7 +217,11 @@ public class BatchProxy {
 			super(executor, batchPolicy, isOperation, keys.length);
 			this.listener = listener;
 			this.keys = keys;
-			this.binNames = binNames;
+			if (binNames == null  || binNames.length == 0) {
+				this.binNames = null;
+			} else {
+				this.binNames = binNames;
+			}
 			this.ops = ops;
 			this.readAttr = readAttr;
 			this.records = new Record[keys.length];
@@ -276,7 +280,11 @@ public class BatchProxy {
 			super(executor, batchPolicy, isOperation, keys.length);
 			this.listener = listener;
 			this.keys = keys;
-			this.binNames = binNames;
+			if (binNames == null || binNames.length == 0) {
+				this.binNames = null;
+			} else {
+				this.binNames = binNames;
+			}
 			this.ops = ops;
 			this.readAttr = readAttr;
 		}

--- a/proxy/src/com/aerospike/client/proxy/ReadCommandProxy.java
+++ b/proxy/src/com/aerospike/client/proxy/ReadCommandProxy.java
@@ -45,7 +45,11 @@ public class ReadCommandProxy extends SingleCommandProxy {
 		super(KVSGrpc.getReadStreamingMethod(), executor, policy);
 		this.listener = listener;
 		this.key = key;
-		this.binNames = binNames;
+		if (binNames == null || binNames.length == 0) {
+			this.binNames = null;
+		} else {
+			this.binNames = binNames;
+		}
 		this.isOperation = false;
 	}
 

--- a/proxy/src/com/aerospike/client/proxy/ScanCommandProxy.java
+++ b/proxy/src/com/aerospike/client/proxy/ScanCommandProxy.java
@@ -47,7 +47,11 @@ public class ScanCommandProxy extends ScanQueryBaseCommandProxy {
 			listener, partitionTracker);
 		this.namespace = namespace;
 		this.setName = setName;
-		this.binNames = binNames;
+		if (binNames == null || binNames.length == 0) {
+			this.binNames = null;
+		} else {
+			this.binNames = binNames;
+		}
 		this.partitionFilter = partitionFilter;
 	}
 


### PR DESCRIPTION
* Added check for `binNames` of all `Command` to avoid `Parameter error` when passing an empty array
  * JVM languages like Kotlin treat null and non-null explicitly. To invoke a constructor version of commands that sets the binNames to `null`, requires a separate if-else code block from the caller site to invoke a desired version of the constructor and, makes code unnecessarily lengthy. However, we can pass an empty array from Kotlin and keep the code cleaner. In the current implementation, it causes a `Parameter error`.
* Applied minor IDE suggestions