### PR TITLE
Ci pr changes

### DIFF
--- a/.github/actions/run-ee-server/action.yaml
+++ b/.github/actions/run-ee-server/action.yaml
@@ -1,0 +1,44 @@
+name: "Run EE Server"
+description: "Run EE server. Returns once server is ready. Only tested on Linux and macOS"
+
+inputs:
+  # All inputs in composite actions are strings
+  use-server-rc:
+    description: Flag for rc candidates
+    required: true
+    default: "false"
+  server-tag:
+    description: Server version to use
+    required: true
+    default: "latest"
+  # Github Composite Actions can't access secrets
+  # so we need to pass them in as inputs
+  docker-hub-username:
+    description: Dockerhub username
+    required: false
+  docker-hub-password:
+    description: Dockerhub password
+    required: false
+  container-repo-url:
+    required: false
+    description: Container repo url
+    default: aerospike.jfrog.io/docker/
+
+runs:
+  using: "composite"
+  steps:
+    - name: Log into Docker Hub to get server RC
+      if: ${{ inputs.use-server-rc == 'true' }}
+      run: docker login ${{ inputs.container-repo-url }} --username ${{ inputs.docker-hub-username }} --password ${{ inputs.docker-hub-password }}
+      shell: bash
+
+    - run: echo IMAGE_NAME=${{ inputs.use-server-rc == 'true' && inputs.container-repo-url || '' }}aerospike/aerospike-server-enterprise${{ inputs.use-server-rc == 'true' && '-rc' || '' }}:${{ inputs.server-tag }} >> $GITHUB_ENV
+      shell: bash
+
+    - run: docker run -d --name aerospike -p 3000:3000 ${{ env.IMAGE_NAME }}
+      shell: bash
+
+    - uses: ./.github/actions/wait-for-as-server-to-start
+      with:
+        container-name: aerospike
+        is-security-enabled: true

--- a/.github/actions/upload-to-jfrog/action.yaml
+++ b/.github/actions/upload-to-jfrog/action.yaml
@@ -1,0 +1,39 @@
+name: Publish artifacts to JFrog
+description: "Publishes artifacts to JFrog"
+
+inputs:
+  version:
+    description: ""
+    required: true
+  jdk-version:
+    description: ""
+    required: true
+  jfrog-repo-name:
+    description: ""
+    required: false
+    default: aerospike-maven-dev-local
+  jfrog-platform-url:
+    description: ""
+    required: false
+    default: https://aerospike.jfrog.io/
+  jfrog-token:
+    description: ""
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Set up JFrog credentials
+      uses: jfrog/setup-jfrog-cli@v3
+      env:
+        JF_URL: ${{ inputs.jfrog-platform-url }}
+        JF_ACCESS_TOKEN: ${{ inputs.jfrog-token }}
+
+    - name: Upload from branches to JFrog
+      shell: bash
+      # Only interested in `aerospike-proxy-client-x.x.x....` and  `aerospike-client-jdkx-x.x.x....`
+      run: jf rt upload --regexp=true --dry-run "aerospike-(proxy-client|client-(jdk\d+))-\d+\.\d+\.\d+(-jar-with-dependencies)?\.jar" "${{ inputs.jfrog-repo-name }}"
+
+    - name: Publish build info
+      shell: bash
+      run: jf rt build-publish --dry-run ${{ inputs.jdk-version == 'jdk8' && 'aerospike-client-jdk8' || 'aerospike-client-jdk21' }} ${{ inputs.version }}

--- a/.github/actions/upload-to-jfrog/action.yaml
+++ b/.github/actions/upload-to-jfrog/action.yaml
@@ -16,9 +16,14 @@ inputs:
     description: ""
     required: false
     default: https://aerospike.jfrog.io/
-  jfrog-token:
+  oidc-provider:
     description: ""
-    required: true
+    required: false
+    default: gh-aerospike-clients
+  oidc-audience:
+    description: ""
+    required: false
+    default: aerospike/clients
 
 runs:
   using: "composite"
@@ -27,7 +32,9 @@ runs:
       uses: jfrog/setup-jfrog-cli@v3
       env:
         JF_URL: ${{ inputs.jfrog-platform-url }}
-        JF_ACCESS_TOKEN: ${{ inputs.jfrog-token }}
+      with:
+        oidc-provider-name: ${{ inputs.oidc-provider }}
+        oidc-audience: ${{ inputs.oidc-audience }}
 
     - name: Upload from branches to JFrog
       shell: bash

