### PR TITLE
Client 3839 skip test for compatibility with version 7

### DIFF
--- a/client/src/com/aerospike/client/util/Version.java
+++ b/client/src/com/aerospike/client/util/Version.java
@@ -114,6 +114,10 @@ public final class Version implements Comparable<Version> {
         return this.compareTo(otherVersion) < 0;
     }
 
+    public boolean isLessThanOrEqual(Version otherVersion) {
+        return this.compareTo(otherVersion) <= 0;
+    }
+
     public boolean isGreaterOrEqual(int major, int minor, int patch, int build) {
         return this.compareTo(new Version(major, minor, patch, build)) >= 0;
     }

--- a/client/src/com/aerospike/client/util/Version.java
+++ b/client/src/com/aerospike/client/util/Version.java
@@ -118,6 +118,14 @@ public final class Version implements Comparable<Version> {
         return this.compareTo(otherVersion) <= 0;
     }
 
+    public boolean isGreaterThan(Version otherVersion) {
+        return this.compareTo(otherVersion) > 0;
+    }
+
+    public boolean isGreaterThan(int major, int minor, int patch, int build) {
+        return this.isGreaterThan(new Version(major, minor, patch, build));
+    }
+
     public boolean isGreaterOrEqual(int major, int minor, int patch, int build) {
         return this.compareTo(new Version(major, minor, patch, build)) >= 0;
     }

--- a/test/src/com/aerospike/test/sync/TestSync.java
+++ b/test/src/com/aerospike/test/sync/TestSync.java
@@ -18,7 +18,10 @@ package com.aerospike.test.sync;
 
 import static org.junit.Assert.fail;
 
+import com.aerospike.client.cluster.Node;
+import com.aerospike.client.util.Version;
 import org.junit.AfterClass;
+import org.junit.Assume;
 import org.junit.BeforeClass;
 
 import com.aerospike.client.Bin;
@@ -30,6 +33,7 @@ import com.aerospike.test.util.TestBase;
 
 public class TestSync extends TestBase {
 	protected static IAerospikeClient client = SuiteSync.client;
+	protected static Version serverVersion;
 	private static boolean DestroyClient = false;
 
 	@BeforeClass
@@ -39,6 +43,13 @@ public class TestSync extends TestBase {
 			client = SuiteSync.client;
 			DestroyClient = true;
 		}
+
+        Node[] nodes = client.getNodes();
+        Assume.assumeTrue("No Aerospike server nodes available", nodes.length > 0);
+
+        if (serverVersion == null) {
+            serverVersion = nodes[0].getServerVersion();
+        }
 	}
 
 	@AfterClass

--- a/test/src/com/aerospike/test/sync/TestSync.java
+++ b/test/src/com/aerospike/test/sync/TestSync.java
@@ -18,10 +18,7 @@ package com.aerospike.test.sync;
 
 import static org.junit.Assert.fail;
 
-import com.aerospike.client.cluster.Node;
-import com.aerospike.client.util.Version;
 import org.junit.AfterClass;
-import org.junit.Assume;
 import org.junit.BeforeClass;
 
 import com.aerospike.client.Bin;
@@ -33,7 +30,6 @@ import com.aerospike.test.util.TestBase;
 
 public class TestSync extends TestBase {
 	protected static IAerospikeClient client = SuiteSync.client;
-	protected static Version serverVersion;
 	private static boolean DestroyClient = false;
 
 	@BeforeClass
@@ -43,13 +39,6 @@ public class TestSync extends TestBase {
 			client = SuiteSync.client;
 			DestroyClient = true;
 		}
-
-        Node[] nodes = client.getNodes();
-        Assume.assumeTrue("No Aerospike server nodes available", nodes.length > 0);
-
-        if (serverVersion == null) {
-            serverVersion = nodes[0].getServerVersion();
-        }
 	}
 
 	@AfterClass

