### PR TITLE
CLIENT-3568 - pki err syntax

### DIFF
--- a/client/src/com/aerospike/client/admin/AdminCommand.java
+++ b/client/src/com/aerospike/client/admin/AdminCommand.java
@@ -138,8 +138,13 @@ public class AdminCommand {
 					// Server does not require login.
 					return;
 				}
+				String msg = "Login failed";
+				if (result == ResultCode.INVALID_CREDENTIAL) {
+					msg = "Authentication failed: Password authentication is disabled for PKI-only users. " +
+							"Please authenticate using your certificate.";
+				}
 
-				throw new AerospikeException(result, "Login failed");
+				throw new AerospikeException(result, msg);
 			}
 
 			// Read session token.
@@ -255,7 +260,7 @@ public class AdminCommand {
 		writeField(PASSWORD, password);
 		int result = executeCommandNode(node, policy);
 		if (result == ResultCode.FORBIDDEN_PASSWORD) {
-			throw new AerospikeException("PKI user password not settable");
+			throw new AerospikeException("FORBIDDEN_PASSWORD (64): PKI user password not changeable");
 		}
 	}
 
@@ -267,7 +272,7 @@ public class AdminCommand {
 		writeField(PASSWORD, password);
 		int result = executeCommandNode(node, policy);
 		if (result == ResultCode.FORBIDDEN_PASSWORD) {
-			throw new AerospikeException("PKI user password not changeable");
+			throw new AerospikeException("FORBIDDEN_PASSWORD (64): PKI user password not changeable");
 		}
 	}
 


### PR DESCRIPTION
I have validated that the server does return err 65 and that the client indeed is handling appropriately.


```
❯ CA_CERT_PATH=/Users/mkaracic/workfolder/containers/aerospike-server-rc/data/CA
USER_CERT_PATH=/Users/mkaracic/workfolder/containers/aerospike-server-rc/data/CA/output
java -Djavax.net.ssl.trustStore=${CA_CERT_PATH}/truststore.jks -Djavax.net.ssl.trustStorePassword=changeit -Djavax.net.ssl.keyStore=${USER_CERT_PATH}/keystore.jks -Djavax.net.ssl.keyStorePassword=changeit -jar target/aerospike-examples-*-jar-with-dependencies.jar -h localhost:tls1:4000 -U admin -tlsEnable -d -auth internal PkiUser
Enter password:
2025-07-29 14:53:18.172 DEBUG Address localhost/127.0.0.1 4000 failed: com.aerospike.client.AerospikeException: Error 65: Authentication failed: Password authentication is disabled for PKI-only users. Please authenticate using your certificate.
        at com.aerospike.client.admin.AdminCommand$LoginCommand.login(AdminCommand.java:147)
        at com.aerospike.client.admin.AdminCommand$LoginCommand.<init>(AdminCommand.java:108)
        at com.aerospike.client.cluster.NodeValidator.validateAddress(NodeValidator.java:187)
        at com.aerospike.client.cluster.NodeValidator.seedNode(NodeValidator.java:65)
        at com.aerospike.client.cluster.Cluster.seedNode(Cluster.java:765)
        at com.aerospike.client.cluster.Cluster.tend(Cluster.java:639)
        at com.aerospike.client.cluster.Cluster.waitTillStabilized(Cluster.java:592)
        at com.aerospike.client.cluster.Cluster.initTendThread(Cluster.java:517)
        at com.aerospike.client.cluster.Cluster.<init>(Cluster.java:381)
        at com.aerospike.client.AerospikeClient.<init>(AerospikeClient.java:378)
        at com.aerospike.examples.Example.runExamples(Example.java:46)
        at com.aerospike.examples.Main.runExamples(Main.java:292)
        at com.aerospike.examples.Main.main(Main.java:186)

2025-07-29 14:53:18.175 DEBUG Address localhost/0:0:0:0:0:0:0:1 4000 failed: com.aerospike.client.AerospikeException: Error 65: Authentication failed: Password authentication is disabled for PKI-only users. Please authenticate using your certificate.
        at com.aerospike.client.admin.AdminCommand$LoginCommand.login(AdminCommand.java:147)
        at com.aerospike.client.admin.AdminCommand$LoginCommand.<init>(AdminCommand.java:108)
        at com.aerospike.client.cluster.NodeValidator.validateAddress(NodeValidator.java:187)
        at com.aerospike.client.cluster.NodeValidator.seedNode(NodeValidator.java:65)
        at com.aerospike.client.cluster.Cluster.seedNode(Cluster.java:765)
        at com.aerospike.client.cluster.Cluster.tend(Cluster.java:639)
        at com.aerospike.client.cluster.Cluster.waitTillStabilized(Cluster.java:592)
        at com.aerospike.client.cluster.Cluster.initTendThread(Cluster.java:517)
        at com.aerospike.client.cluster.Cluster.<init>(Cluster.java:381)
        at com.aerospike.client.AerospikeClient.<init>(AerospikeClient.java:378)
        at com.aerospike.examples.Example.runExamples(Example.java:46)
        at com.aerospike.examples.Main.runExamples(Main.java:292)
        at com.aerospike.examples.Main.main(Main.java:186)

com.aerospike.client.AerospikeException$Connection: Error -8: Failed to connect to [1] host(s): 
localhost 4000 Error 65: Authentication failed: Password authentication is disabled for PKI-only users. Please authenticate using your certificate.

        at com.aerospike.client.cluster.Cluster.seedNode(Cluster.java:821)
        at com.aerospike.client.cluster.Cluster.tend(Cluster.java:639)
        at com.aerospike.client.cluster.Cluster.waitTillStabilized(Cluster.java:592)
        at com.aerospike.client.cluster.Cluster.initTendThread(Cluster.java:517)
        at com.aerospike.client.cluster.Cluster.<init>(Cluster.java:381)
        at com.aerospike.client.AerospikeClient.<init>(AerospikeClient.java:378)
        at com.aerospike.examples.Example.runExamples(Example.java:46)
        at com.aerospike.examples.Main.runExamples(Main.java:292)
        at com.aerospike.examples.Main.main(Main.java:186)
```