### PR TITLE
refactor(batch): extract shared generation-policy logic in BatchAttr

### DIFF
--- a/client/src/com/aerospike/client/command/BatchAttr.java
+++ b/client/src/com/aerospike/client/command/BatchAttr.java
@@ -24,6 +24,7 @@ import com.aerospike.client.policy.BatchReadPolicy;
 import com.aerospike.client.policy.BatchUDFPolicy;
 import com.aerospike.client.policy.BatchWritePolicy;
 import com.aerospike.client.policy.CommitLevel;
+import com.aerospike.client.policy.GenerationPolicy;
 import com.aerospike.client.policy.Policy;
 import com.aerospike.client.policy.ReadModeAP;
 
@@ -194,6 +195,22 @@ public final class BatchAttr {
 		}
 	}
 
+    private void applyGenerationPolicy(GenerationPolicy generationPolicy, int gen) {
+        switch (generationPolicy) {
+            default:
+            case NONE:
+                generation = 0;
+                break;
+            case EXPECT_GEN_EQUAL:
+                generation = (short)gen;
+                writeAttr |= Command.INFO2_GENERATION;
+                break;
+            case EXPECT_GEN_GT:
+                generation = (short)gen;
+                writeAttr |= Command.INFO2_GENERATION_GT;
+                break;
+        }
+    }
 	public void setWrite(BatchPolicy bp, BatchWritePolicy wp) {
 		setWrite(wp, bp.sendKey, wp.durableDelete);
 	}
@@ -208,20 +225,7 @@ public final class BatchAttr {
 		hasWrite = true;
 		this.sendKey = (sendKey || wp.sendKey);
 
-		switch (wp.generationPolicy) {
-		default:
-		case NONE:
-			generation = 0;
-			break;
-		case EXPECT_GEN_EQUAL:
-			generation = (short)wp.generation;
-			writeAttr |= Command.INFO2_GENERATION;
-			break;
-		case EXPECT_GEN_GT:
-			generation = (short)wp.generation;
-			writeAttr |= Command.INFO2_GENERATION_GT;
-			break;
-		}
+        applyGenerationPolicy(wp.generationPolicy, wp.generation);
 
 		switch (wp.recordExistsAction) {
 		case UPDATE:
@@ -314,20 +318,7 @@ public final class BatchAttr {
 		hasWrite = true;
 		this.sendKey = (sendKey || dp.sendKey);
 
-		switch (dp.generationPolicy) {
-		default:
-		case NONE:
-			generation = 0;
-			break;
-		case EXPECT_GEN_EQUAL:
-			generation = (short)dp.generation;
-			writeAttr |= Command.INFO2_GENERATION;
-			break;
-		case EXPECT_GEN_GT:
-			generation = (short)dp.generation;
-			writeAttr |= Command.INFO2_GENERATION_GT;
-			break;
-		}
+        applyGenerationPolicy(dp.generationPolicy, dp.generation);
 
 		if (durableDelete) {
 			writeAttr |= Command.INFO2_DURABLE_DELETE;


### PR DESCRIPTION
## Summary
"BatchAttr.setWrite()" and "BatchAttr.setDelete()" had the exact
same switch statement for applying generation policy. Extracted it
into a shared private method, "applyGenerationPolicy()", called
from both.

## Why
Same logic duplicated in two places — any future change would need
to be made twice and kept in sync manually.

## Change
Added "applyGenerationPolicy(GenerationPolicy, int)" in "BatchAttr".
"setWrite()" and "setDelete()" now call it instead of repeating the
switch block.

## Behavior
No functional change 
