### PR TITLE
CLIENT-4959 prevent txn abort on in-doubt txns

### DIFF
--- a/client/src/com/aerospike/client/AbortStatus.java
+++ b/client/src/com/aerospike/client/AbortStatus.java
@@ -22,6 +22,7 @@ package com.aerospike.client;
 public enum AbortStatus {
 	OK("Abort succeeded"),
 	ALREADY_ABORTED("Already aborted"),
+	COMMIT_FAILED("Abort not allowed because a commit already failed on this transaction with an in-doubt outcome"),
 	ROLL_BACK_ABANDONED("Transaction client roll back abandoned. Server will eventually abort the transaction."),
 	CLOSE_ABANDONED("Transaction has been rolled back, but transaction client close was abandoned. Server will eventually close the transaction.");
 

--- a/client/src/com/aerospike/client/AerospikeClient.java
+++ b/client/src/com/aerospike/client/AerospikeClient.java
@@ -796,6 +796,7 @@ public class AerospikeClient implements IAerospikeClient, Closeable {
 				return tr.commit(mergedTxnRollPolicyDefault);
 
 			case VERIFIED:
+			case COMMIT_FAILED:
 				return tr.commit(mergedTxnRollPolicyDefault);
 
 			case COMMITTED:
@@ -839,6 +840,7 @@ public class AerospikeClient implements IAerospikeClient, Closeable {
 				break;
 
 			case VERIFIED:
+			case COMMIT_FAILED:
 				atr.commit(listener);
 				break;
 
@@ -854,10 +856,14 @@ public class AerospikeClient implements IAerospikeClient, Closeable {
 	/**
 	 * Abort and rollback the given transaction.
 	 * <p>
+	 * Abort is not allowed after an in-doubt mark-roll-forward failure; the server may still
+	 * roll the transaction forward. Retry {@link #commit(Txn)} instead.
+	 * <p>
 	 * Requires server version 8.0+
 	 *
 	 * @param txn	transaction
 	 * @return		status of the abort
+	 * @throws AerospikeException	if transaction is already committed or commit failed in-doubt
 	 */
 	public final AbortStatus abort(Txn txn) {
 		TxnRoll tr = new TxnRoll(cluster, txn);
@@ -867,6 +873,10 @@ public class AerospikeClient implements IAerospikeClient, Closeable {
 			case OPEN:
 			case VERIFIED:
 				return tr.abort(mergedTxnRollPolicyDefault);
+
+			case COMMIT_FAILED:
+				throw new AerospikeException(ResultCode.TXN_FAILED,
+					"Transaction commit failed. Abort is not allowed.");
 
 			case COMMITTED:
 				throw new AerospikeException(ResultCode.TXN_ALREADY_COMMITTED, "Transaction already committed");
@@ -879,6 +889,9 @@ public class AerospikeClient implements IAerospikeClient, Closeable {
 	/**
 	 * Asynchronously abort and rollback the given transaction.
 	 * <p>
+	 * Abort is not allowed after an in-doubt mark-roll-forward failure; the server may still
+	 * roll the transaction forward. Retry {@link #commit(EventLoop, CommitListener, Txn)} instead.
+	 * <p>
 	 * This method registers the command with an event loop and returns.
 	 * The event loop thread will process the command and send the results to the listener.
 	 * <p>
@@ -888,7 +901,8 @@ public class AerospikeClient implements IAerospikeClient, Closeable {
 	 * 						loop will be chosen by round-robin.
 	 * @param listener		where to send results
 	 * @param txn			transaction
-	 * @throws AerospikeException	if event loop registration fails
+	 * @throws AerospikeException	if event loop registration fails, or transaction is already
+	 * 								committed or commit failed in-doubt
 	 */
 	public final void abort(EventLoop eventLoop, AbortListener listener, Txn txn)
 		throws AerospikeException {
@@ -904,6 +918,10 @@ public class AerospikeClient implements IAerospikeClient, Closeable {
 			case VERIFIED:
 				atr.abort(listener);
 				break;
+
+			case COMMIT_FAILED:
+				throw new AerospikeException(ResultCode.TXN_FAILED,
+					"Transaction commit failed. Abort is not allowed.");
 
 			case COMMITTED:
 				throw new AerospikeException(ResultCode.TXN_ALREADY_COMMITTED, "Transaction already committed");

--- a/client/src/com/aerospike/client/CommitError.java
+++ b/client/src/com/aerospike/client/CommitError.java
@@ -23,7 +23,7 @@ public enum CommitError {
 	VERIFY_FAIL("Transaction verify failed. Transaction aborted."),
 	VERIFY_FAIL_CLOSE_ABANDONED("Transaction verify failed. Transaction aborted. Transaction client close abandoned. Server will eventually close the transaction."),
 	VERIFY_FAIL_ABORT_ABANDONED("Transaction verify failed. Transaction client abort abandoned. Server will eventually abort the transaction."),
-	MARK_ROLL_FORWARD_ABANDONED("Transaction client mark roll forward abandoned. Server will eventually abort the transaction.");
+	MARK_ROLL_FORWARD_ABANDONED("Transaction client mark roll forward abandoned. Server will eventually commit or abort the transaction.");
 
 	public final String str;
 

--- a/client/src/com/aerospike/client/Txn.java
+++ b/client/src/com/aerospike/client/Txn.java
@@ -32,6 +32,7 @@ public final class Txn {
 	public static enum State {
 		OPEN,
 		VERIFIED,
+		COMMIT_FAILED,
 		COMMITTED,
 		ABORTED;
 	}
@@ -168,8 +169,20 @@ public final class Txn {
 	        		throw new AerospikeException(ResultCode.TXN_ALREADY_ABORTED,
 	                		"Issuing commands to this transaction is forbidden because it has been aborted.");
 	    		case VERIFIED:
+	    		case COMMIT_FAILED:
 	        		throw new AerospikeException(ResultCode.TXN_FAILED,
 	                		"Issuing commands to this transaction is forbidden because it is currently being committed.");
+		}
+	}
+
+	/**
+	 * Transition to COMMIT_FAILED when mark-roll-forward fails in an in-doubt state.
+	 * The server may still roll the transaction forward; abort must not be called.
+	 * For internal use only.
+	 */
+	public void markCommitFailed() {
+		if (state != State.ABORTED && state != State.COMMITTED) {
+			state = State.COMMIT_FAILED;
 		}
 	}
 

--- a/client/src/com/aerospike/client/async/AsyncTxnRoll.java
+++ b/client/src/com/aerospike/client/async/AsyncTxnRoll.java
@@ -428,16 +428,19 @@ public final class AsyncTxnRoll {
 				// The transaction was already inDoubt and just failed again,
 				// so the new exception should also be inDoubt.
 				aec.setInDoubt(true);
+				txn.markCommitFailed();
 			}
 			else if (ae.getInDoubt()){
 				// The current exception is inDoubt.
 				aec.setInDoubt(true);
 				txn.setInDoubt(true);
+				txn.markCommitFailed();
 			}
 		}
 		else {
 			if (txn.getInDoubt()) {
 				aec.setInDoubt(true);
+				txn.markCommitFailed();
 			}
 		}
 

--- a/client/src/com/aerospike/client/command/TxnRoll.java
+++ b/client/src/com/aerospike/client/command/TxnRoll.java
@@ -101,11 +101,13 @@ public final class TxnRoll {
 					// The transaction was already inDoubt and just failed again,
 					// so the new exception should also be inDoubt.
 					aec.setInDoubt(true);
+					txn.markCommitFailed();
 				}
 				else if (ae.getInDoubt()){
 					// The current exception is inDoubt.
 					aec.setInDoubt(true);
 					txn.setInDoubt(true);
+					txn.markCommitFailed();
 				}
 				throw aec;
 			}
@@ -114,6 +116,7 @@ public final class TxnRoll {
 
 				if (txn.getInDoubt()) {
 					aec.setInDoubt(true);
+					txn.markCommitFailed();
 				}
 				throw aec;
 			}

--- a/test/src/com/aerospike/client/TxnTest.java
+++ b/test/src/com/aerospike/client/TxnTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2012-2025 Aerospike, Inc.
+ *
+ * Portions may be licensed to Aerospike, Inc. under one or more contributor
+ * license agreements WHICH ARE COMPATIBLE WITH THE APACHE LICENSE, VERSION 2.0.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.aerospike.client;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import org.junit.Test;
+
+import com.aerospike.client.AerospikeException;
+
+public class TxnTest {
+	@Test
+	public void markCommitFailedFromOpen() {
+		Txn txn = new Txn();
+		txn.markCommitFailed();
+		assertEquals(Txn.State.COMMIT_FAILED, txn.getState());
+	}
+
+	@Test
+	public void markCommitFailedFromVerified() {
+		Txn txn = new Txn();
+		txn.setState(Txn.State.VERIFIED);
+		txn.markCommitFailed();
+		assertEquals(Txn.State.COMMIT_FAILED, txn.getState());
+	}
+
+	@Test
+	public void markCommitFailedPreservesAborted() {
+		Txn txn = new Txn();
+		txn.setState(Txn.State.ABORTED);
+		txn.markCommitFailed();
+		assertEquals(Txn.State.ABORTED, txn.getState());
+	}
+
+	@Test
+	public void markCommitFailedPreservesCommitted() {
+		Txn txn = new Txn();
+		txn.setState(Txn.State.COMMITTED);
+		txn.markCommitFailed();
+		assertEquals(Txn.State.COMMITTED, txn.getState());
+	}
+
+	@Test
+	public void verifyCommandRejectsCommitFailed() {
+		Txn txn = new Txn();
+		txn.setState(Txn.State.COMMIT_FAILED);
+
+		try {
+			txn.verifyCommand();
+			fail("Expected AerospikeException for COMMIT_FAILED state");
+		}
+		catch (AerospikeException ex) {
+			assertEquals(ResultCode.TXN_FAILED, ex.getResultCode());
+		}
+	}
+}

--- a/test/src/com/aerospike/test/SuiteSync.java
+++ b/test/src/com/aerospike/test/SuiteSync.java
@@ -21,6 +21,7 @@ import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 
+import com.aerospike.client.TxnTest;
 import com.aerospike.client.AerospikeClient;
 import com.aerospike.client.Host;
 import com.aerospike.client.IAerospikeClient;
@@ -101,6 +102,7 @@ import com.aerospike.test.util.Args;
 	TestScan.class,
 	TestServerInfo.class,
 	TestTouch.class,
+	TxnTest.class,
 	TestTxn.class,
 	TestUDF.class,
 	TestIndex.class,

--- a/test/src/com/aerospike/test/async/TestAsyncTxn.java
+++ b/test/src/com/aerospike/test/async/TestAsyncTxn.java
@@ -47,6 +47,7 @@ import com.aerospike.test.sync.basic.TestUDF;
 
 public class TestAsyncTxn extends TestAsync {
 	public static final String binName = "bin";
+	private static final String txnMonitorSet = "<ERO~MRT";
 
 	@BeforeClass
 	public static void register() {
@@ -335,6 +336,216 @@ public class TestAsyncTxn extends TestAsync {
 		};
 
 		execute(cmds);
+	}
+
+	@Test
+	public void asyncTxnAbortBlockedAfterCommitFailed() {
+		Key key = uniqueKey("asyncMrtCommitFailedBlock");
+
+		client.put(null, key, new Bin(binName, "val1"));
+
+		Txn txn = new Txn();
+
+		WritePolicy wp = client.copyWritePolicyDefault();
+		wp.txn = txn;
+		client.put(wp, key, new Bin(binName, "val2"));
+
+		txn.setInDoubt(true);
+		deleteTxnMonitor(txn);
+
+		client.commit(eventLoop, new CommitListener() {
+			public void onSuccess(CommitStatus status) {
+				setError(new AerospikeException("Unexpected commit success"));
+				notifyComplete();
+			}
+
+			public void onFailure(AerospikeException.Commit ce) {
+				if (! assertTrue(ce.getInDoubt())) {
+					notifyComplete();
+					return;
+				}
+
+				if (! assertEquals(Txn.State.COMMIT_FAILED, txn.getState())) {
+					notifyComplete();
+					return;
+				}
+
+				try {
+					client.abort(eventLoop, new AbortListener() {
+						public void onSuccess(AbortStatus status) {
+							setError(new AerospikeException("Unexpected abort success"));
+							notifyComplete();
+						}
+					}, txn);
+					setError(new AerospikeException("Expected abort to be blocked"));
+					notifyComplete();
+				}
+				catch (AerospikeException ae) {
+					if (! assertEquals(ResultCode.TXN_FAILED, ae.getResultCode())) {
+						notifyComplete();
+						return;
+					}
+
+					if (! assertEquals(Txn.State.COMMIT_FAILED, txn.getState())) {
+						notifyComplete();
+						return;
+					}
+
+					client.commit(eventLoop, new CommitListener() {
+						public void onSuccess(CommitStatus status) {
+							notifyComplete();
+						}
+
+						public void onFailure(AerospikeException.Commit ce) {
+							if (! assertEquals(Txn.State.COMMIT_FAILED, txn.getState())) {
+								notifyComplete();
+								return;
+							}
+							notifyComplete();
+						}
+					}, txn);
+				}
+			}
+		}, txn);
+
+		waitTillComplete();
+	}
+
+	@Test
+	public void asyncTxnAbortAllowedAfterCleanMarkFailure() {
+		Key key = uniqueKey("asyncMrtCleanMarkFail");
+
+		client.put(null, key, new Bin(binName, "val1"));
+
+		Txn txn = new Txn();
+
+		WritePolicy wp = client.copyWritePolicyDefault();
+		wp.txn = txn;
+		client.put(wp, key, new Bin(binName, "val2"));
+
+		deleteTxnMonitor(txn);
+
+		client.commit(eventLoop, new CommitListener() {
+			public void onSuccess(CommitStatus status) {
+				setError(new AerospikeException("Unexpected commit success"));
+				notifyComplete();
+			}
+
+			public void onFailure(AerospikeException.Commit ce) {
+				Throwable cause = ce.getCause();
+
+				if (! (cause instanceof AerospikeException)) {
+					setError(new AerospikeException("Expected AerospikeException cause"));
+					notifyComplete();
+					return;
+				}
+
+				if (! assertEquals(ResultCode.MRT_EXPIRED, ((AerospikeException)cause).getResultCode())) {
+					notifyComplete();
+					return;
+				}
+
+				if (! assertEquals(false, ce.getInDoubt())) {
+					notifyComplete();
+					return;
+				}
+
+				if (! assertEquals(false, txn.getInDoubt())) {
+					notifyComplete();
+					return;
+				}
+
+				if (! assertEquals(Txn.State.VERIFIED, txn.getState())) {
+					notifyComplete();
+					return;
+				}
+
+				client.abort(eventLoop, new AbortListener() {
+					public void onSuccess(AbortStatus status) {
+						if (! assertEquals(AbortStatus.OK, status)) {
+							notifyComplete();
+							return;
+						}
+
+						if (! assertEquals(Txn.State.ABORTED, txn.getState())) {
+							notifyComplete();
+							return;
+						}
+
+						client.get(eventLoop, new RecordListener() {
+							public void onSuccess(Key key, Record record) {
+								if (assertBinEqual(key, record, binName, "val1")) {
+									notifyComplete();
+								}
+								else {
+									notifyComplete();
+								}
+							}
+
+							public void onFailure(AerospikeException e) {
+								setError(e);
+								notifyComplete();
+							}
+						}, null, key);
+					}
+				}, txn);
+			}
+		}, txn);
+
+		waitTillComplete();
+	}
+
+	@Test
+	public void asyncTxnAbortAllowedAfterVerifyFailure() {
+		Key key = uniqueKey("asyncMrtVerifyFailAbort");
+
+		client.put(null, key, new Bin(binName, "val1"));
+
+		Txn txn = new Txn();
+
+		Policy rp = client.copyReadPolicyDefault();
+		rp.txn = txn;
+		client.get(rp, key);
+
+		client.put(null, key, new Bin(binName, "val3"));
+
+		client.commit(eventLoop, new CommitListener() {
+			public void onSuccess(CommitStatus status) {
+				setError(new AerospikeException("Unexpected commit success"));
+				notifyComplete();
+			}
+
+			public void onFailure(AerospikeException.Commit ce) {
+				if (! assertEquals(Txn.State.ABORTED, txn.getState())) {
+					notifyComplete();
+					return;
+				}
+
+				client.abort(eventLoop, new AbortListener() {
+					public void onSuccess(AbortStatus status) {
+						if (assertEquals(AbortStatus.ALREADY_ABORTED, status)) {
+							notifyComplete();
+						}
+						else {
+							notifyComplete();
+						}
+					}
+				}, txn);
+			}
+		}, txn);
+
+		waitTillComplete();
+	}
+
+	private Key uniqueKey(String prefix) {
+		return new Key(args.namespace, args.set, prefix + "-" + System.nanoTime());
+	}
+
+	private void deleteTxnMonitor(Txn txn) {
+		Key monitorKey = new Key(txn.getNamespace(), txnMonitorSet, txn.getId());
+		WritePolicy dwp = client.copyWritePolicyDefault();
+		dwp.durableDelete = true;
+		client.delete(dwp, monitorKey);
 	}
 
 	private void execute(Runner[] cmdArray) {

--- a/test/src/com/aerospike/test/sync/basic/TestCdtOperate.java
+++ b/test/src/com/aerospike/test/sync/basic/TestCdtOperate.java
@@ -2776,6 +2776,7 @@ public class TestCdtOperate extends TestSync {
 
     @Test
     public void hllLoopVarFilterOnNestedHLLs() {
+        checkMinServerVersion(8, 1, 2, 0);
         Key rkey = new Key(NAMESPACE, SET, "hllLoopVarFilterKey");
         client.delete(null, rkey);
 
@@ -2942,6 +2943,7 @@ public class TestCdtOperate extends TestSync {
 
     @Test
     public void testChainedAndFilters() {
+        checkMinServerVersion(8, 1, 2, 0);
         Key rkey = new Key(NAMESPACE, SET, "chainedAndFilters");
 
         try {
@@ -3012,6 +3014,7 @@ public class TestCdtOperate extends TestSync {
 
     @Test
     public void testAndFilterWithMapIndex() {
+        checkMinServerVersion(8, 1, 2, 0);
         Key rkey = new Key(NAMESPACE, SET, "andFilterMapIndex");
 
         try {

--- a/test/src/com/aerospike/test/sync/basic/TestTxn.java
+++ b/test/src/com/aerospike/test/sync/basic/TestTxn.java
@@ -17,14 +17,17 @@
 package com.aerospike.test.sync.basic;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import com.aerospike.test.sync.TestSync;
 import org.junit.Test;
 import org.junit.BeforeClass;
 
+import com.aerospike.client.AbortStatus;
 import com.aerospike.client.AerospikeException;
 import com.aerospike.client.BatchRecord;
 import com.aerospike.client.BatchResults;
@@ -43,6 +46,7 @@ import com.aerospike.client.Txn;
 
 public class TestTxn extends TestSync {
 	public static final String binName = "bin";
+	private static final String txnMonitorSet = "<ERO~MRT";
 
 	@BeforeClass
 	public static void register() {
@@ -123,7 +127,8 @@ public class TestTxn extends TestSync {
 				{ Txn.State.OPEN, null },
 				{ Txn.State.COMMITTED, ResultCode.TXN_ALREADY_COMMITTED },
 				{ Txn.State.ABORTED, ResultCode.TXN_ALREADY_ABORTED },
-				{ Txn.State.VERIFIED, ResultCode.TXN_FAILED }
+				{ Txn.State.VERIFIED, ResultCode.TXN_FAILED },
+				{ Txn.State.COMMIT_FAILED, ResultCode.TXN_FAILED }
 		};
 		Key key = new Key(args.namespace, args.set, "mrtkey21");
 
@@ -153,6 +158,112 @@ public class TestTxn extends TestSync {
 				}
 			}
 		}
+	}
+
+	@Test
+	public void txnAbortBlockedAfterCommitFailed() {
+		Key key = uniqueKey("mrtCommitFailedBlock");
+
+		client.put(null, key, new Bin(binName, "val1"));
+
+		Txn txn = new Txn();
+
+		WritePolicy wp = client.copyWritePolicyDefault();
+		wp.txn = txn;
+		client.put(wp, key, new Bin(binName, "val2"));
+
+		// Simulate an in-doubt outcome before mark-roll-forward fails.
+		txn.setInDoubt(true);
+		deleteTxnMonitor(txn);
+
+		try {
+			client.commit(txn);
+			fail("Expected commit to fail");
+		}
+		catch (AerospikeException.Commit ce) {
+			assertTrue(ce.getInDoubt());
+			assertEquals(Txn.State.COMMIT_FAILED, txn.getState());
+		}
+
+		try {
+			client.abort(txn);
+			fail("Expected abort to be blocked");
+		}
+		catch (AerospikeException ae) {
+			assertEquals(ResultCode.TXN_FAILED, ae.getResultCode());
+			assertEquals(Txn.State.COMMIT_FAILED, txn.getState());
+		}
+
+		// Commit retry is allowed from COMMIT_FAILED (may fail again at mark-roll-forward).
+		try {
+			client.commit(txn);
+		}
+		catch (AerospikeException.Commit ce) {
+			assertEquals(Txn.State.COMMIT_FAILED, txn.getState());
+		}
+		catch (AerospikeException ae) {
+			fail("Unexpected commit rejection: " + ae);
+		}
+	}
+
+	@Test
+	public void txnAbortAllowedAfterCleanMarkFailure() {
+		Key key = uniqueKey("mrtCleanMarkFail");
+
+		client.put(null, key, new Bin(binName, "val1"));
+
+		Txn txn = new Txn();
+
+		WritePolicy wp = client.copyWritePolicyDefault();
+		wp.txn = txn;
+		client.put(wp, key, new Bin(binName, "val2"));
+
+		deleteTxnMonitor(txn);
+
+		try {
+			client.commit(txn);
+			fail("Expected commit to fail");
+		}
+		catch (AerospikeException.Commit ce) {
+			Throwable cause = ce.getCause();
+
+			assertTrue(cause instanceof AerospikeException);
+			assertEquals(ResultCode.MRT_EXPIRED, ((AerospikeException)cause).getResultCode());
+			assertFalse(ce.getInDoubt());
+			assertFalse(txn.getInDoubt());
+			assertEquals(Txn.State.VERIFIED, txn.getState());
+		}
+
+		assertEquals(AbortStatus.OK, client.abort(txn));
+		assertEquals(Txn.State.ABORTED, txn.getState());
+
+		Record record = client.get(null, key);
+		assertBinEqual(key, record, binName, "val1");
+	}
+
+	@Test
+	public void txnAbortAllowedAfterVerifyFailure() {
+		Key key = uniqueKey("mrtVerifyFailAbort");
+
+		client.put(null, key, new Bin(binName, "val1"));
+
+		Txn txn = new Txn();
+
+		Policy rp = client.copyReadPolicyDefault();
+		rp.txn = txn;
+		client.get(rp, key);
+
+		client.put(null, key, new Bin(binName, "val3"));
+
+		try {
+			client.commit(txn);
+			fail("Expected commit to fail");
+		}
+		catch (AerospikeException.Commit ce) {
+			assertEquals(Txn.State.ABORTED, txn.getState());
+		}
+
+		assertEquals(AbortStatus.ALREADY_ABORTED, client.abort(txn));
 	}
 
 
@@ -505,5 +616,16 @@ public class TestTxn extends TestSync {
 			int received = rec.getInt(binName);
 			assertEquals(expected, received);
 		}
+	}
+
+	private Key uniqueKey(String prefix) {
+		return new Key(args.namespace, args.set, prefix + "-" + System.nanoTime());
+	}
+
+	private void deleteTxnMonitor(Txn txn) {
+		Key monitorKey = new Key(txn.getNamespace(), txnMonitorSet, txn.getId());
+		WritePolicy dwp = client.copyWritePolicyDefault();
+		dwp.durableDelete = true;
+		client.delete(dwp, monitorKey);
 	}
 }


### PR DESCRIPTION
This is a porting of the fix applied in the go client, to avoid txn abort in case of in-doubt txns.
Ref: https://github.com/aerospike/aerospike-client-go/pull/719