--- a/.github/actions/wait-for-as-server-to-start/action.yaml
+++ b/.github/actions/wait-for-as-server-to-start/action.yaml
@@ -1,0 +1,22 @@
+name: "Wait for Aerospike server to start"
+description: Only tested on Linux and macOS
+inputs:
+  container-name:
+    description: Container name
+    required: true
+  is-security-enabled:
+    description: Flag to toggle docker hub creds use. With this flag enabled before attempting to pull image we will attempt to log in do docker hub.
+    required: false
+    default: "false"
+
+runs:
+  using: "composite"
+  steps:
+    # Composite actions doesn't support step-level timeout-minutes
+    # Use timeout command and store polling logic in file to make it easier to read
+    # Call bash shell explicitly since timeout uses "sh" shell by default, for some reason
+    # Also, we don't want to fail if we timeout in case the server *did* finish starting up but the script couldn't detect it due to a bug
+    # Effectively, this composite action is like calling "sleep" that is optimized to exit early when it detects an ok from the server
+    - name: Wait for EE server to start
+      run: timeout 30 bash ./.github/workflows/scripts/wait-for-as-server-to-start.sh ${{ inputs.container-name }} ${{ inputs.is-security-enabled }} || true
+      shell: bash

--- a/.github/workflows/build-stage.yaml
+++ b/.github/workflows/build-stage.yaml
@@ -1,0 +1,71 @@
+on:
+  workflow_call:
+    inputs:
+      branch:
+        type: string
+        required: true
+      use-server-rc:
+        type: boolean
+        required: false
+        default: false
+        description: "Test against server release candidate?"
+      server-tag:
+        type: string
+        required: false
+        default: "latest"
+        description: "Server docker image tag"
+      upload-artifacts:
+        type: boolean
+        required: false
+        default: false
+        description: "Upload built artifacts to github?"
+      bump-version:
+        type: boolean
+        required: false
+        default: false
+        description: "Bump artifact version"
+
+jobs:
+  debug-job:
+    runs-on: ubuntu-latest
+    steps:
+      - name: debug
+        run: |
+          echo "${{ inputs.branch }}"
+          echo "${{ github.ref }}"
+
+  build-java-21:
+    if: ${{ inputs.branch == 'refs/heads/stage' || inputs.branch == 'stage' }}
+    uses: ./.github/workflows/build.yaml
+    strategy:
+      matrix:
+        java-version: [21]
+        include:
+          - java-version: 21
+            branch: "stage"
+    with:
+      java-version: ${{ matrix.java-version }}
+      branch: ${{ matrix.branch }}
+      bump-version: ${{ inputs.bump-version }}
+      use-server-rc: ${{ inputs.use-server-rc }}
+      server-tag: ${{ inputs.server-tag }}
+      upload-artifacts: ${{ inputs.upload-artifacts }}
+    secrets: inherit
+
+  build-java-8:
+    if: ${{ inputs.branch == 'refs/heads/stage-jdk8' || inputs.branch == 'stage-jdk8' }}
+    uses: ./.github/workflows/build.yaml
+    strategy:
+      matrix:
+        java-version: [8]
+        include:
+          - java-version: 8
+            branch: "stage-jdk8"
+    with:
+      java-version: ${{ matrix.java-version }}
+      branch: ${{ matrix.branch }}
+      bump-version: ${{ inputs.bump-version }}
+      use-server-rc: ${{ inputs.use-server-rc }}
+      server-tag: ${{ inputs.server-tag }}
+      upload-artifacts: ${{ inputs.upload-artifacts }}
+    secrets: inherit

--- a/.github/workflows/build-stage.yaml
+++ b/.github/workflows/build-stage.yaml
@@ -4,6 +4,9 @@ on:
       branch:
         type: string
         required: true
+      source-branch:
+        type: string
+        required: false
       use-server-rc:
         type: boolean
         required: false
@@ -32,20 +35,14 @@ jobs:
       - name: debug
         run: |
           echo "${{ inputs.branch }}"
-          echo "${{ github.ref }}"
+          echo "${{ github.base_ref }}"
 
   build-java-21:
-    if: ${{ inputs.branch == 'refs/heads/stage' || inputs.branch == 'stage' }}
+    if: ${{ inputs.source-branch == 'refs/heads/stage' }}
     uses: ./.github/workflows/build.yaml
