### PR TITLE
Fixing broken tests because of missing dependency jdk8

### DIFF
--- a/.github/workflows/pull-request-open.yaml
+++ b/.github/workflows/pull-request-open.yaml
@@ -33,7 +33,7 @@ jobs:
     name: Build stage - Test with latest RC version of Aerospike Enterprise Server
     uses: ./.github/workflows/build-pr.yaml
     with:
-      branch: ${{ github.base_ref || inputs.branch }}
+      branch: ${{ github.ref }}
       source-branch: ${{ inputs.source-branch || github.base_ref }}
       use-server-rc: true
       upload-artifacts: false

--- a/client/deploy-resources/bouncycastle_pom.xml
+++ b/client/deploy-resources/bouncycastle_pom.xml
@@ -57,6 +57,11 @@
       <artifactId>jbcrypt</artifactId>
       <version>0.4</version>
     </dependency>
+    <dependency>
+      <groupId>org.yaml</groupId>
+      <artifactId>snakeyaml</artifactId>
+      <version>2.4</version>
+    </dependency>
   </dependencies>
   <parent>
     <groupId>org.sonatype.oss</groupId>

--- a/client/deploy-resources/gnu_pom.xml
+++ b/client/deploy-resources/gnu_pom.xml
@@ -57,6 +57,11 @@
       <artifactId>jbcrypt</artifactId>
       <version>0.4</version>
     </dependency>
+    <dependency>
+      <groupId>org.yaml</groupId>
+      <artifactId>snakeyaml</artifactId>
+      <version>2.4</version>
+    </dependency>
   </dependencies>
   <parent>
     <groupId>org.sonatype.oss</groupId>


### PR DESCRIPTION
When we install maven installs using the POMs we publish with. On that node the publish POMs do require snakeyaml to be added as well.