--- a/test/src/com/aerospike/test/sync/basic/TestBatch.java
+++ b/test/src/com/aerospike/test/sync/basic/TestBatch.java
@@ -26,6 +26,8 @@ import static org.junit.Assert.fail;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.aerospike.client.cluster.Node;
+import com.aerospike.client.util.Version;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -415,6 +417,7 @@ public class TestBatch extends TestSync {
 	@Test
 	public void batchReadTTL() {
 		org.junit.Assume.assumeTrue(args.hasTtl);
+        org.junit.Assume.assumeTrue("Skipping for server version less than 7.0", !isServerVersionGreaterThan7_0());
 
 		// WARNING: This test takes a long time to run due to sleeps.
 		// Define keys
@@ -438,7 +441,7 @@ public class TestBatch extends TestSync {
 		BatchRead br1 = new BatchRead(brp1, key1, new String[] {"a"});
 		BatchRead br2 = new BatchRead(brp2, key2, new String[] {"a"});
 
-		List<BatchRecord> list = new ArrayList<BatchRecord>();
+		List<BatchRecord> list = new ArrayList<>();
 		list.add(br1);
 		list.add(br2);
 
@@ -476,7 +479,14 @@ public class TestBatch extends TestSync {
 		assertFalse(rv);
 	}
 
-	private void assertBatchBinEqual(List<BatchRead> list, String binName, int i) {
+    private boolean isServerVersionGreaterThan7_0() {
+        Node[] nodes = client.getNodes();
+        org.junit.Assume.assumeTrue(nodes.length > 0);
+        Version serverVersion = nodes[0].getServerVersion();
+        return !serverVersion.isLessThanOrEqual(new Version(7, 0, 0, 0));
+    }
+
+    private void assertBatchBinEqual(List<BatchRead> list, String binName, int i) {
 		BatchRead batch = list.get(i);
 		assertBinEqual(batch.key, batch.record, binName, ValuePrefix + (i + 1));
 	}

--- a/test/src/com/aerospike/test/sync/basic/TestBatch.java
+++ b/test/src/com/aerospike/test/sync/basic/TestBatch.java
@@ -416,7 +416,7 @@ public class TestBatch extends TestSync {
 	@Test
 	public void batchReadTTL() {
 		org.junit.Assume.assumeTrue(args.hasTtl);
-        org.junit.Assume.assumeTrue("Skipping for server version less than 7.0", serverVersion.isGreaterThan(new Version(7, 0, 0, 0)));
+        org.junit.Assume.assumeTrue("Skipping for server version less than 7.0", args.serverVersion.isGreaterThan(new Version(7, 0, 0, 0)));
 
 		// WARNING: This test takes a long time to run due to sleeps.
 		// Define keys

--- a/test/src/com/aerospike/test/sync/basic/TestBatch.java
+++ b/test/src/com/aerospike/test/sync/basic/TestBatch.java
@@ -417,7 +417,7 @@ public class TestBatch extends TestSync {
 	@Test
 	public void batchReadTTL() {
 		org.junit.Assume.assumeTrue(args.hasTtl);
-        org.junit.Assume.assumeFalse("Skipping for server version less than 7.0", isServerVersionLessThan(new Version(7, 0, 0, 0)));
+        org.junit.Assume.assumeTrue("Skipping for server version less than 7.0", serverVersion.isGreaterThan(new Version(7, 0, 0, 0)));
 
 		// WARNING: This test takes a long time to run due to sleeps.
 		// Define keys

--- a/test/src/com/aerospike/test/sync/basic/TestBatch.java
+++ b/test/src/com/aerospike/test/sync/basic/TestBatch.java
@@ -417,7 +417,7 @@ public class TestBatch extends TestSync {
 	@Test
 	public void batchReadTTL() {
 		org.junit.Assume.assumeTrue(args.hasTtl);
-        org.junit.Assume.assumeTrue("Skipping for server version less than 7.0", !isServerVersionGreaterThan7_0());
+        org.junit.Assume.assumeFalse("Skipping for server version less than 7.0", isServerVersionLessThan(new Version(7, 0, 0, 0)));
 
 		// WARNING: This test takes a long time to run due to sleeps.
 		// Define keys
@@ -479,11 +479,11 @@ public class TestBatch extends TestSync {
 		assertFalse(rv);
 	}
 
-    private boolean isServerVersionGreaterThan7_0() {
+    private boolean isServerVersionLessThan(Version version) {
         Node[] nodes = client.getNodes();
         org.junit.Assume.assumeTrue(nodes.length > 0);
         Version serverVersion = nodes[0].getServerVersion();
-        return !serverVersion.isLessThanOrEqual(new Version(7, 0, 0, 0));
+        return serverVersion.isLessThanOrEqual(version);
     }
 
     private void assertBatchBinEqual(List<BatchRead> list, String binName, int i) {

--- a/test/src/com/aerospike/test/sync/basic/TestBatch.java
+++ b/test/src/com/aerospike/test/sync/basic/TestBatch.java
@@ -26,7 +26,6 @@ import static org.junit.Assert.fail;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.aerospike.client.cluster.Node;
 import com.aerospike.client.util.Version;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -478,13 +477,6 @@ public class TestBatch extends TestSync {
 		assertEquals(ResultCode.KEY_NOT_FOUND_ERROR, br2.resultCode);
 		assertFalse(rv);
 	}
-
-    private boolean isServerVersionLessThan(Version version) {
-        Node[] nodes = client.getNodes();
-        org.junit.Assume.assumeTrue(nodes.length > 0);
-        Version serverVersion = nodes[0].getServerVersion();
-        return serverVersion.isLessThanOrEqual(version);
-    }
 
     private void assertBatchBinEqual(List<BatchRead> list, String binName, int i) {
 		BatchRead batch = list.get(i);

--- a/test/src/com/aerospike/test/util/Args.java
+++ b/test/src/com/aerospike/test/util/Args.java
@@ -60,6 +60,7 @@ public class Args {
 	public boolean enterprise;
 	public boolean hasTtl;
 	public boolean scMode;
+	public Version serverVersion;
 
 	public Args() {
 		host = "127.0.0.1";
@@ -260,7 +261,8 @@ public class Args {
 		}
 
 		Node node = client.getNodes()[0];
-		String editionFilter = node.serverVersion.isGreaterOrEqual(Version.SERVER_VERSION_8_1) ? "release" : "edition";
+		serverVersion = node.getServerVersion();
+		String editionFilter = serverVersion.isGreaterOrEqual(Version.SERVER_VERSION_8_1) ? "release" : "edition";
 		String namespaceFilter = "namespace/" + namespace;
 		Map<String,String> map = Info.request(null, node, editionFilter, namespaceFilter);
 


### PR DESCRIPTION
Skipping `batchReadTTL` test for older server versions: 7.0 or below