### PR TITLE
Switch Buffer.bytesToHexString from using String.format() in a loop

### DIFF
--- a/client/src/com/aerospike/client/command/Buffer.java
+++ b/client/src/com/aerospike/client/command/Buffer.java
@@ -19,6 +19,7 @@ package com.aerospike.client.command;
 import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import java.util.HexFormat;
 
 import com.aerospike.client.AerospikeException;
 import com.aerospike.client.Value;
@@ -235,21 +236,11 @@ public final class Buffer {
 		if (buf == null || buf.length == 0) {
 			return "";
 		}
-		StringBuilder sb = new StringBuilder(buf.length * 2);
-
-		for (int i = 0; i < buf.length; i++) {
-			sb.append(String.format("%02x", buf[i]));
-		}
-		return sb.toString();
+		return HexFormat.of().formatHex(buf);
 	}
 
 	public static String bytesToHexString(byte[] buf, int offset, int length) {
-		StringBuilder sb = new StringBuilder(length * 2);
-
-		for (int i = offset; i < length; i++) {
-			sb.append(String.format("%02x", buf[i]));
-		}
-		return sb.toString();
+		return HexFormat.of().formatHex(buf, offset, offset + length);
 	}
 
 	public static Value bytesToLongValue(byte[] buf, int offset, int len) {


### PR DESCRIPTION
In our application, I'm looking at performance via the perf utility and noticing that `java.util.Formatter.parse(java.lang.String)` is on CPU quite often (Second highest non-kernel call). Taking repeated stack snapshots of our application, I am seeing that the parse is almost exclusively coming in via a stack trace similar to this one:
```
"reactor-http-epoll-25" #450 [464] daemon prio=5 os_prio=0 cpu=56476923.75ms elapsed=193733.65s tid=0x00007f1aa33fbc90 nid=464 runnable  [0x00007ef3226e3000]
   java.lang.Thread.State: RUNNABLE
	at java.util.regex.Pattern$BmpCharPropertyGreedy.match(java.base@21.0.5/Pattern.java:4502)
	at java.util.regex.Pattern$GroupHead.match(java.base@21.0.5/Pattern.java:4969)
	at java.util.regex.Pattern$Branch.match(java.base@21.0.5/Pattern.java:4914)
	at java.util.regex.Pattern$BranchConn.match(java.base@21.0.5/Pattern.java:4878)
	at java.util.regex.Pattern$GroupTail.match(java.base@21.0.5/Pattern.java:5000)
	at java.util.regex.Pattern$BmpCharPropertyGreedy.match(java.base@21.0.5/Pattern.java:4509)
	at java.util.regex.Pattern$GroupHead.match(java.base@21.0.5/Pattern.java:4969)
	at java.util.regex.Pattern$Branch.match(java.base@21.0.5/Pattern.java:4914)
	at java.util.regex.Pattern$Branch.match(java.base@21.0.5/Pattern.java:4912)
	at java.util.regex.Pattern$BmpCharProperty.match(java.base@21.0.5/Pattern.java:4134)
	at java.util.regex.Pattern$Start.match(java.base@21.0.5/Pattern.java:3787)
	at java.util.regex.Matcher.search(java.base@21.0.5/Matcher.java:1767)
	at java.util.regex.Matcher.find(java.base@21.0.5/Matcher.java:814)
	at java.util.Formatter.parse(java.base@21.0.5/Formatter.java:2848)
	at java.util.Formatter.format(java.base@21.0.5/Formatter.java:2774)
	at java.util.Formatter.format(java.base@21.0.5/Formatter.java:2728)
	at java.lang.String.format(java.base@21.0.5/String.java:4390)
	at com.aerospike.client.command.Buffer.bytesToHexString(Buffer.java:241)
	at com.aerospike.client.Key.toString(Key.java:321)\
```

Now that the Aerospike client is on a JDK higher than 17, I would like to request that the client library switch to utilizing the newer java.util.HexFormat upstream library that's designed for this exact functionality rather than looping through the byte array, as I believe it would be a benefit for us performance-wise.