### PR TITLE
Fixed compression

### DIFF
--- a/client/src/com/aerospike/client/command/Command.java
+++ b/client/src/com/aerospike/client/command/Command.java
@@ -2210,9 +2210,8 @@ public class Command {
 
 	private final void compress(Policy policy) {
 		if (policy.compress && dataOffset > COMPRESS_THRESHOLD) {
-			Deflater def = new Deflater();
+			Deflater def = new Deflater(Deflater.BEST_SPEED);
 			try {
-				def.setLevel(Deflater.BEST_SPEED);
 				def.setInput(dataBuffer, 0, dataOffset);
 				def.finish();
 


### PR DESCRIPTION
A forum user (@sleshxdev) highlighted that the compression inside the Aerospike client did not work. This was reproduced in a test case. After extensive testing it was determined that under all circumstances
```
Deflater def = new Deflater();
def.setLevel(Deflater.BEST_SPEED);
```
results in no compression. The input data does not matter, nor does the level being set, providing it is different to the existing level. 

However,
```
Deflater def = new Deflater(Deflater.BEST_SPEED);
```
always works with no issues. Updated the code to reflect this.