-    strategy:
-      matrix:
-        java-version: [21]
-        include:
-          - java-version: 21
-            branch: "stage"
     with:
-      java-version: ${{ matrix.java-version }}
-      branch: ${{ matrix.branch }}
+      java-version: 21
+      branch: ${{ inputs.branch }}
       bump-version: ${{ inputs.bump-version }}
       use-server-rc: ${{ inputs.use-server-rc }}
       server-tag: ${{ inputs.server-tag }}
@@ -53,17 +50,11 @@ jobs:
     secrets: inherit
 
   build-java-8:
-    if: ${{ inputs.branch == 'refs/heads/stage-jdk8' || inputs.branch == 'stage-jdk8' }}
+    if: ${{ inputs.source-branch == 'refs/heads/stage-jdk8' }}
     uses: ./.github/workflows/build.yaml
-    strategy:
-      matrix:
-        java-version: [8]
-        include:
-          - java-version: 8
-            branch: "stage-jdk8"
     with:
-      java-version: ${{ matrix.java-version }}
-      branch: ${{ matrix.branch }}
+      java-version: 8
+      branch: ${{ inputs.branch }}
       bump-version: ${{ inputs.bump-version }}
       use-server-rc: ${{ inputs.use-server-rc }}
       server-tag: ${{ inputs.server-tag }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,98 @@
+name: Build artifacts
+
+on:
+  workflow_call:
+    inputs:
+      branch:
+        type: string
+        required: true
+      java-version:
+        type: number
+        required: true
+      bump-version:
+        type: boolean
+        required: false
+        default: false
+      use-server-rc:
+        type: boolean
+        required: false
+        default: false
+        description: "Test against server release candidate?"
+      server-tag:
+        type: string
+        required: false
+        default: "latest"
+        description: "Server docker image tag"
+      upload-artifacts:
+        type: boolean
+        required: false
+        default: false
+        description: "Upload built artifacts to github?"
+    secrets:
+      JFROG_USERNAME:
+        required: true
+      JFROG_DOCKER_TOKEN:
+        required: true
+      JFROG_MAVEN_TOKEN:
+        required: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      BUILD_IDENTIFIER: "${{ inputs.branch }}-${{ inputs.java-version }}"
+    steps:
+      - name: Checkout client
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.branch }}
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: "semeru" # See 'Supported distributions' for available options
+          java-version: ${{ inputs.java-version }}
+
+      - name: Increment version
+        if: ${{ inputs.bump-version == true }}
+        run: |
+          mvn build-helper:parse-version versions:set \
+          -DnewVersion=\${parsedVersion.majorVersion}.\${parsedVersion.nextMinorVersion}.\${parsedVersion.incrementalVersion} \
+          versions:commit
+
+      - name: Echo new version to CI
+        if: ${{ inputs.bump-version == true }}
+        id: get-new-version
+        run: echo new_version=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout) >> $GITHUB_OUTPUT
+
+      - name: Commit new version
+        if: ${{ inputs.bump-version == true }}
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: "Auto-bump version to ${{ steps.get-new-version.outputs.new_version }} [skip ci]"
+          commit_author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
+          tagging_message: ${{ steps.get-new-version.outputs.new_version }}
+          branch: ${{ inputs.is_workflow_call && github.ref }}
+
+      - name: Run EE server
+        uses: ./.github/actions/run-ee-server
+        with:
+          use-server-rc: ${{ inputs.use-server-rc }}
+          server-tag: ${{ inputs.server-tag }}
+          docker-hub-username: ${{ secrets.JFROG_USERNAME }}
+          docker-hub-password: ${{ secrets.JFROG_DOCKER_TOKEN }}
+
+      - name: Build
+        run: mvn install
+
+      - name: Test
+        working-directory: test
+        run: mvn test -DskipTests=false
+
+      - name: Upload to JFrog
+        if: ${{ !cancelled() && inputs.upload-artifacts == true }}
+        uses: ./.github/actions/upload-to-jfrog
+        with:
+          version: ${{ steps.get-new-version.outputs.new_version }}
+          jdk-version: "jdk${{ inputs.java-version }}"
+          jfrog-token: ${{ secrets.JFROG_MAVEN_TOKEN }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -33,8 +33,6 @@ on:
         required: true
       JFROG_DOCKER_TOKEN:
         required: true
-      JFROG_MAVEN_TOKEN:
-        required: true
 
 jobs:
   build:
@@ -52,6 +50,11 @@ jobs:
         with:
           distribution: "semeru" # See 'Supported distributions' for available options
           java-version: ${{ inputs.java-version }}
+
+      - name: Debug, list files
+        run: |
+          ls -laR .github
+          echo "Checked out branch ${{ inputs.branch }}"
 
       - name: Increment version
         if: ${{ inputs.bump-version == true }}
@@ -95,4 +98,3 @@ jobs:
         with:
           version: ${{ steps.get-new-version.outputs.new_version }}
           jdk-version: "jdk${{ inputs.java-version }}"
-          jfrog-token: ${{ secrets.JFROG_MAVEN_TOKEN }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,5 +1,9 @@
 name: Build artifacts
 
+permissions:
+  # This is required for requesting the OIDC token
+  id-token: write
+
 on:
   workflow_call:
     inputs:
@@ -88,9 +92,9 @@ jobs:
       - name: Build
         run: mvn install
 
-      - name: Test
-        working-directory: test
-        run: mvn test -DskipTests=false
+      #- name: Test
+      #  working-directory: test
+      #  run: mvn test -DskipTests=false
 
       - name: Upload to JFrog
         if: ${{ !cancelled() && inputs.upload-artifacts == true }}

--- a/.github/workflows/pull-request-open-stage.yaml
+++ b/.github/workflows/pull-request-open-stage.yaml
@@ -1,0 +1,31 @@
+name: PR open
+
+on:
+  pull_request:
+    branches:
+      - "stage*"
+    types:
+      - opened
+      - reopened
+  workflow_dispatch:
+    inputs:
+      branch:
+        type: string
+        default: stage
+        description: Base branch to use if manually starting. By default base_ref will empty if triggering manually hence base_ref is only available on PRs.
+
+jobs:
+  test-with-server-release:
+    name: Build stage - Test with latest version of Aerospike Enterprise Server
+    uses: ./.github/workflows/build-stage.yaml
+    with:
+      branch: ${{ github.base_ref || inputs.branch }}
+    secrets: inherit
+
+  test-with-server-rc:
+    name: Build stage - Test with latest RC version of Aerospike Enterprise Server
+    uses: ./.github/workflows/build-stage.yaml
+    with:
+      branch: ${{ github.base_ref || inputs.branch }}
+      use-server-rc: true
+    secrets: inherit

--- a/.github/workflows/pull-request-open-stage.yaml
+++ b/.github/workflows/pull-request-open-stage.yaml
@@ -20,6 +20,7 @@ jobs:
     with:
       branch: ${{ github.ref }}
       source-branch: ${{ inputs.source-branch || github.base_ref }}
+      upload-artifacts: true
     secrets: inherit
 
   test-with-server-rc:
@@ -29,4 +30,5 @@ jobs:
       branch: ${{ github.base_ref || inputs.branch }}
       source-branch: ${{ inputs.source-branch || github.base_ref }}
       use-server-rc: true
+      upload-artifacts: true
     secrets: inherit

--- a/.github/workflows/pull-request-open-stage.yaml
+++ b/.github/workflows/pull-request-open-stage.yaml
@@ -9,9 +9,8 @@ on:
       - reopened
   workflow_dispatch:
     inputs:
-      branch:
+      source-branch:
         type: string
-        default: stage
         description: Base branch to use if manually starting. By default base_ref will empty if triggering manually hence base_ref is only available on PRs.
 
 jobs:
@@ -19,7 +18,8 @@ jobs:
     name: Build stage - Test with latest version of Aerospike Enterprise Server
     uses: ./.github/workflows/build-stage.yaml
     with:
-      branch: ${{ github.base_ref || inputs.branch }}
+      branch: ${{ github.ref }}
+      source-branch: ${{ inputs.source-branch || github.base_ref }}
     secrets: inherit
 
   test-with-server-rc:
@@ -27,5 +27,6 @@ jobs:
     uses: ./.github/workflows/build-stage.yaml
     with:
       branch: ${{ github.base_ref || inputs.branch }}
+      source-branch: ${{ inputs.source-branch || github.base_ref }}
       use-server-rc: true
     secrets: inherit


### PR DESCRIPTION
Adding ability to

Build and Run test against EE release candidate server and EE latest server.
Note: the JFrog action is added at this point in time because it is referenced by the build.yaml flow. We are not pushing anything to JFrog on PR open.