### PR TITLE
Added fix for failing test when using AS non enterprise

### DIFF
--- a/test/src/com/aerospike/test/SuiteSync.java
+++ b/test/src/com/aerospike/test/SuiteSync.java
@@ -113,13 +113,14 @@ import com.aerospike.test.util.Args;
 })
 public class SuiteSync {
 	public static IAerospikeClient client = null;
+	public static Args args = null;
 
 	@BeforeClass
 	public static void init() {
 		Log.setCallback(null);
 
 		System.out.println("Begin AerospikeClient");
-		Args args = Args.Instance;
+		args = Args.Instance;
 
 		ClientPolicy policy = new ClientPolicy();
 		args.setClientPolicy(policy);

--- a/test/src/com/aerospike/test/sync/TestSync.java
+++ b/test/src/com/aerospike/test/sync/TestSync.java
@@ -18,6 +18,7 @@ package com.aerospike.test.sync;
 
 import static org.junit.Assert.fail;
 
+import com.aerospike.test.util.Args;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 
@@ -30,6 +31,7 @@ import com.aerospike.test.util.TestBase;
 
 public class TestSync extends TestBase {
 	protected static IAerospikeClient client = SuiteSync.client;
+	protected static Args args = SuiteSync.args;
 	private static boolean DestroyClient = false;
 
 	@BeforeClass

--- a/test/src/com/aerospike/test/sync/basic/TestPutGet.java
+++ b/test/src/com/aerospike/test/sync/basic/TestPutGet.java
@@ -16,11 +16,15 @@
  */
 package com.aerospike.test.sync.basic;
 
+import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import com.aerospike.test.SuiteSync;
+import com.aerospike.test.util.Args;
+import org.junit.Assume;
 import org.junit.Test;
 
 import com.aerospike.client.Bin;
@@ -85,6 +89,7 @@ public class TestPutGet extends TestSync {
 
 	@Test
 	public void putGetCompress() {
+		Assume.assumeThat(args.enterprise, is(true));
 		Key key = new Key(args.namespace, args.set, "pgc");
 		byte[] bytes = new byte[2000];
 


### PR DESCRIPTION
Effectively skipping test if we have detected that we are testing against AES