### PR TITLE
Vector search and Map Reduce api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ apidocs
 *.iml
 .idea/
 .vscode
+.vs
 dependency-reduced-pom.xml
 gnu.config
 bouncycastle.config

--- a/client/src/com/aerospike/client/AerospikeClient.java
+++ b/client/src/com/aerospike/client/AerospikeClient.java
@@ -126,6 +126,8 @@ import com.aerospike.client.query.QueryListenerExecutor;
 import com.aerospike.client.query.QueryPartitionExecutor;
 import com.aerospike.client.query.QueryRecordExecutor;
 import com.aerospike.client.query.RecordSet;
+import com.aerospike.client.query.ReduceResult;
+import com.aerospike.client.query.ReduceSpec;
 import com.aerospike.client.query.ResultSet;
 import com.aerospike.client.query.ServerCommand;
 import com.aerospike.client.query.Statement;
@@ -4428,6 +4430,8 @@ public class AerospikeClient implements IAerospikeClient, Closeable {
 	 */
 	public final RecordSet query(QueryPolicy policy, Statement statement)
 		throws AerospikeException {
+		statement.validateRecordQuery();
+
 		if (policy == null) {
 			policy = mergedQueryPolicyDefault;
 		} else if (configProvider != null) {
@@ -4446,6 +4450,62 @@ public class AerospikeClient implements IAerospikeClient, Closeable {
 			executor.execute();
 			return executor.getRecordSet();
 		}
+	}
+
+	/**
+	 * Execute a query with a scalar reduce spec set via {@link Statement#setReduce(ReduceSpec...)}
+	 * ({@link com.aerospike.client.query.Reduce#sum}, {@link com.aerospike.client.query.Reduce#count},
+	 * {@link com.aerospike.client.query.Reduce#min}, or {@link com.aerospike.client.query.Reduce#max})
+	 * and return the merged scalar result. This method blocks until all nodes have responded.
+	 * <p>
+	 * For Top-K reduces ({@link com.aerospike.client.query.Reduce#topK} or the split
+	 * {@link com.aerospike.client.query.Reduce#orderBy} + {@link com.aerospike.client.query.Reduce#limit}
+	 * form) which return full records, use {@link #query(QueryPolicy, Statement)} instead; the
+	 * merged Top-K records are streamed through the returned {@link RecordSet} like any other query.
+	 * <p>
+	 * Requires server version 6.0+ if using a secondary index query.
+	 *
+	 * @param policy				query configuration parameters, pass in null for defaults
+	 * @param statement				query definition with a scalar reduce spec set
+	 * @return						merged scalar result
+	 * @throws IllegalArgumentException if no reduce is set, or a Top-K reduce is set
+	 * @throws AerospikeException	if query fails
+	 */
+	public final ReduceResult queryReduce(QueryPolicy policy, Statement statement)
+		throws AerospikeException {
+		statement.validateReduceQuery();
+
+		if (policy == null) {
+			policy = mergedQueryPolicyDefault;
+		} else if (configProvider != null) {
+			policy = new QueryPolicy(policy, configProvider);
+		}
+
+		Node[] nodes = cluster.validateNodes();
+
+		if (! (cluster.hasPartitionQuery || statement.getFilter() == null)) {
+			throw new AerospikeException(ResultCode.PARAMETER_ERROR,
+				"queryReduce() requires partition query support (server version 6.0+) when a query index filter is set");
+		}
+
+		PartitionTracker tracker = new PartitionTracker(policy, statement, nodes);
+		QueryPartitionExecutor executor = new QueryPartitionExecutor(cluster, policy, statement, nodes.length, tracker);
+		RecordSet rs = executor.getRecordSet();
+
+		try {
+			// Scalar reduce specs do not emit rows into the RecordSet; this loop simply
+			// blocks until the executor has fed every partition's records into the
+			// combiner and signals completion.
+			while (rs.next()) {
+				// Nothing to do; defensively drain in case a future scalar variant emits rows.
+			}
+		}
+		finally {
+			rs.close();
+		}
+
+		ReduceSpec<Record, ?> reducer = statement.resolveReduce();
+		return new ReduceResult(reducer.getScalarResult());
 	}
 
 	/**
@@ -4579,6 +4639,8 @@ public class AerospikeClient implements IAerospikeClient, Closeable {
 	 */
 	public final RecordSet queryNode(QueryPolicy policy, Statement statement, Node node)
 		throws AerospikeException {
+		statement.validateRecordQuery();
+
 		if (policy == null) {
 			policy = mergedQueryPolicyDefault;
 		} else if (configProvider != null) {
@@ -4614,6 +4676,8 @@ public class AerospikeClient implements IAerospikeClient, Closeable {
 		Statement statement,
 		PartitionFilter partitionFilter
 	) throws AerospikeException {
+		statement.validateRecordQuery();
+
 		if (policy == null) {
 			policy = mergedQueryPolicyDefault;
 		} else if (configProvider != null) {

--- a/client/src/com/aerospike/client/IAerospikeClient.java
+++ b/client/src/com/aerospike/client/IAerospikeClient.java
@@ -1736,6 +1736,28 @@ public interface IAerospikeClient extends Closeable {
 		throws AerospikeException;
 
 	/**
+	 * Execute a query with a scalar reduce spec set via {@link Statement#setReduce(com.aerospike.client.query.ReduceSpec...)}
+	 * ({@link com.aerospike.client.query.Reduce#sum}, {@link com.aerospike.client.query.Reduce#count},
+	 * {@link com.aerospike.client.query.Reduce#min}, or {@link com.aerospike.client.query.Reduce#max})
+	 * and return the merged scalar result. This method blocks until all nodes have responded.
+	 * <p>
+	 * For Top-K reduces ({@link com.aerospike.client.query.Reduce#topK} or the split
+	 * {@link com.aerospike.client.query.Reduce#orderBy} + {@link com.aerospike.client.query.Reduce#limit}
+	 * form) which return full records, use {@link #query(QueryPolicy, Statement)} instead; the
+	 * merged Top-K records are streamed through the returned {@link RecordSet} like any other query.
+	 * <p>
+	 * Requires server version 6.0+ if using a secondary index query.
+	 *
+	 * @param policy				query configuration parameters, pass in null for defaults
+	 * @param statement				query definition with a scalar reduce spec set
+	 * @return						merged scalar result
+	 * @throws IllegalArgumentException if no reduce is set, or a Top-K reduce is set
+	 * @throws AerospikeException	if query fails
+	 */
+	public com.aerospike.client.query.ReduceResult queryReduce(QueryPolicy policy, Statement statement)
+		throws AerospikeException;
+
+	/**
 	 * Asynchronously execute query on all server nodes.
 	 * This method registers the command with an event loop and returns.
 	 * The event loop thread will process the command and send the results to the listener.

--- a/client/src/com/aerospike/client/query/BinDataType.java
+++ b/client/src/com/aerospike/client/query/BinDataType.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2012-2025 Aerospike, Inc.
+ *
+ * Portions may be licensed to Aerospike, Inc. under one or more contributor
+ * license agreements WHICH ARE COMPATIBLE WITH THE APACHE LICENSE, VERSION 2.0.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.aerospike.client.query;
+
+/**
+ * Scalar bin data type used by {@link Reduce} order/reduce specs to interpret a bin's
+ * value for comparison (min/max/order-by).
+ * <p>
+ * Note: investigate {@code ParticleType} as a possible replacement for this type during
+ * implementation.
+ */
+public enum BinDataType {
+	/**
+	 * Integer (long) value.
+	 */
+	INTEGER,
+
+	/**
+	 * Double precision floating point value.
+	 */
+	DOUBLE,
+
+	/**
+	 * String value.
+	 */
+	STRING,
+
+	/**
+	 * Byte array value.
+	 */
+	BYTES
+}

--- a/client/src/com/aerospike/client/query/CountReduceSpec.java
+++ b/client/src/com/aerospike/client/query/CountReduceSpec.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2012-2025 Aerospike, Inc.
+ *
+ * Portions may be licensed to Aerospike, Inc. under one or more contributor
+ * license agreements WHICH ARE COMPATIBLE WITH THE APACHE LICENSE, VERSION 2.0.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.aerospike.client.query;
+
+import com.aerospike.client.Key;
+import com.aerospike.client.Record;
+
+/**
+ * Scalar COUNT reduce combiner. Backs {@link Reduce#count()}.
+ * <p>
+ * Counts one per {@link #acceptPartial(Record, Key)} call (one per matching record).
+ */
+final class CountReduceSpec implements ReduceSpec<Record, Long> {
+	private long count;
+
+	@Override
+	public void acceptPartial(Record record, Key key) {
+		count++;
+	}
+
+	@Override
+	public Long getScalarResult() {
+		return count;
+	}
+
+	@Override
+	public Long[] getResult() {
+		return new Long[] { getScalarResult() };
+	}
+}

--- a/client/src/com/aerospike/client/query/CountReduceSpec.java
+++ b/client/src/com/aerospike/client/query/CountReduceSpec.java
@@ -22,7 +22,8 @@ import com.aerospike.client.Record;
 /**
  * Scalar COUNT reduce combiner. Backs {@link Reduce#count()}.
  * <p>
- * Counts one per {@link #acceptPartial(Record, Key)} call (one per matching record).
+ * Counts one per {@link #acceptPartial(Record, Key)} call (one per matching record). Not part
+ * of the public API surface beyond the {@link Reduce#count} factory method.
  */
 final class CountReduceSpec implements ReduceSpec<Record, Long> {
 	private long count;

--- a/client/src/com/aerospike/client/query/LimitReduceSpec.java
+++ b/client/src/com/aerospike/client/query/LimitReduceSpec.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2012-2025 Aerospike, Inc.
+ *
+ * Portions may be licensed to Aerospike, Inc. under one or more contributor
+ * license agreements WHICH ARE COMPATIBLE WITH THE APACHE LICENSE, VERSION 2.0.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.aerospike.client.query;
+
+import com.aerospike.client.Key;
+import com.aerospike.client.Record;
+
+/**
+ * Cap-metadata-only reduce spec produced by {@link Reduce#limit(String, int)}.
+ * <p>
+ * Carries no combiner logic by itself. {@link Statement#setReduce(ReduceSpec...)} pairs this
+ * with an {@link OrderByReduceSpec} on the same bin and composes them into a
+ * {@link TopKReduceSpec} via {@link TopKReduceSpec#compose(ReduceSpec, ReduceSpec)}. Not part
+ * of the public API surface beyond the {@link Reduce#limit} factory method.
+ */
+final class LimitReduceSpec implements ReduceSpec<Record, Record> {
+	final String bin;
+	final int limit;
+
+	LimitReduceSpec(String bin, int limit) {
+		if (limit < 1 || limit > 1000) {
+			throw new IllegalArgumentException("limit must be in [1, 1000], got: " + limit);
+		}
+		this.bin = bin;
+		this.limit = limit;
+	}
+
+	@Override
+	public void acceptPartial(Record record, Key key) {
+		throw new UnsupportedOperationException("limit must be combined with orderBy (see Reduce.topK)");
+	}
+
+	@Override
+	public Record getScalarResult() {
+		throw new UnsupportedOperationException("limit must be combined with orderBy (see Reduce.topK)");
+	}
+
+	@Override
+	public Record[] getResult() {
+		throw new UnsupportedOperationException("limit must be combined with orderBy (see Reduce.topK)");
+	}
+}

--- a/client/src/com/aerospike/client/query/MinMaxReduceSpec.java
+++ b/client/src/com/aerospike/client/query/MinMaxReduceSpec.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2012-2025 Aerospike, Inc.
+ *
+ * Portions may be licensed to Aerospike, Inc. under one or more contributor
+ * license agreements WHICH ARE COMPATIBLE WITH THE APACHE LICENSE, VERSION 2.0.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.aerospike.client.query;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import com.aerospike.client.Key;
+import com.aerospike.client.Record;
+import com.aerospike.client.command.Buffer;
+
+/**
+ * Scalar MIN/MAX reduce combiner. Backs both {@link Reduce#min(String, BinDataType)} and
+ * {@link Reduce#max(String, BinDataType)} — direction is selected via {@link Order}
+ * ({@code ASC} picks the minimum, {@code DESC} picks the maximum).
+ * <p>
+ * Merge is commutative: the order in which {@link #acceptPartial(Record, Key)} is called
+ * across nodes does not affect the result.
+ */
+final class MinMaxReduceSpec implements ReduceSpec<Record, Number> {
+	private final String bin;
+	private final BinDataType type;
+	private final Order order;
+
+	private Number best;
+	private final Map<String, Record> tiesByDigest = new LinkedHashMap<>();
+
+	MinMaxReduceSpec(String bin, BinDataType type, Order order) {
+		if (type != BinDataType.INTEGER && type != BinDataType.DOUBLE) {
+			throw new IllegalArgumentException("min/max requires BinDataType.INTEGER or BinDataType.DOUBLE, got: " + type);
+		}
+		this.bin = bin;
+		this.type = type;
+		this.order = order;
+	}
+
+	@Override
+	public void acceptPartial(Record record, Key key) {
+		Number value = readNumber(record);
+
+		if (value == null) {
+			return;
+		}
+
+		int cmp = (best == null) ? 1 : compareNumber(value, best);
+		boolean better = (order == Order.ASC) ? cmp < 0 : cmp > 0;
+
+		if (best == null || better) {
+			best = value;
+			tiesByDigest.clear();
+			tiesByDigest.put(digestKey(key), record);
+		}
+		else if (cmp == 0) {
+			tiesByDigest.putIfAbsent(digestKey(key), record);
+		}
+	}
+
+	@Override
+	public Number getScalarResult() {
+		if (best == null) {
+			throw new IllegalStateException("No partials accepted");
+		}
+		return best;
+	}
+
+	@Override
+	public Number[] getResult() {
+		return new Number[] { getScalarResult() };
+	}
+
+	/**
+	 * Records tied at the current MIN/MAX value, in the order they were first seen.
+	 */
+	Record[] getTiedRecords() {
+		return tiesByDigest.values().toArray(new Record[0]);
+	}
+
+	private Number readNumber(Record record) {
+		return type == BinDataType.DOUBLE ? record.getDouble(bin) : record.getLong(bin);
+	}
+
+	private static int compareNumber(Number a, Number b) {
+		return Double.compare(a.doubleValue(), b.doubleValue());
+	}
+
+	static String digestKey(Key key) {
+		return Buffer.bytesToHexString(key.digest);
+	}
+}

--- a/client/src/com/aerospike/client/query/MinMaxReduceSpec.java
+++ b/client/src/com/aerospike/client/query/MinMaxReduceSpec.java
@@ -29,7 +29,8 @@ import com.aerospike.client.command.Buffer;
  * ({@code ASC} picks the minimum, {@code DESC} picks the maximum).
  * <p>
  * Merge is commutative: the order in which {@link #acceptPartial(Record, Key)} is called
- * across nodes does not affect the result.
+ * across nodes does not affect the result. Not part of the public API surface beyond the
+ * {@link Reduce#min} / {@link Reduce#max} factory methods.
  */
 final class MinMaxReduceSpec implements ReduceSpec<Record, Number> {
 	private final String bin;
@@ -72,7 +73,8 @@ final class MinMaxReduceSpec implements ReduceSpec<Record, Number> {
 	@Override
 	public Number getScalarResult() {
 		if (best == null) {
-			throw new IllegalStateException("No partials accepted");
+			throw new IllegalStateException(
+				"getScalarResult() called before any records were accepted via acceptPartial()");
 		}
 		return best;
 	}

--- a/client/src/com/aerospike/client/query/Order.java
+++ b/client/src/com/aerospike/client/query/Order.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2012-2025 Aerospike, Inc.
+ *
+ * Portions may be licensed to Aerospike, Inc. under one or more contributor
+ * license agreements WHICH ARE COMPATIBLE WITH THE APACHE LICENSE, VERSION 2.0.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.aerospike.client.query;
+
+/**
+ * Sort direction for {@link Reduce#orderBy(String, BinDataType, Order, OrderByFlags)} and
+ * {@link Reduce#topK(String, BinDataType, Order, OrderByFlags, int)}.
+ */
+public enum Order {
+	/**
+	 * Ascending order (smallest value first).
+	 */
+	ASC,
+
+	/**
+	 * Descending order (largest value first).
+	 */
+	DESC
+}

--- a/client/src/com/aerospike/client/query/OrderByFlags.java
+++ b/client/src/com/aerospike/client/query/OrderByFlags.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2012-2025 Aerospike, Inc.
+ *
+ * Portions may be licensed to Aerospike, Inc. under one or more contributor
+ * license agreements WHICH ARE COMPATIBLE WITH THE APACHE LICENSE, VERSION 2.0.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.aerospike.client.query;
+
+/**
+ * Options for {@link Reduce#orderBy(String, BinDataType, Order, OrderByFlags)} and
+ * {@link Reduce#topK(String, BinDataType, Order, OrderByFlags, int)}.
+ */
+public enum OrderByFlags {
+	/**
+	 * No special comparison behavior.
+	 */
+	NONE,
+
+	/**
+	 * Case-insensitive comparison. Only applicable when {@link BinDataType#STRING} is used.
+	 */
+	CASE_INSENSITIVE
+}

--- a/client/src/com/aerospike/client/query/OrderByReduceSpec.java
+++ b/client/src/com/aerospike/client/query/OrderByReduceSpec.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2012-2025 Aerospike, Inc.
+ *
+ * Portions may be licensed to Aerospike, Inc. under one or more contributor
+ * license agreements WHICH ARE COMPATIBLE WITH THE APACHE LICENSE, VERSION 2.0.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.aerospike.client.query;
+
+import com.aerospike.client.Key;
+import com.aerospike.client.Record;
+
+/**
+ * Sort-metadata-only reduce spec produced by {@link Reduce#orderBy(String, BinDataType, Order, OrderByFlags)}.
+ * <p>
+ * Carries no combiner logic by itself. {@link Statement#setReduce(ReduceSpec...)} pairs this
+ * with a {@link LimitReduceSpec} on the same bin and composes them into a {@link TopKReduceSpec}
+ * via {@link TopKReduceSpec#compose(ReduceSpec, ReduceSpec)}. Not part of the public API surface
+ * beyond the {@link Reduce#orderBy} factory method.
+ */
+final class OrderByReduceSpec implements ReduceSpec<Record, Record> {
+	final String bin;
+	final BinDataType type;
+	final Order order;
+	final OrderByFlags flags;
+
+	OrderByReduceSpec(String bin, BinDataType type, Order order, OrderByFlags flags) {
+		this.bin = bin;
+		this.type = type;
+		this.order = order;
+		this.flags = flags;
+	}
+
+	@Override
+	public void acceptPartial(Record record, Key key) {
+		throw new UnsupportedOperationException("orderBy must be combined with limit (see Reduce.topK)");
+	}
+
+	@Override
+	public Record getScalarResult() {
+		throw new UnsupportedOperationException("orderBy must be combined with limit (see Reduce.topK)");
+	}
+
+	@Override
+	public Record[] getResult() {
+		throw new UnsupportedOperationException("orderBy must be combined with limit (see Reduce.topK)");
+	}
+}

--- a/client/src/com/aerospike/client/query/OrderKey.java
+++ b/client/src/com/aerospike/client/query/OrderKey.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2012-2025 Aerospike, Inc.
+ *
+ * Portions may be licensed to Aerospike, Inc. under one or more contributor
+ * license agreements WHICH ARE COMPATIBLE WITH THE APACHE LICENSE, VERSION 2.0.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.aerospike.client.query;
+
+import com.aerospike.client.Record;
+
+/**
+ * Sort key extracted from a projected or physical bin, used internally by
+ * {@link TopKReduceSpec} to order records and break ties by digest.
+ * <p>
+ * Not part of the public API.
+ */
+final class OrderKey implements Comparable<OrderKey> {
+	final Object value;
+	final BinDataType type;
+	final Order order;
+	final OrderByFlags flags;
+	final byte[] digest;
+
+	OrderKey(Record record, String bin, BinDataType type, Order order, OrderByFlags flags, byte[] digest) {
+		this.value = readValue(record, bin, type);
+		this.type = type;
+		this.order = order;
+		this.flags = flags;
+		this.digest = digest;
+	}
+
+	@Override
+	public int compareTo(OrderKey other) {
+		int cmp = compareValues(value, other.value, type, flags);
+
+		if (cmp != 0) {
+			return order == Order.ASC ? cmp : -cmp;
+		}
+		// Tie-break: digest ascending (stable, deterministic ordering).
+		return compareDigest(digest, other.digest);
+	}
+
+	static Object readValue(Record record, String bin, BinDataType type) {
+		switch (type) {
+			case INTEGER:
+				return record.getLong(bin);
+			case DOUBLE:
+				return record.getDouble(bin);
+			case STRING:
+				return record.getString(bin);
+			case BYTES:
+				return record.getBytes(bin);
+			default:
+				throw new IllegalArgumentException("Unsupported BinDataType: " + type);
+		}
+	}
+
+	@SuppressWarnings("unchecked")
+	private static int compareValues(Object a, Object b, BinDataType type, OrderByFlags flags) {
+		if (type == BinDataType.STRING && flags == OrderByFlags.CASE_INSENSITIVE) {
+			return ((String)a).compareToIgnoreCase((String)b);
+		}
+
+		if (type == BinDataType.BYTES) {
+			return compareBytes((byte[])a, (byte[])b);
+		}
+		return ((Comparable<Object>)a).compareTo(b);
+	}
+
+	private static int compareBytes(byte[] a, byte[] b) {
+		int len = Math.min(a.length, b.length);
+
+		for (int i = 0; i < len; i++) {
+			int cmp = (a[i] & 0xff) - (b[i] & 0xff);
+
+			if (cmp != 0) {
+				return cmp;
+			}
+		}
+		return a.length - b.length;
+	}
+
+	private static int compareDigest(byte[] a, byte[] b) {
+		int len = Math.min(a.length, b.length);
+
+		for (int i = 0; i < len; i++) {
+			int cmp = (a[i] & 0xff) - (b[i] & 0xff);
+
+			if (cmp != 0) {
+				return cmp;
+			}
+		}
+		return a.length - b.length;
+	}
+}

--- a/client/src/com/aerospike/client/query/QueryPartitionCommand.java
+++ b/client/src/com/aerospike/client/query/QueryPartitionCommand.java
@@ -31,6 +31,7 @@ public final class QueryPartitionCommand extends MultiCommand {
 	private final Statement statement;
 	private final long taskId;
 	private final RecordSet recordSet;
+	private final ReduceSpec<Record, ?> reducer;
 	private final PartitionTracker tracker;
 	private final NodePartitions nodePartitions;
 
@@ -40,6 +41,7 @@ public final class QueryPartitionCommand extends MultiCommand {
 		Statement statement,
 		long taskId,
 		RecordSet recordSet,
+		ReduceSpec<Record, ?> reducer,
 		PartitionTracker tracker,
 		NodePartitions nodePartitions
 	) {
@@ -47,6 +49,7 @@ public final class QueryPartitionCommand extends MultiCommand {
 		this.statement = statement;
 		this.taskId = taskId;
 		this.recordSet = recordSet;
+		this.reducer = reducer;
 		this.tracker = tracker;
 		this.nodePartitions = nodePartitions;
 	}
@@ -99,7 +102,13 @@ public final class QueryPartitionCommand extends MultiCommand {
 		}
 
 		if (tracker.allowRecord(nodePartitions)) {
-			if (! recordSet.put(new KeyRecord(key, record))) {
+			if (reducer != null) {
+				// Feed the client-side global reduce combiner instead of streaming this
+				// partial result directly to the caller. The executor emits the merged
+				// result (if any) once all partitions have been received.
+				reducer.acceptPartial(record, key);
+			}
+			else if (! recordSet.put(new KeyRecord(key, record))) {
 				stop();
 				throw new AerospikeException.QueryTerminated();
 			}

--- a/client/src/com/aerospike/client/query/QueryPartitionExecutor.java
+++ b/client/src/com/aerospike/client/query/QueryPartitionExecutor.java
@@ -24,6 +24,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import com.aerospike.client.AerospikeException;
+import com.aerospike.client.Key;
+import com.aerospike.client.Record;
 import com.aerospike.client.cluster.Cluster;
 import com.aerospike.client.command.MultiCommand;
 import com.aerospike.client.policy.QueryPolicy;
@@ -37,6 +39,7 @@ public final class QueryPartitionExecutor implements IQueryExecutor, Runnable {
 	private final Statement statement;
 	private final PartitionTracker tracker;
 	private final RecordSet recordSet;
+	private final ReduceSpec<Record, ?> reducer;
 	private final List<QueryThread> threads;
 	private final AtomicInteger completedCount;
 	private final AtomicBoolean done;
@@ -55,6 +58,7 @@ public final class QueryPartitionExecutor implements IQueryExecutor, Runnable {
 		this.statement = statement;
 		this.tracker = tracker;
 		this.recordSet = new RecordSet(this, policy.recordQueueSize);
+		this.reducer = statement.resolveReduce();
 		this.threads = new ArrayList<QueryThread>(nodeCapacity);
 		this.completedCount = new AtomicInteger();
 		this.done = new AtomicBoolean();
@@ -99,7 +103,7 @@ public final class QueryPartitionExecutor implements IQueryExecutor, Runnable {
 					es = Executors.newThreadPerTaskExecutor(cluster.threadFactory);
 
 					for (NodePartitions nodePartitions : list) {
-						MultiCommand command = new QueryPartitionCommand(cluster, policy, statement, taskId, recordSet, tracker, nodePartitions);
+						MultiCommand command = new QueryPartitionCommand(cluster, policy, statement, taskId, recordSet, reducer, tracker, nodePartitions);
 						threads.add(new QueryThread(command));
 					}
 
@@ -115,7 +119,7 @@ public final class QueryPartitionExecutor implements IQueryExecutor, Runnable {
 			}
 			else {
 				for (NodePartitions nodePartitions : list) {
-					MultiCommand command = new QueryPartitionCommand(cluster, policy, statement, taskId, recordSet, tracker, nodePartitions);
+					MultiCommand command = new QueryPartitionCommand(cluster, policy, statement, taskId, recordSet, reducer, tracker, nodePartitions);
 					command.execute();
 				}
 			}
@@ -128,7 +132,19 @@ public final class QueryPartitionExecutor implements IQueryExecutor, Runnable {
 			done.set(false);
 
 			if (tracker.isComplete(cluster, policy)) {
-				// All partitions received.
+				// All partitions received. Emit the merged reduce result (if record-shaped,
+				// e.g. Top-K) now that every node/partition has fed the combiner. Scalar
+				// reduce results (sum/count/min/max) are not emitted here; the caller reads
+				// them directly off the combiner via Statement.resolveReduce().
+				if (reducer instanceof TopKReduceSpec) {
+					TopKReduceSpec topK = (TopKReduceSpec)reducer;
+					Record[] records = topK.getResult();
+					Key[] keys = topK.getResultKeys();
+
+					for (int i = 0; i < records.length; i++) {
+						recordSet.put(new KeyRecord(keys[i], records[i]));
+					}
+				}
 				recordSet.put(RecordSet.END);
 				break;
 			}

--- a/client/src/com/aerospike/client/query/Reduce.java
+++ b/client/src/com/aerospike/client/query/Reduce.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2012-2025 Aerospike, Inc.
+ *
+ * Portions may be licensed to Aerospike, Inc. under one or more contributor
+ * license agreements WHICH ARE COMPATIBLE WITH THE APACHE LICENSE, VERSION 2.0.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.aerospike.client.query;
+
+import com.aerospike.client.Record;
+
+/**
+ * Factory for {@link ReduceSpec} instances used with {@link Statement#setReduce(ReduceSpec...)}.
+ * <p>
+ * Two reduce shapes are supported:
+ * <ul>
+ *   <li><b>Ordered LIMIT k</b> ({@link #topK}, or {@link #orderBy} + {@link #limit} passed
+ *       together) — returns up to k full records, globally ordered.</li>
+ *   <li><b>Scalar</b> ({@link #sum}, {@link #count}, {@link #min}, {@link #max}) — returns a
+ *       single commutative aggregate value.</li>
+ * </ul>
+ */
+public final class Reduce {
+
+	private Reduce() {
+	}
+
+	/**
+	 * Ordered LIMIT k reduce; returns up to {@code k} full records in global sort order
+	 * (e.g. vector search Top-K, {@code ORDER BY bin LIMIT k}).
+	 *
+	 * @param bin	bin name to order by; must be a physical bin or a projected bin from
+	 *              {@link Statement#setOperations(com.aerospike.client.Operation[])}
+	 * @param type	scalar type of {@code bin}
+	 * @param order	sort direction
+	 * @param flags	comparison options ({@link OrderByFlags#CASE_INSENSITIVE} for
+	 *              {@link BinDataType#STRING} only)
+	 * @param k		maximum number of records to return, in {@code [1, 1000]}
+	 */
+	public static ReduceSpec<Record, Record> topK(String bin, BinDataType type, Order order, OrderByFlags flags, int k) {
+		return TopKReduceSpec.compose(orderBy(bin, type, order, flags), limit(bin, k));
+	}
+
+	/**
+	 * Sort-order building block for {@code topK}. Must be paired with {@link #limit(String, int)}
+	 * on the same bin via {@link Statement#setReduce(ReduceSpec...)}; using it alone throws
+	 * {@link UnsupportedOperationException}.
+	 */
+	public static ReduceSpec<Record, Record> orderBy(String bin, BinDataType type, Order order, OrderByFlags flags) {
+		return new OrderByReduceSpec(bin, type, order, flags);
+	}
+
+	/**
+	 * Cap building block for {@code topK}. Must be paired with
+	 * {@link #orderBy(String, BinDataType, Order, OrderByFlags)} on the same bin via
+	 * {@link Statement#setReduce(ReduceSpec...)}; using it alone throws
+	 * {@link UnsupportedOperationException}.
+	 *
+	 * @param bin	bin name; must match the paired {@code orderBy} bin
+	 * @param limit	maximum number of records to return, in {@code [1, 1000]}
+	 */
+	public static ReduceSpec<Record, Record> limit(String bin, int limit) {
+		return new LimitReduceSpec(bin, limit);
+	}
+
+	/**
+	 * Sum of {@code bin} across all matching records. {@code bin} must be an integer bin
+	 * (or a projected bin from {@link Statement#setOperations(com.aerospike.client.Operation[])}
+	 * that evaluates to an integer).
+	 */
+	public static ReduceSpec<Record, Long> sum(String bin) {
+		return new SumReduceSpec(bin);
+	}
+
+	/**
+	 * Count of records matching the query filter and record predicate.
+	 */
+	public static ReduceSpec<Record, Long> count() {
+		return new CountReduceSpec();
+	}
+
+	/**
+	 * Minimum value of {@code bin} across all matching records.
+	 * {@link ReduceSpec#getScalarResult()} returns the minimum value.
+	 *
+	 * @param bin	bin name; must be {@link BinDataType#INTEGER} or {@link BinDataType#DOUBLE}
+	 * @param type	scalar type of {@code bin}
+	 */
+	public static ReduceSpec<Record, Number> min(String bin, BinDataType type) {
+		return new MinMaxReduceSpec(bin, type, Order.ASC);
+	}
+
+	/**
+	 * Maximum value of {@code bin} across all matching records.
+	 *
+	 * @param bin	bin name; must be {@link BinDataType#INTEGER} or {@link BinDataType#DOUBLE}
+	 * @param type	scalar type of {@code bin}
+	 */
+	public static ReduceSpec<Record, Number> max(String bin, BinDataType type) {
+		return new MinMaxReduceSpec(bin, type, Order.DESC);
+	}
+}

--- a/client/src/com/aerospike/client/query/ReduceResult.java
+++ b/client/src/com/aerospike/client/query/ReduceResult.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2012-2025 Aerospike, Inc.
+ *
+ * Portions may be licensed to Aerospike, Inc. under one or more contributor
+ * license agreements WHICH ARE COMPATIBLE WITH THE APACHE LICENSE, VERSION 2.0.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.aerospike.client.query;
+
+/**
+ * Result of a scalar reduce query. Returned by
+ * {@link com.aerospike.client.AerospikeClient#queryReduce(com.aerospike.client.policy.QueryPolicy, Statement)}
+ * for statements with a scalar reduce spec set via
+ * {@link Statement#setReduce(ReduceSpec...)} ({@link Reduce#sum}, {@link Reduce#count},
+ * {@link Reduce#min}, or {@link Reduce#max}).
+ */
+public final class ReduceResult {
+	private final Object value;
+
+	public ReduceResult(Object value) {
+		this.value = value;
+	}
+
+	/**
+	 * Return the raw scalar value merged across all nodes.
+	 */
+	public Object getObject() {
+		return value;
+	}
+
+	/**
+	 * Return the scalar value as a {@link Number}. Valid for all scalar reduces
+	 * ({@link Reduce#sum}, {@link Reduce#count}, {@link Reduce#min}, {@link Reduce#max}).
+	 */
+	public Number getNumber() {
+		return (Number)value;
+	}
+
+	/**
+	 * Return the scalar value as a {@code long}. Valid for {@link Reduce#sum} and
+	 * {@link Reduce#count}, which always return {@link Long}.
+	 */
+	public long getLong() {
+		return ((Number)value).longValue();
+	}
+
+	/**
+	 * Return the scalar value as a {@code double}. Valid for {@link Reduce#min} and
+	 * {@link Reduce#max} on {@link BinDataType#DOUBLE} bins.
+	 */
+	public double getDouble() {
+		return ((Number)value).doubleValue();
+	}
+
+	@Override
+	public String toString() {
+		return String.valueOf(value);
+	}
+}

--- a/client/src/com/aerospike/client/query/ReduceSpec.java
+++ b/client/src/com/aerospike/client/query/ReduceSpec.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2012-2025 Aerospike, Inc.
+ *
+ * Portions may be licensed to Aerospike, Inc. under one or more contributor
+ * license agreements WHICH ARE COMPATIBLE WITH THE APACHE LICENSE, VERSION 2.0.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.aerospike.client.query;
+
+import com.aerospike.client.Key;
+
+/**
+ * Client-side global reduce combiner for query results.
+ * <p>
+ * Each cluster node produces a partial result for a query (e.g. a locally bounded Top-K
+ * heap, or a partial scalar aggregate). The query executor feeds every node's partial
+ * results into {@link #acceptPartial(Object, Key)} in any order (nodes complete
+ * concurrently), then reads the merged result via {@link #getScalarResult()} or
+ * {@link #getResult()}.
+ * <p>
+ * Instances are created via {@link Reduce} factory methods and passed to
+ * {@link Statement#setReduce(ReduceSpec...)}.
+ *
+ * @param <TInput>  type of each partial accepted by {@link #acceptPartial(Object, Key)}
+ *                  (usually {@link com.aerospike.client.Record})
+ * @param <TResult> element type returned by {@link #getResult()}
+ */
+public interface ReduceSpec<TInput, TResult> {
+
+	/**
+	 * Merge one partial result from a node into this combiner.
+	 *
+	 * @param record	partial result (usually a {@link com.aerospike.client.Record})
+	 * @param key		record key; used for digest-based deduplication and tie-breaking
+	 */
+	void acceptPartial(TInput record, Key key);
+
+	/**
+	 * Return a single scalar view of the merged result (e.g. MAX value, SUM, or the
+	 * best-ranked record for a Top-K reduce).
+	 */
+	TResult getScalarResult();
+
+	/**
+	 * Return the full merged result set (e.g. all Top-K records in order, or all records
+	 * tied at a MIN/MAX value).
+	 */
+	TResult[] getResult();
+}

--- a/client/src/com/aerospike/client/query/Statement.java
+++ b/client/src/com/aerospike/client/query/Statement.java
@@ -17,6 +17,7 @@
 package com.aerospike.client.query;
 
 import com.aerospike.client.Operation;
+import com.aerospike.client.Record;
 import com.aerospike.client.Value;
 import com.aerospike.client.util.RandomShift;
 
@@ -35,6 +36,14 @@ public final class Statement {
 	String functionName;
 	Value[] functionArgs;
 	Operation[] operations;
+	ReduceSpec<?, ?>[] reduceSpecs;
+	private ReduceSpec<?, ?> resolvedReduce;
+	private boolean reduceResolved;
+	private String orderByBin;
+	private BinDataType orderByType;
+	private Order orderByOrder;
+	private OrderByFlags orderByFlags;
+	private boolean orderBySet;
 	long taskId;
 	long maxRecords;
 	int recordsPerSecond;
@@ -258,6 +267,178 @@ public final class Statement {
 	 */
 	public Operation[] getOperations() {
 		return this.operations;
+	}
+
+	/**
+	 * Set reduce spec(s) for this query, used for client-side global reduce (e.g. Top-K,
+	 * SUM, COUNT, MIN, MAX). Accepts:
+	 * <ul>
+	 *   <li>zero args — clear any reduce (stream all matching records; default behavior)</li>
+	 *   <li>one scalar or Top-K spec — e.g. {@code setReduce(Reduce.sum("amt"))} or
+	 *       {@code setReduce(Reduce.topK("d", BinDataType.DOUBLE, Order.ASC, OrderByFlags.NONE, 10))}</li>
+	 *   <li>exactly one {@link Reduce#orderBy} + one {@link Reduce#limit} on the same bin —
+	 *       split Top-K, equivalent to {@link Reduce#topK}</li>
+	 * </ul>
+	 * Mutually exclusive with {@link #setAggregateFunction}. Replaces any previously set reduce
+	 * (this setter does not accumulate across calls, consistent with {@link #setOperations(Operation[])}
+	 * and {@link #setBinNames(String...)}).
+	 */
+	public void setReduce(ReduceSpec<?, ?>... reduceSpecs) {
+		this.reduceSpecs = reduceSpecs;
+		this.resolvedReduce = null;
+		this.reduceResolved = false;
+	}
+
+	/**
+	 * Return reduce spec(s) set by {@link #setReduce(ReduceSpec...)}.
+	 */
+	public ReduceSpec<?, ?>[] getReduce() {
+		return reduceSpecs;
+	}
+
+	/**
+	 * Sort order building block for {@link #setTopK(int)}. Equivalent to
+	 * {@code setOrderBy(binName, type, order, OrderByFlags.NONE)}.
+	 * <p>
+	 * Sugar: remembers the sort order for a subsequent {@link #setTopK(int)} call, which
+	 * together resolve internally to {@code setReduce(Reduce.topK(binName, type, order, flags, k))}.
+	 *
+	 * @param binName	bin name to order by
+	 * @param type		scalar type of {@code binName}
+	 * @param order		sort direction
+	 */
+	public void setOrderBy(String binName, BinDataType type, Order order) {
+		setOrderBy(binName, type, order, OrderByFlags.NONE);
+	}
+
+	/**
+	 * Sort order building block for {@link #setTopK(int)}.
+	 * <p>
+	 * Sugar: remembers the sort order for a subsequent {@link #setTopK(int)} call, which
+	 * together resolve internally to {@code setReduce(Reduce.topK(binName, type, order, flags, k))}.
+	 *
+	 * @param binName	bin name to order by
+	 * @param type		scalar type of {@code binName}
+	 * @param order		sort direction
+	 * @param flags		comparison options ({@link OrderByFlags#CASE_INSENSITIVE} for
+	 *                  {@link BinDataType#STRING} only)
+	 */
+	public void setOrderBy(String binName, BinDataType type, Order order, OrderByFlags flags) {
+		this.orderByBin = binName;
+		this.orderByType = type;
+		this.orderByOrder = order;
+		this.orderByFlags = flags;
+		this.orderBySet = true;
+	}
+
+	/**
+	 * Ordered LIMIT k reduce; must be preceded by a {@link #setOrderBy} call on this statement.
+	 * <p>
+	 * Sugar for {@code setReduce(Reduce.topK(binName, type, order, flags, k))} using the bin,
+	 * type, order, and flags from the preceding {@link #setOrderBy} call. Like
+	 * {@link #setReduce(ReduceSpec...)}, replaces any previously set reduce.
+	 *
+	 * @param k	maximum number of records to return, in {@code [1, 1000]}
+	 * @throws IllegalStateException if {@link #setOrderBy} was not called first
+	 */
+	public void setTopK(int k) {
+		if (! orderBySet) {
+			throw new IllegalStateException("setTopK() requires setOrderBy() to be called first");
+		}
+		setReduce(Reduce.topK(orderByBin, orderByType, orderByOrder, orderByFlags, k));
+	}
+
+	/**
+	 * Resolve the reduce spec(s) set by {@link #setReduce(ReduceSpec...)} into a single combiner
+	 * usable by a query executor. Returns {@code null} if no reduce was set. Composes a split
+	 * {@link Reduce#orderBy} + {@link Reduce#limit} pair into a single Top-K combiner.
+	 *
+	 * @throws IllegalArgumentException if the reduce specs are not a single reducer or a valid
+	 *                                   orderBy/limit pair on the same bin
+	 */
+	@SuppressWarnings("unchecked")
+	public <I, O> ReduceSpec<I, O> resolveReduce() {
+		if (! reduceResolved) {
+			resolvedReduce = computeResolveReduce();
+			reduceResolved = true;
+		}
+		return (ReduceSpec<I, O>)resolvedReduce;
+	}
+
+	@SuppressWarnings("unchecked")
+	private ReduceSpec<?, ?> computeResolveReduce() {
+		if (reduceSpecs == null || reduceSpecs.length == 0) {
+			return null;
+		}
+
+		boolean isSplit = reduceSpecs[0] instanceof OrderByReduceSpec || reduceSpecs[0] instanceof LimitReduceSpec;
+
+		if (reduceSpecs.length == 1 && !isSplit) {
+			return reduceSpecs[0];
+		}
+
+		ReduceSpec<Record, Record> orderBy = null;
+		ReduceSpec<Record, Record> limit = null;
+
+		for (ReduceSpec<?, ?> spec : reduceSpecs) {
+			if (spec instanceof OrderByReduceSpec) {
+				orderBy = (ReduceSpec<Record, Record>)spec;
+			}
+			else if (spec instanceof LimitReduceSpec) {
+				limit = (ReduceSpec<Record, Record>)spec;
+			}
+			else {
+				throw new IllegalArgumentException("Cannot mix topK parts (orderBy/limit) with other reducers");
+			}
+		}
+
+		if (orderBy == null || limit == null) {
+			throw new IllegalArgumentException("topK requires both an orderBy spec and a limit spec");
+		}
+		return TopKReduceSpec.compose(orderBy, limit);
+	}
+
+	/**
+	 * For internal use by query executors. Validate that this statement's reduce (if any) is
+	 * compatible with record-streaming queries (e.g.
+	 * {@link com.aerospike.client.AerospikeClient#query(com.aerospike.client.policy.QueryPolicy, Statement)}),
+	 * which return full records via a {@link RecordSet} and therefore only support a Top-K (or no)
+	 * reduce.
+	 *
+	 * @throws IllegalArgumentException if a scalar reduce (sum/count/min/max) is set
+	 */
+	public void validateRecordQuery() {
+		ReduceSpec<?, ?> reduce = resolveReduce();
+
+		if (reduce != null && !(reduce instanceof TopKReduceSpec)) {
+			throw new IllegalArgumentException(
+				"Statement has a scalar reduce (sum/count/min/max) set. Use queryReduce() instead of query().");
+		}
+	}
+
+	/**
+	 * For internal use by query executors. Validate that this statement's reduce is compatible
+	 * with scalar reduce queries (e.g.
+	 * {@link com.aerospike.client.AerospikeClient#queryReduce(com.aerospike.client.policy.QueryPolicy, Statement)}),
+	 * which return a single scalar result and therefore require a scalar reduce spec
+	 * (sum/count/min/max).
+	 *
+	 * @throws IllegalArgumentException if no reduce is set, or a Top-K reduce is set
+	 */
+	public void validateReduceQuery() {
+		ReduceSpec<?, ?> reduce = resolveReduce();
+
+		if (reduce == null) {
+			throw new IllegalArgumentException(
+				"Statement has no reduce set. Call setReduce() with a scalar reducer " +
+				"(Reduce.sum/count/min/max) before calling queryReduce().");
+		}
+
+		if (reduce instanceof TopKReduceSpec) {
+			throw new IllegalArgumentException(
+				"Statement has a Top-K reduce set. Use query() instead of queryReduce() " +
+				"for Top-K / orderBy+limit reduces.");
+		}
 	}
 
 	/**

--- a/client/src/com/aerospike/client/query/SumReduceSpec.java
+++ b/client/src/com/aerospike/client/query/SumReduceSpec.java
@@ -22,7 +22,8 @@ import com.aerospike.client.Record;
 /**
  * Scalar SUM reduce combiner. Backs {@link Reduce#sum(String)}.
  * <p>
- * Merge is commutative and associative: adds each record's bin value across all nodes.
+ * Merge is commutative and associative: adds each record's bin value across all nodes. Not
+ * part of the public API surface beyond the {@link Reduce#sum} factory method.
  */
 final class SumReduceSpec implements ReduceSpec<Record, Long> {
 	private final String bin;

--- a/client/src/com/aerospike/client/query/SumReduceSpec.java
+++ b/client/src/com/aerospike/client/query/SumReduceSpec.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2012-2025 Aerospike, Inc.
+ *
+ * Portions may be licensed to Aerospike, Inc. under one or more contributor
+ * license agreements WHICH ARE COMPATIBLE WITH THE APACHE LICENSE, VERSION 2.0.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.aerospike.client.query;
+
+import com.aerospike.client.Key;
+import com.aerospike.client.Record;
+
+/**
+ * Scalar SUM reduce combiner. Backs {@link Reduce#sum(String)}.
+ * <p>
+ * Merge is commutative and associative: adds each record's bin value across all nodes.
+ */
+final class SumReduceSpec implements ReduceSpec<Record, Long> {
+	private final String bin;
+	private long sum;
+
+	SumReduceSpec(String bin) {
+		this.bin = bin;
+	}
+
+	@Override
+	public void acceptPartial(Record record, Key key) {
+		sum += record.getLong(bin);
+	}
+
+	@Override
+	public Long getScalarResult() {
+		return sum;
+	}
+
+	@Override
+	public Long[] getResult() {
+		return new Long[] { getScalarResult() };
+	}
+}

--- a/client/src/com/aerospike/client/query/TopKReduceSpec.java
+++ b/client/src/com/aerospike/client/query/TopKReduceSpec.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2012-2025 Aerospike, Inc.
+ *
+ * Portions may be licensed to Aerospike, Inc. under one or more contributor
+ * license agreements WHICH ARE COMPATIBLE WITH THE APACHE LICENSE, VERSION 2.0.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.aerospike.client.query;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.PriorityQueue;
+
+import com.aerospike.client.Key;
+import com.aerospike.client.Record;
+import com.aerospike.client.command.Buffer;
+
+/**
+ * Ordered LIMIT k reduce combiner backing {@link Reduce#topK(String, BinDataType, Order, OrderByFlags, int)}
+ * and the composed split form {@code setReduce(Reduce.orderBy(...), Reduce.limit(...))}.
+ * <p>
+ * Maintains a size-k heap keyed by the order bin, deduplicated by record digest (a record may
+ * be re-scanned across partition migrations) with ties broken by digest ascending for stable,
+ * deterministic results.
+ */
+final class TopKReduceSpec implements ReduceSpec<Record, Record> {
+	private final String bin;
+	private final BinDataType type;
+	private final Order order;
+	private final OrderByFlags flags;
+	private final int limit;
+
+	/** digest (hex) -> (key, record), for dedup and result reconstruction. */
+	private final Map<String, Entry> byDigest = new HashMap<>();
+
+	/** Worst-first heap: head is evicted first when the heap exceeds {@code limit}. */
+	private final PriorityQueue<OrderKey> heap;
+
+	private static final class Entry {
+		final Key key;
+		final Record record;
+		final OrderKey orderKey;
+
+		Entry(Key key, Record record, OrderKey orderKey) {
+			this.key = key;
+			this.record = record;
+			this.orderKey = orderKey;
+		}
+	}
+
+	private TopKReduceSpec(String bin, BinDataType type, Order order, OrderByFlags flags, int limit) {
+		this.bin = bin;
+		this.type = type;
+		this.order = order;
+		this.flags = flags;
+		this.limit = limit;
+		this.heap = new PriorityQueue<>(limit + 1, TopKReduceSpec::compareWorstFirst);
+	}
+
+	/**
+	 * Compose an {@link OrderByReduceSpec} and a {@link LimitReduceSpec} on the same bin into a
+	 * single {@link TopKReduceSpec} combiner. Used by {@link Reduce#topK} and by
+	 * {@link Statement#resolveReduce()} when the two specs are set separately.
+	 *
+	 * @throws IllegalArgumentException if the specs are not exactly one orderBy + one limit, or
+	 *                                   their bins do not match
+	 */
+	static TopKReduceSpec compose(ReduceSpec<Record, Record> orderBy, ReduceSpec<Record, Record> limit) {
+		if (!(orderBy instanceof OrderByReduceSpec) || !(limit instanceof LimitReduceSpec)) {
+			throw new IllegalArgumentException("topK requires one orderBy spec and one limit spec");
+		}
+		OrderByReduceSpec ob = (OrderByReduceSpec)orderBy;
+		LimitReduceSpec lim = (LimitReduceSpec)limit;
+
+		if (!ob.bin.equals(lim.bin)) {
+			throw new IllegalArgumentException(
+				"orderBy bin (" + ob.bin + ") must match limit bin (" + lim.bin + ")");
+		}
+		return new TopKReduceSpec(ob.bin, ob.type, ob.order, ob.flags, lim.limit);
+	}
+
+	@Override
+	public void acceptPartial(Record record, Key key) {
+		byte[] digest = key.digest;
+		String digestKey = digestKey(digest);
+		OrderKey candidate = new OrderKey(record, bin, type, order, flags, digest);
+
+		// Dedup: at most one row per digest (partition migration may re-scan a record).
+		Entry existingEntry = byDigest.get(digestKey);
+
+		if (existingEntry != null) {
+			if (candidate.compareTo(existingEntry.orderKey) >= 0) {
+				return; // existing entry is at least as good.
+			}
+			heap.remove(existingEntry.orderKey);
+			byDigest.remove(digestKey);
+		}
+
+		heap.offer(candidate);
+		byDigest.put(digestKey, new Entry(key, record, candidate));
+
+		if (heap.size() > limit) {
+			OrderKey evicted = heap.poll();
+			byDigest.remove(digestKey(evicted.digest));
+		}
+	}
+
+	@Override
+	public Record getScalarResult() {
+		Record[] all = getResult();
+
+		if (all.length == 0) {
+			throw new IllegalStateException("No partials accepted");
+		}
+		return all[0];
+	}
+
+	@Override
+	public Record[] getResult() {
+		List<OrderKey> list = new ArrayList<>(heap);
+		list.sort(Comparator.naturalOrder()); // best first.
+
+		Record[] out = new Record[list.size()];
+
+		for (int i = 0; i < list.size(); i++) {
+			out[i] = byDigest.get(digestKey(list.get(i).digest)).record;
+		}
+		return out;
+	}
+
+	/**
+	 * Return the record keys corresponding to {@link #getResult()}, in the same order.
+	 * Used by the query executor to reconstruct key/record pairs for {@link RecordSet}.
+	 */
+	Key[] getResultKeys() {
+		List<OrderKey> list = new ArrayList<>(heap);
+		list.sort(Comparator.naturalOrder()); // best first.
+
+		Key[] out = new Key[list.size()];
+
+		for (int i = 0; i < list.size(); i++) {
+			out[i] = byDigest.get(digestKey(list.get(i).digest)).key;
+		}
+		return out;
+	}
+
+	/** Evict the candidate with the worst sort key first (heap head = worst). */
+	private static int compareWorstFirst(OrderKey a, OrderKey b) {
+		return b.compareTo(a);
+	}
+
+	private static String digestKey(byte[] digest) {
+		return Buffer.bytesToHexString(digest);
+	}
+}

--- a/client/src/com/aerospike/client/query/TopKReduceSpec.java
+++ b/client/src/com/aerospike/client/query/TopKReduceSpec.java
@@ -33,7 +33,8 @@ import com.aerospike.client.command.Buffer;
  * <p>
  * Maintains a size-k heap keyed by the order bin, deduplicated by record digest (a record may
  * be re-scanned across partition migrations) with ties broken by digest ascending for stable,
- * deterministic results.
+ * deterministic results. Not part of the public API surface beyond the {@link Reduce#topK}
+ * factory method.
  */
 final class TopKReduceSpec implements ReduceSpec<Record, Record> {
 	private final String bin;
@@ -122,7 +123,8 @@ final class TopKReduceSpec implements ReduceSpec<Record, Record> {
 		Record[] all = getResult();
 
 		if (all.length == 0) {
-			throw new IllegalStateException("No partials accepted");
+			throw new IllegalStateException(
+				"getScalarResult() called before any records were accepted via acceptPartial()");
 		}
 		return all[0];
 	}

--- a/examples/src/com/aerospike/examples/Main.java
+++ b/examples/src/com/aerospike/examples/Main.java
@@ -71,6 +71,8 @@ public class Main extends JPanel {
 		"QueryResume",
 		"QuerySum",
 		"QueryAverage",
+		"QueryTopK",
+		"QueryMin",
 		"QueryCollection",
 		"QueryRegion",
 		"QueryRegionFilter",

--- a/examples/src/com/aerospike/examples/QueryMin.java
+++ b/examples/src/com/aerospike/examples/QueryMin.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2012-2026 Aerospike, Inc.
+ *
+ * Portions may be licensed to Aerospike, Inc. under one or more contributor
+ * license agreements WHICH ARE COMPATIBLE WITH THE APACHE LICENSE, VERSION 2.0.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.aerospike.examples;
+
+import com.aerospike.client.AerospikeException;
+import com.aerospike.client.Bin;
+import com.aerospike.client.IAerospikeClient;
+import com.aerospike.client.Key;
+import com.aerospike.client.ResultCode;
+import com.aerospike.client.policy.Policy;
+import com.aerospike.client.query.BinDataType;
+import com.aerospike.client.query.Filter;
+import com.aerospike.client.query.IndexType;
+import com.aerospike.client.query.ReduceResult;
+import com.aerospike.client.query.Reduce;
+import com.aerospike.client.query.Statement;
+import com.aerospike.client.task.IndexTask;
+
+/**
+ * Demonstrate client-side scalar reduce using {@link Reduce#min}.
+ * <p>
+ * Note: the server does not yet send a per-node partial MIN for this reduce
+ * (see docs/REDUCE-SPEC-DESIGN.md); every matching record is still sent to the client, which
+ * merges them locally. {@link IAerospikeClient#queryReduce} applies the reduce internally and
+ * blocks until all nodes have responded, returning the single merged scalar result.
+ * {@link Reduce#max} works the same way.
+ */
+public class QueryMin extends Example {
+
+	public QueryMin(Console console) {
+		super(console);
+	}
+
+	/**
+	 * Query records and calculate the minimum bin value using a ReduceSpec combiner.
+	 */
+	@Override
+	public void runExample(IAerospikeClient client, Parameters params) throws Exception {
+		String indexName = "minindex";
+		String keyPrefix = "minkey";
+		String binName = "minbin";
+		int size = 20;
+
+		createIndex(client, params, indexName, binName);
+		writeRecords(client, params, keyPrefix, binName, size);
+		runQuery(client, params, indexName, binName);
+		client.dropIndex(params.policy, params.namespace, params.set, indexName);
+	}
+
+	private void createIndex(
+		IAerospikeClient client,
+		Parameters params,
+		String indexName,
+		String binName
+	) throws Exception {
+		console.info("Create index: ns=%s set=%s index=%s bin=%s",
+			params.namespace, params.set, indexName, binName);
+
+		Policy policy = new Policy();
+		policy.socketTimeout = 0; // Do not timeout on index create.
+
+		try {
+			IndexTask task = client.createIndex(policy, params.namespace, params.set, indexName, binName, IndexType.NUMERIC);
+			task.waitTillComplete();
+		}
+		catch (AerospikeException ae) {
+			if (ae.getResultCode() != ResultCode.INDEX_ALREADY_EXISTS) {
+				throw ae;
+			}
+		}
+	}
+
+	private void writeRecords(
+		IAerospikeClient client,
+		Parameters params,
+		String keyPrefix,
+		String binName,
+		int size
+	) throws Exception {
+		console.info("Write " + size + " records.");
+
+		// Values 1..size. The minimum is 1.
+		for (int i = 1; i <= size; i++) {
+			Key key = new Key(params.namespace, params.set, keyPrefix + i);
+			Bin bin = new Bin(binName, i);
+			client.put(params.writePolicy, key, bin);
+		}
+	}
+
+	private void runQuery(
+		IAerospikeClient client,
+		Parameters params,
+		String indexName,
+		String binName
+	) throws Exception {
+		int begin = 1;
+		int end = 1000;
+
+		console.info("Query minimum bin=%s", binName);
+
+		Statement stmt = new Statement();
+		stmt.setNamespace(params.namespace);
+		stmt.setSetName(params.set);
+		stmt.setBinNames(binName);
+		stmt.setFilter(Filter.range(binName, begin, end));
+		stmt.setReduce(Reduce.min(binName, BinDataType.INTEGER));
+
+		// client.queryReduce() merges every node's partial MIN and blocks until the final
+		// scalar result is ready.
+		ReduceResult result = client.queryReduce(null, stmt);
+		int min = result.getNumber().intValue();
+		int expected = 1;
+
+		if (min == expected) {
+			console.info("Minimum matched: value=%d", min);
+		}
+		else {
+			console.error("Minimum mismatch. Expected %d. Received %d.", expected, min);
+		}
+	}
+}

--- a/examples/src/com/aerospike/examples/QueryTopK.java
+++ b/examples/src/com/aerospike/examples/QueryTopK.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2012-2026 Aerospike, Inc.
+ *
+ * Portions may be licensed to Aerospike, Inc. under one or more contributor
+ * license agreements WHICH ARE COMPATIBLE WITH THE APACHE LICENSE, VERSION 2.0.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.aerospike.examples;
+
+import com.aerospike.client.AerospikeException;
+import com.aerospike.client.Bin;
+import com.aerospike.client.IAerospikeClient;
+import com.aerospike.client.Key;
+import com.aerospike.client.Record;
+import com.aerospike.client.ResultCode;
+import com.aerospike.client.policy.Policy;
+import com.aerospike.client.query.BinDataType;
+import com.aerospike.client.query.Filter;
+import com.aerospike.client.query.IndexType;
+import com.aerospike.client.query.Order;
+import com.aerospike.client.query.OrderByFlags;
+import com.aerospike.client.query.RecordSet;
+import com.aerospike.client.query.Reduce;
+import com.aerospike.client.query.Statement;
+import com.aerospike.client.task.IndexTask;
+
+/**
+ * Demonstrate client-side Top-K reduce using {@link Reduce#topK} (or the equivalent split
+ * {@link Reduce#orderBy} + {@link Reduce#limit}).
+ * <p>
+ * Note: the server does not yet send a per-node bounded Top-K result set for this reduce
+ * (see docs/REDUCE-SPEC-DESIGN.md); every matching record is still sent to the client, which
+ * merges them locally. Once {@link Statement#setReduce} is set, {@link IAerospikeClient#query}
+ * applies the reduce internally and streams only the final merged Top-K records through the
+ * returned {@link RecordSet} — no manual combiner handling is needed.
+ */
+public class QueryTopK extends Example {
+
+	public QueryTopK(Console console) {
+		super(console);
+	}
+
+	/**
+	 * Query records and select the top K by bin value using a ReduceSpec combiner.
+	 */
+	@Override
+	public void runExample(IAerospikeClient client, Parameters params) throws Exception {
+		String indexName = "topkindex";
+		String keyPrefix = "topkkey";
+		String binName = "topkbin";
+		int size = 20;
+		int k = 5;
+
+		createIndex(client, params, indexName, binName);
+		writeRecords(client, params, keyPrefix, binName, size);
+		runQuery(client, params, indexName, binName, k);
+		client.dropIndex(params.policy, params.namespace, params.set, indexName);
+	}
+
+	private void createIndex(
+		IAerospikeClient client,
+		Parameters params,
+		String indexName,
+		String binName
+	) throws Exception {
+		console.info("Create index: ns=%s set=%s index=%s bin=%s",
+			params.namespace, params.set, indexName, binName);
+
+		Policy policy = new Policy();
+		policy.socketTimeout = 0; // Do not timeout on index create.
+
+		try {
+			IndexTask task = client.createIndex(policy, params.namespace, params.set, indexName, binName, IndexType.NUMERIC);
+			task.waitTillComplete();
+		}
+		catch (AerospikeException ae) {
+			if (ae.getResultCode() != ResultCode.INDEX_ALREADY_EXISTS) {
+				throw ae;
+			}
+		}
+	}
+
+	private void writeRecords(
+		IAerospikeClient client,
+		Parameters params,
+		String keyPrefix,
+		String binName,
+		int size
+	) throws Exception {
+		console.info("Write " + size + " records.");
+
+		// Values 1..size. The top 5 descending are size, size-1, size-2, size-3, size-4.
+		for (int i = 1; i <= size; i++) {
+			Key key = new Key(params.namespace, params.set, keyPrefix + i);
+			Bin bin = new Bin(binName, i);
+			client.put(params.writePolicy, key, bin);
+		}
+	}
+
+	private void runQuery(
+		IAerospikeClient client,
+		Parameters params,
+		String indexName,
+		String binName,
+		int k
+	) throws Exception {
+		int begin = 1;
+		int end = 1000;
+
+		console.info("Query top %d by bin=%s descending", k, binName);
+
+		Statement stmt = new Statement();
+		stmt.setNamespace(params.namespace);
+		stmt.setSetName(params.set);
+		stmt.setBinNames(binName);
+		stmt.setFilter(Filter.range(binName, begin, end));
+
+		// Split form is also valid and equivalent:
+		// stmt.setReduce(
+		//     Reduce.orderBy(binName, BinDataType.INTEGER, Order.DESC, OrderByFlags.NONE),
+		//     Reduce.limit(binName, k));
+		stmt.setReduce(Reduce.topK(binName, BinDataType.INTEGER, Order.DESC, OrderByFlags.NONE, k));
+
+		// client.query() merges every node's results and streams back only the final,
+		// globally-ordered top k records.
+		RecordSet rs = client.query(null, stmt);
+		int count = 0;
+		int expected = 20; // largest value written
+
+		try {
+			while (rs.next()) {
+				Record record = rs.getRecord();
+				int value = record.getInt(binName);
+
+				console.info("Top-K record: %s=%d", binName, value);
+
+				if (value != expected) {
+					console.error("Top-K order mismatch. Expected %d. Received %d.", expected, value);
+				}
+				expected--;
+				count++;
+			}
+		}
+		finally {
+			rs.close();
+		}
+
+		if (count != k) {
+			console.error("Top-K count mismatch. Expected %d. Received %d.", k, count);
+		}
+	}
+}

--- a/test/src/com/aerospike/test/SuiteUnit.java
+++ b/test/src/com/aerospike/test/SuiteUnit.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2012-2026 Aerospike, Inc.
+ *
+ * Portions may be licensed to Aerospike, Inc. under one or more contributor
+ * license agreements WHICH ARE COMPATIBLE WITH THE APACHE LICENSE, VERSION 2.0.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.aerospike.test;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+import com.aerospike.test.sync.query.TestReduceSpec;
+
+/**
+ * Pure client-side unit tests that do not require a running Aerospike cluster.
+ * Run with: ./run_tests -DrunSuite=**&#47;SuiteUnit.class
+ */
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+	TestReduceSpec.class
+})
+public class SuiteUnit {
+}

--- a/test/src/com/aerospike/test/sync/query/TestReduceSpec.java
+++ b/test/src/com/aerospike/test/sync/query/TestReduceSpec.java
@@ -1,0 +1,576 @@
+/*
+ * Copyright 2012-2026 Aerospike, Inc.
+ *
+ * Portions may be licensed to Aerospike, Inc. under one or more contributor
+ * license agreements WHICH ARE COMPATIBLE WITH THE APACHE LICENSE, VERSION 2.0.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.aerospike.test.sync.query;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Test;
+
+import com.aerospike.client.Key;
+import com.aerospike.client.Record;
+import com.aerospike.client.query.BinDataType;
+import com.aerospike.client.query.Order;
+import com.aerospike.client.query.OrderByFlags;
+import com.aerospike.client.query.Reduce;
+import com.aerospike.client.query.ReduceSpec;
+import com.aerospike.client.query.Statement;
+
+/**
+ * Pure client-side unit tests for the {@link ReduceSpec} / {@link Reduce} / {@link Statement}
+ * map-reduce framework (see docs/REDUCE-SPEC-DESIGN.md).
+ * <p>
+ * These tests do not require a running Aerospike cluster: {@link Key} digests are computed
+ * locally (RIPEMD-160), and {@link Record} instances are constructed directly. They deliberately
+ * do not extend {@link com.aerospike.test.sync.TestSync} / {@link com.aerospike.test.util.TestBase}
+ * so they can run standalone without connecting a client, e.g.:
+ * <pre>
+ *   mvn test -pl test -am -DskipTests=false -DrunSuite=**&#47;TestReduceSpec.class
+ * </pre>
+ */
+public class TestReduceSpec {
+	private static final String NS = "test";
+	private static final String SET = "reduceset";
+	private static final String BIN = "val";
+
+	private static Key key(String userKey) {
+		return new Key(NS, SET, userKey);
+	}
+
+	private static Record record(String binName, Object value) {
+		Map<String, Object> bins = new HashMap<>();
+		bins.put(binName, value);
+		return new Record(bins, 1, 0);
+	}
+
+	//-------------------------------------------------------
+	// Scalar reducers: sum / count / min / max
+	//-------------------------------------------------------
+
+	@Test
+	public void sumIsCommutativeAndAssociative() {
+		ReduceSpec<Record, Long> reducer = Reduce.sum(BIN);
+
+		// Feed out of order, simulating partials arriving from different nodes.
+		reducer.acceptPartial(record(BIN, 5L), key("k3"));
+		reducer.acceptPartial(record(BIN, 10L), key("k1"));
+		reducer.acceptPartial(record(BIN, 7L), key("k2"));
+
+		assertEquals(22L, reducer.getScalarResult().longValue());
+		assertEquals(1, reducer.getResult().length);
+		assertEquals(22L, reducer.getResult()[0].longValue());
+	}
+
+	@Test
+	public void countIncrementsOncePerAccept() {
+		ReduceSpec<Record, Long> reducer = Reduce.count();
+
+		for (int i = 0; i < 7; i++) {
+			reducer.acceptPartial(record(BIN, i), key("k" + i));
+		}
+		assertEquals(7L, reducer.getScalarResult().longValue());
+	}
+
+	@Test
+	public void minPicksSmallestInteger() {
+		ReduceSpec<Record, Number> reducer = Reduce.min(BIN, BinDataType.INTEGER);
+
+		reducer.acceptPartial(record(BIN, 9L), key("k1"));
+		reducer.acceptPartial(record(BIN, 2L), key("k2"));
+		reducer.acceptPartial(record(BIN, 5L), key("k3"));
+
+		assertEquals(2L, reducer.getScalarResult().longValue());
+	}
+
+	@Test
+	public void maxPicksLargestDouble() {
+		ReduceSpec<Record, Number> reducer = Reduce.max(BIN, BinDataType.DOUBLE);
+
+		reducer.acceptPartial(record(BIN, 1.5), key("k1"));
+		reducer.acceptPartial(record(BIN, 9.25), key("k2"));
+		reducer.acceptPartial(record(BIN, 4.0), key("k3"));
+
+		assertEquals(9.25, reducer.getScalarResult().doubleValue(), 0.0001);
+	}
+
+	@Test
+	public void minMaxRejectsNonNumericBinDataType() {
+		try {
+			Reduce.min(BIN, BinDataType.STRING);
+			fail("Expected IllegalArgumentException");
+		}
+		catch (IllegalArgumentException expected) {
+			// pass
+		}
+	}
+
+	@Test
+	public void minMaxOrderIndependent() {
+		// Merge order should not affect the result (commutative).
+		ReduceSpec<Record, Number> a = Reduce.min(BIN, BinDataType.INTEGER);
+		a.acceptPartial(record(BIN, 3L), key("k1"));
+		a.acceptPartial(record(BIN, 1L), key("k2"));
+		a.acceptPartial(record(BIN, 2L), key("k3"));
+
+		ReduceSpec<Record, Number> b = Reduce.min(BIN, BinDataType.INTEGER);
+		b.acceptPartial(record(BIN, 2L), key("k3"));
+		b.acceptPartial(record(BIN, 1L), key("k2"));
+		b.acceptPartial(record(BIN, 3L), key("k1"));
+
+		assertEquals(a.getScalarResult(), b.getScalarResult());
+	}
+
+	//-------------------------------------------------------
+	// Top-K reducer
+	//-------------------------------------------------------
+
+	@Test
+	public void topKReturnsKLargestDescending() {
+		ReduceSpec<Record, Record> reducer = Reduce.topK(BIN, BinDataType.INTEGER, Order.DESC, OrderByFlags.NONE, 3);
+
+		for (int i = 1; i <= 10; i++) {
+			reducer.acceptPartial(record(BIN, (long)i), key("k" + i));
+		}
+
+		Record[] result = reducer.getResult();
+		assertEquals(3, result.length);
+		assertEquals(10L, result[0].getLong(BIN));
+		assertEquals(9L, result[1].getLong(BIN));
+		assertEquals(8L, result[2].getLong(BIN));
+	}
+
+	@Test
+	public void topKReturnsKSmallestAscending() {
+		ReduceSpec<Record, Record> reducer = Reduce.topK(BIN, BinDataType.INTEGER, Order.ASC, OrderByFlags.NONE, 3);
+
+		for (int i = 1; i <= 10; i++) {
+			reducer.acceptPartial(record(BIN, (long)i), key("k" + i));
+		}
+
+		Record[] result = reducer.getResult();
+		assertEquals(3, result.length);
+		assertEquals(1L, result[0].getLong(BIN));
+		assertEquals(2L, result[1].getLong(BIN));
+		assertEquals(3L, result[2].getLong(BIN));
+	}
+
+	@Test
+	public void topKScalarResultIsBestRanked() {
+		ReduceSpec<Record, Record> reducer = Reduce.topK(BIN, BinDataType.INTEGER, Order.DESC, OrderByFlags.NONE, 3);
+
+		reducer.acceptPartial(record(BIN, 1L), key("k1"));
+		reducer.acceptPartial(record(BIN, 5L), key("k2"));
+		reducer.acceptPartial(record(BIN, 3L), key("k3"));
+
+		assertEquals(5L, reducer.getScalarResult().getLong(BIN));
+	}
+
+	@Test
+	public void topKFewerThanKMatchesReturnsAllOfThem() {
+		ReduceSpec<Record, Record> reducer = Reduce.topK(BIN, BinDataType.INTEGER, Order.DESC, OrderByFlags.NONE, 5);
+
+		reducer.acceptPartial(record(BIN, 1L), key("k1"));
+		reducer.acceptPartial(record(BIN, 2L), key("k2"));
+
+		assertEquals(2, reducer.getResult().length);
+	}
+
+	@Test
+	public void topKDedupesSameDigestKeepingBetterValue() {
+		ReduceSpec<Record, Record> reducer = Reduce.topK(BIN, BinDataType.INTEGER, Order.DESC, OrderByFlags.NONE, 5);
+
+		Key k1 = key("k1");
+
+		// Same key re-scanned (e.g. across a partition migration retry) with a worse, then
+		// better, value. Only one entry for k1 should survive, holding the better value.
+		reducer.acceptPartial(record(BIN, 1L), k1);
+		reducer.acceptPartial(record(BIN, 1L), key("k2"));
+		reducer.acceptPartial(record(BIN, 9L), k1);
+
+		Record[] result = reducer.getResult();
+		assertEquals(2, result.length);
+		assertEquals(9L, result[0].getLong(BIN));
+		assertEquals(1L, result[1].getLong(BIN));
+	}
+
+	@Test
+	public void topKDedupeIgnoresWorseRescan() {
+		ReduceSpec<Record, Record> reducer = Reduce.topK(BIN, BinDataType.INTEGER, Order.DESC, OrderByFlags.NONE, 5);
+
+		Key k1 = key("k1");
+
+		// Better value seen first; a later, worse re-scan of the same key must not replace it.
+		reducer.acceptPartial(record(BIN, 9L), k1);
+		reducer.acceptPartial(record(BIN, 1L), k1);
+
+		Record[] result = reducer.getResult();
+		assertEquals(1, result.length);
+		assertEquals(9L, result[0].getLong(BIN));
+	}
+
+	@Test
+	public void topKTiesBrokenDeterministicallyByDigest() {
+		ReduceSpec<Record, Record> a = Reduce.topK(BIN, BinDataType.INTEGER, Order.DESC, OrderByFlags.NONE, 2);
+		a.acceptPartial(record(BIN, 5L), key("alpha"));
+		a.acceptPartial(record(BIN, 5L), key("beta"));
+		a.acceptPartial(record(BIN, 5L), key("gamma"));
+
+		ReduceSpec<Record, Record> b = Reduce.topK(BIN, BinDataType.INTEGER, Order.DESC, OrderByFlags.NONE, 2);
+		b.acceptPartial(record(BIN, 5L), key("gamma"));
+		b.acceptPartial(record(BIN, 5L), key("alpha"));
+		b.acceptPartial(record(BIN, 5L), key("beta"));
+
+		// Same input set fed in different orders must produce the same result (stable
+		// tie-break by digest), regardless of acceptPartial() call order.
+		Record[] ra = a.getResult();
+		Record[] rb = b.getResult();
+		assertEquals(ra.length, rb.length);
+
+		for (int i = 0; i < ra.length; i++) {
+			assertEquals(ra[i].getLong(BIN), rb[i].getLong(BIN));
+		}
+	}
+
+	@Test
+	public void topKCaseInsensitiveStringOrdering() {
+		ReduceSpec<Record, Record> reducer = Reduce.topK(BIN, BinDataType.STRING, Order.ASC, OrderByFlags.CASE_INSENSITIVE, 3);
+
+		reducer.acceptPartial(record(BIN, "banana"), key("k1"));
+		reducer.acceptPartial(record(BIN, "Apple"), key("k2"));
+		reducer.acceptPartial(record(BIN, "cherry"), key("k3"));
+
+		Record[] result = reducer.getResult();
+		assertEquals(3, result.length);
+		assertEquals("Apple", result[0].getString(BIN));
+		assertEquals("banana", result[1].getString(BIN));
+		assertEquals("cherry", result[2].getString(BIN));
+	}
+
+	@Test
+	public void limitRejectsOutOfRangeValues() {
+		try {
+			Reduce.limit(BIN, 0);
+			fail("Expected IllegalArgumentException for limit below 1");
+		}
+		catch (IllegalArgumentException expected) {
+			// pass
+		}
+
+		try {
+			Reduce.limit(BIN, 1001);
+			fail("Expected IllegalArgumentException for limit above 1000");
+		}
+		catch (IllegalArgumentException expected) {
+			// pass
+		}
+	}
+
+	@Test
+	public void orderByAloneThrowsUnsupported() {
+		ReduceSpec<Record, Record> orderBy = Reduce.orderBy(BIN, BinDataType.INTEGER, Order.ASC, OrderByFlags.NONE);
+
+		try {
+			orderBy.acceptPartial(record(BIN, 1L), key("k1"));
+			fail("Expected UnsupportedOperationException");
+		}
+		catch (UnsupportedOperationException expected) {
+			// pass
+		}
+	}
+
+	@Test
+	public void limitAloneThrowsUnsupported() {
+		ReduceSpec<Record, Record> limit = Reduce.limit(BIN, 5);
+
+		try {
+			limit.acceptPartial(record(BIN, 1L), key("k1"));
+			fail("Expected UnsupportedOperationException");
+		}
+		catch (UnsupportedOperationException expected) {
+			// pass
+		}
+	}
+
+	//-------------------------------------------------------
+	// Statement.setReduce / getReduce / resolveReduce
+	//-------------------------------------------------------
+
+	@Test
+	public void statementDefaultsToNoReduce() {
+		Statement stmt = new Statement();
+		assertEquals(null, stmt.resolveReduce());
+	}
+
+	@Test
+	public void statementResolvesSingleScalarReduce() {
+		Statement stmt = new Statement();
+		stmt.setReduce(Reduce.sum(BIN));
+
+		ReduceSpec<Record, Long> resolved = stmt.resolveReduce();
+		resolved.acceptPartial(record(BIN, 4L), key("k1"));
+		assertEquals(4L, resolved.getScalarResult().longValue());
+	}
+
+	@Test
+	public void statementResolvesSingleTopK() {
+		Statement stmt = new Statement();
+		stmt.setReduce(Reduce.topK(BIN, BinDataType.INTEGER, Order.DESC, OrderByFlags.NONE, 2));
+
+		ReduceSpec<Record, Record> resolved = stmt.resolveReduce();
+		resolved.acceptPartial(record(BIN, 1L), key("k1"));
+		resolved.acceptPartial(record(BIN, 2L), key("k2"));
+		assertEquals(2, resolved.getResult().length);
+	}
+
+	@Test
+	public void statementComposesSplitOrderByAndLimit() {
+		Statement stmt = new Statement();
+		stmt.setReduce(
+			Reduce.orderBy(BIN, BinDataType.INTEGER, Order.DESC, OrderByFlags.NONE),
+			Reduce.limit(BIN, 2));
+
+		ReduceSpec<Record, Record> resolved = stmt.resolveReduce();
+
+		resolved.acceptPartial(record(BIN, 1L), key("k1"));
+		resolved.acceptPartial(record(BIN, 5L), key("k2"));
+		resolved.acceptPartial(record(BIN, 3L), key("k3"));
+
+		Record[] result = resolved.getResult();
+		assertEquals(2, result.length);
+		assertEquals(5L, result[0].getLong(BIN));
+		assertEquals(3L, result[1].getLong(BIN));
+	}
+
+	@Test
+	public void statementSplitOrderIndependent() {
+		Statement stmt = new Statement();
+		// limit passed before orderBy; order within setReduce should not matter.
+		stmt.setReduce(
+			Reduce.limit(BIN, 2),
+			Reduce.orderBy(BIN, BinDataType.INTEGER, Order.ASC, OrderByFlags.NONE));
+
+		ReduceSpec<Record, Record> resolved = stmt.resolveReduce();
+		resolved.acceptPartial(record(BIN, 3L), key("k1"));
+		resolved.acceptPartial(record(BIN, 1L), key("k2"));
+
+		Record[] result = resolved.getResult();
+		assertEquals(2, result.length);
+		assertEquals(1L, result[0].getLong(BIN));
+	}
+
+	@Test
+	public void statementResolveReduceIsMemoized() {
+		Statement stmt = new Statement();
+		stmt.setReduce(
+			Reduce.orderBy(BIN, BinDataType.INTEGER, Order.DESC, OrderByFlags.NONE),
+			Reduce.limit(BIN, 2));
+
+		ReduceSpec<Record, Record> first = stmt.resolveReduce();
+		ReduceSpec<Record, Record> second = stmt.resolveReduce();
+
+		// Must return the exact same combiner instance across calls, otherwise records fed
+		// via one reference would be invisible to a caller holding another reference.
+		assertSame(first, second);
+	}
+
+	@Test
+	public void statementSetReduceResetsMemoizedResolution() {
+		Statement stmt = new Statement();
+		stmt.setReduce(Reduce.sum(BIN));
+		ReduceSpec<Record, Long> first = stmt.resolveReduce();
+
+		stmt.setReduce(Reduce.count());
+		ReduceSpec<Record, Long> second = stmt.resolveReduce();
+
+		assertTrue(first != second);
+	}
+
+	@Test
+	public void statementResolveReduceMixingTopKPartsWithScalarThrows() {
+		Statement stmt = new Statement();
+		stmt.setReduce(
+			Reduce.orderBy(BIN, BinDataType.INTEGER, Order.DESC, OrderByFlags.NONE),
+			Reduce.sum(BIN));
+
+		try {
+			stmt.resolveReduce();
+			fail("Expected IllegalArgumentException");
+		}
+		catch (IllegalArgumentException expected) {
+			// pass
+		}
+	}
+
+	@Test
+	public void statementResolveReduceOrderByWithoutLimitThrows() {
+		Statement stmt = new Statement();
+		stmt.setReduce(Reduce.orderBy(BIN, BinDataType.INTEGER, Order.DESC, OrderByFlags.NONE));
+
+		try {
+			stmt.resolveReduce();
+			fail("Expected IllegalArgumentException");
+		}
+		catch (IllegalArgumentException expected) {
+			// pass
+		}
+	}
+
+	@Test
+	public void statementResolveReduceComposeBinMismatchThrows() {
+		Statement stmt = new Statement();
+		stmt.setReduce(
+			Reduce.orderBy("binA", BinDataType.INTEGER, Order.DESC, OrderByFlags.NONE),
+			Reduce.limit("binB", 2));
+
+		try {
+			stmt.resolveReduce();
+			fail("Expected IllegalArgumentException for mismatched bins");
+		}
+		catch (IllegalArgumentException expected) {
+			// pass
+		}
+	}
+
+	//-------------------------------------------------------
+	// Statement.setOrderBy / setTopK sugar
+	//-------------------------------------------------------
+
+	@Test
+	public void setOrderByThenSetTopKResolvesToTopK() {
+		Statement stmt = new Statement();
+		stmt.setOrderBy(BIN, BinDataType.DOUBLE, Order.ASC);
+		stmt.setTopK(2);
+
+		ReduceSpec<Record, Record> resolved = stmt.resolveReduce();
+		resolved.acceptPartial(record(BIN, 3.0), key("k1"));
+		resolved.acceptPartial(record(BIN, 1.0), key("k2"));
+		resolved.acceptPartial(record(BIN, 2.0), key("k3"));
+
+		Record[] result = resolved.getResult();
+		assertEquals(2, result.length);
+		assertEquals(1.0, result[0].getDouble(BIN), 0.0001);
+		assertEquals(2.0, result[1].getDouble(BIN), 0.0001);
+	}
+
+	@Test
+	public void setOrderByWithFlagsThenSetTopKResolvesToTopK() {
+		Statement stmt = new Statement();
+		stmt.setOrderBy(BIN, BinDataType.STRING, Order.ASC, OrderByFlags.CASE_INSENSITIVE);
+		stmt.setTopK(2);
+
+		ReduceSpec<Record, Record> resolved = stmt.resolveReduce();
+		resolved.acceptPartial(record(BIN, "banana"), key("k1"));
+		resolved.acceptPartial(record(BIN, "Apple"), key("k2"));
+
+		Record[] result = resolved.getResult();
+		assertEquals(2, result.length);
+		assertEquals("Apple", result[0].getString(BIN));
+	}
+
+	@Test
+	public void setTopKWithoutSetOrderByThrows() {
+		Statement stmt = new Statement();
+
+		try {
+			stmt.setTopK(5);
+			fail("Expected IllegalStateException");
+		}
+		catch (IllegalStateException expected) {
+			// pass
+		}
+	}
+
+	@Test
+	public void setTopKOverridesPriorReduce() {
+		Statement stmt = new Statement();
+		stmt.setReduce(Reduce.sum(BIN));
+		stmt.setOrderBy(BIN, BinDataType.INTEGER, Order.DESC);
+		stmt.setTopK(3);
+
+		// setTopK() replaces any previously set reduce, same as setReduce().
+		assertTrue(stmt.resolveReduce() instanceof ReduceSpec);
+		stmt.resolveReduce().acceptPartial(record(BIN, 1L), key("k1"));
+		assertEquals(1, stmt.resolveReduce().getResult().length);
+	}
+
+	//-------------------------------------------------------
+	// Statement validation used by the query executor entry points
+	//-------------------------------------------------------
+
+	@Test
+	public void validateRecordQueryAllowsNoReduce() {
+		new Statement().validateRecordQuery(); // should not throw
+	}
+
+	@Test
+	public void validateRecordQueryAllowsTopK() {
+		Statement stmt = new Statement();
+		stmt.setReduce(Reduce.topK(BIN, BinDataType.INTEGER, Order.DESC, OrderByFlags.NONE, 2));
+		stmt.validateRecordQuery(); // should not throw
+	}
+
+	@Test
+	public void validateRecordQueryRejectsScalarReduce() {
+		Statement stmt = new Statement();
+		stmt.setReduce(Reduce.sum(BIN));
+
+		try {
+			stmt.validateRecordQuery();
+			fail("Expected IllegalArgumentException");
+		}
+		catch (IllegalArgumentException expected) {
+			// pass
+		}
+	}
+
+	@Test
+	public void validateReduceQueryRejectsNoReduce() {
+		try {
+			new Statement().validateReduceQuery();
+			fail("Expected IllegalArgumentException");
+		}
+		catch (IllegalArgumentException expected) {
+			// pass
+		}
+	}
+
+	@Test
+	public void validateReduceQueryRejectsTopK() {
+		Statement stmt = new Statement();
+		stmt.setReduce(Reduce.topK(BIN, BinDataType.INTEGER, Order.DESC, OrderByFlags.NONE, 2));
+
+		try {
+			stmt.validateReduceQuery();
+			fail("Expected IllegalArgumentException");
+		}
+		catch (IllegalArgumentException expected) {
+			// pass
+		}
+	}
+
+	@Test
+	public void validateReduceQueryAllowsScalarReduce() {
+		Statement stmt = new Statement();
+		stmt.setReduce(Reduce.count());
+		stmt.validateReduceQuery(); // should not throw
+	}
+}


### PR DESCRIPTION
Adds a ReduceSpec/Reduce framework for client-side Top-K and scalar reduces (sum, count, min, max), with Statement.setReduce() and setOrderBy()/setTopK() sugar, wired into client.query() and the new client.queryReduce().
Pure client-side merge over records the server already returns — no wire-protocol changes.

Covered by unit tests for reducer correctness, Top-K ordering/dedup, and Statement resolution.
Not yet exercised end-to-end against a live cluster, and the legacy pre-partition-query executor
path doesn't honor it.