### PR TITLE
feat: null safe check for BatchWrite

### DIFF
--- a/client/src/com/aerospike/client/BatchWrite.java
+++ b/client/src/com/aerospike/client/BatchWrite.java
@@ -21,6 +21,9 @@ import com.aerospike.client.command.Command;
 import com.aerospike.client.policy.BatchWritePolicy;
 import com.aerospike.client.policy.Policy;
 
+import java.util.Arrays;
+import java.util.Objects;
+
 /**
  * Batch key and read/write operations with write policy.
  */
@@ -44,7 +47,7 @@ public final class BatchWrite extends BatchRecord {
 	 */
 	public BatchWrite(Key key, Operation[] ops) {
 		super(key, true);
-		this.ops = ops;
+		this.ops = Arrays.stream(ops).filter(Objects::nonNull).toArray(Operation[]::new);
 		this.policy = null;
 	}
 
@@ -57,7 +60,7 @@ public final class BatchWrite extends BatchRecord {
 	 */
 	public BatchWrite(BatchWritePolicy policy, Key key, Operation[] ops) {
 		super(key, true);
-		this.ops = ops;
+		this.ops = Arrays.stream(ops).filter(Objects::nonNull).toArray(Operation[]::new);
 		this.policy = policy;
 	}
 


### PR DESCRIPTION
- The BatchWrite constructor which accepts an array of operations assumes no null values are present in the given array and accordingly performs dot operations on the individual elements within the class
`(eg for (Operation op : ops) { if (op.type.isWrite) { hasWrite = true; } size += Buffer.estimateSizeUtf8(op.binName) + Command.OPERATION_HEADER_SIZE; size += op.value.estimateSize(); } )`
- This causes a Null pointer exception.
- Adding individual checks doesn't seem helpful since the same array might be passed down to other classes like BatchAttr, hence filtering at constructor level seems to make sense .
- This PR is for jdk 8