### PR TITLE
OM-330 Add client metrics exporter framework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ apidocs
 *.tgz
 *.zip
 *.out
+metrics-*.log
 *.jar
 *.iml
 .idea/

--- a/client/src/com/aerospike/client/cluster/Cluster.java
+++ b/client/src/com/aerospike/client/cluster/Cluster.java
@@ -53,6 +53,7 @@ import com.aerospike.client.configuration.serializers.Configuration;
 import com.aerospike.client.configuration.serializers.StaticConfiguration;
 import com.aerospike.client.configuration.serializers.staticconfig.StaticClientConfig;
 import com.aerospike.client.listener.ClusterStatsListener;
+import com.aerospike.client.metrics.MetricsExporterThread;
 import com.aerospike.client.metrics.MetricsListener;
 import com.aerospike.client.metrics.MetricsPolicy;
 import com.aerospike.client.metrics.MetricsWriter;
@@ -216,6 +217,7 @@ public class Cluster implements Runnable, Closeable {
 	public boolean metricsEnabled;
 	MetricsPolicy metricsPolicy;
 	private volatile MetricsListener metricsListener;
+	private volatile MetricsExporterThread metricsExporterThread;
 	private final Object metricsLock = new Object();
 	private final AtomicLong retryCount = new AtomicLong();
 	private final AtomicLong commandCount = new AtomicLong();
@@ -1232,6 +1234,11 @@ public class Cluster implements Runnable, Closeable {
 
 	private void enableMetricsInternal(MetricsPolicy policy) {
 		MetricsPolicy mergedMP = mergeMetricsPolicyWithConfig(policy);
+
+		if (!mergedMP.getExporters().isEmpty()) {
+			mergedMP.validateExporterSettings();
+		}
+
 		MetricsListener listener = mergedMP.listener;
 
 		if (listener == null) {
@@ -1243,6 +1250,7 @@ public class Cluster implements Runnable, Closeable {
 
 		if (metricsEnabled) {
 			this.metricsListener.onDisable(this);
+			stopExporterThread();
 		}
 
 		Node[] nodeArray = nodes;
@@ -1252,6 +1260,7 @@ public class Cluster implements Runnable, Closeable {
 		}
 
 		this.metricsListener.onEnable(this, this.metricsPolicy);
+		startExporterThread(mergedMP);
 		metricsEnabled = true;
 		Log.info("Metrics have been enabled.");
 	}
@@ -1273,8 +1282,24 @@ public class Cluster implements Runnable, Closeable {
 	private void disableMetricsInternal() {
 		if (metricsEnabled) {
 			metricsEnabled = false;
+			stopExporterThread();
 			metricsListener.onDisable(this);
 			Log.info("Metrics have been disabled.");
+		}
+	}
+
+	private void startExporterThread(MetricsPolicy policy) {
+		if (!policy.getExporters().isEmpty()) {
+			metricsExporterThread = new MetricsExporterThread(this, policy);
+			metricsExporterThread.start();
+		}
+	}
+
+	private void stopExporterThread() {
+		MetricsExporterThread thread = metricsExporterThread;
+		if (thread != null) {
+			thread.shutdown();
+			metricsExporterThread = null;
 		}
 	}
 

--- a/client/src/com/aerospike/client/cluster/Cluster.java
+++ b/client/src/com/aerospike/client/cluster/Cluster.java
@@ -1296,9 +1296,9 @@ public class Cluster implements Runnable, Closeable {
 	}
 
 	private void stopExporterThread() {
-		MetricsExporterThread thread = metricsExporterThread;
-		if (thread != null) {
-			thread.shutdown();
+		MetricsExporterThread metricsThread = metricsExporterThread;
+		if (metricsThread != null) {
+			metricsThread.shutdown();
 			metricsExporterThread = null;
 		}
 	}

--- a/client/src/com/aerospike/client/configuration/serializers/dynamicconfig/DynamicMetricsConfig.java
+++ b/client/src/com/aerospike/client/configuration/serializers/dynamicconfig/DynamicMetricsConfig.java
@@ -38,7 +38,9 @@ public class DynamicMetricsConfig {
         this.enableExtendedMetrics = enableExtendedMetrics;
     }
 
-    public BooleanProperty getEnableExtendedMetrics() { return enableExtendedMetrics; }
+    public BooleanProperty getEnableExtendedMetrics() {
+        return enableExtendedMetrics;
+    }
 
     public void setLatencyShift(IntProperty latencyShift) { this.latencyShift = latencyShift; }
 
@@ -60,7 +62,9 @@ public class DynamicMetricsConfig {
         StringBuffer propsString = new StringBuffer("{");
         try {
             propsString.append(" enable=").append(enable.value).append(", ");
-            propsString.append(" enable_extended_metrics=").append(enableExtendedMetrics != null ? enableExtendedMetrics.value : "null").append(", ");
+            propsString.append(" enable_extended_metrics=")
+                    .append(enableExtendedMetrics != null ? enableExtendedMetrics.value : "null")
+                    .append(", ");
             propsString.append(" latency_shift=").append(latencyShift.value).append(", ");
             propsString.append(" latency_columns=").append(latencyColumns.value).append(", ");
             propsString.append(" labels=").append(getLabels().toString()).append(", ");

--- a/client/src/com/aerospike/client/configuration/serializers/dynamicconfig/DynamicMetricsConfig.java
+++ b/client/src/com/aerospike/client/configuration/serializers/dynamicconfig/DynamicMetricsConfig.java
@@ -25,6 +25,7 @@ import com.aerospike.client.Log;
 
 public class DynamicMetricsConfig {
     public BooleanProperty enable;
+    public BooleanProperty enableExtendedMetrics;
     public IntProperty latencyShift;
     public IntProperty latencyColumns;
     public Map<String, String> labels;
@@ -32,6 +33,12 @@ public class DynamicMetricsConfig {
     public DynamicMetricsConfig() {}
 
     public void setEnable(BooleanProperty enable) { this.enable = enable; }
+
+    public void setEnableExtendedMetrics(BooleanProperty enableExtendedMetrics) {
+        this.enableExtendedMetrics = enableExtendedMetrics;
+    }
+
+    public BooleanProperty getEnableExtendedMetrics() { return enableExtendedMetrics; }
 
     public void setLatencyShift(IntProperty latencyShift) { this.latencyShift = latencyShift; }
 
@@ -53,6 +60,7 @@ public class DynamicMetricsConfig {
         StringBuffer propsString = new StringBuffer("{");
         try {
             propsString.append(" enable=").append(enable.value).append(", ");
+            propsString.append(" enable_extended_metrics=").append(enableExtendedMetrics != null ? enableExtendedMetrics.value : "null").append(", ");
             propsString.append(" latency_shift=").append(latencyShift.value).append(", ");
             propsString.append(" latency_columns=").append(latencyColumns.value).append(", ");
             propsString.append(" labels=").append(getLabels().toString()).append(", ");

--- a/client/src/com/aerospike/client/metrics/IMetricsExporter.java
+++ b/client/src/com/aerospike/client/metrics/IMetricsExporter.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2012-2026 Aerospike, Inc.
+ *
+ * Portions may be licensed to Aerospike, Inc. under one or more contributor
+ * license agreements WHICH ARE COMPATIBLE WITH THE APACHE LICENSE, VERSION 2.0.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.aerospike.client.metrics;
+
+/**
+ * Interface for exporting Aerospike client metrics to external systems.
+ * <p>
+ * Implementations can export metrics to OpenTelemetry, Prometheus, log files,
+ * or any custom observability platform.
+ * <p>
+ * The exporter is responsible for its own initialization and cleanup.
+ * The snapshot passed to {@link #export(MetricsSnapshot)} is immutable and
+ * safe to retain, but exporters should avoid holding references longer than
+ * necessary to reduce memory pressure.
+ * <p>
+ * Exporter calls are isolated per exporter. A failure in one exporter does
+ * not prevent other exporters from receiving the same snapshot. Exporters
+ * are invoked from the metrics thread, never from the tend thread or
+ * command hot path.
+ *
+ * @see MetricsSnapshot
+ * @see MetricsPolicy
+ */
+public interface IMetricsExporter {
+
+	/**
+	 * Export a metrics snapshot. Called periodically by the metrics thread
+	 * based on the configured interval.
+	 *
+	 * @param snapshot immutable point-in-time snapshot of all client metrics
+	 */
+	void export(MetricsSnapshot snapshot);
+
+	/**
+	 * Release any resources held by this exporter (connections, threads, etc.).
+	 */
+	void close();
+}

--- a/client/src/com/aerospike/client/metrics/MetricsExporterDispatcher.java
+++ b/client/src/com/aerospike/client/metrics/MetricsExporterDispatcher.java
@@ -38,219 +38,213 @@ import com.aerospike.client.util.Util;
  * Delivers snapshots to exporters with independent timeout and failure state.
  */
 final class MetricsExporterDispatcher {
-	private final MetricsPolicy policy;
-	private final LongSupplier clock;
-	private final TimeUnit timeoutUnit;
-	private final List<ExporterRegistration> registrations;
-	private volatile boolean running = true;
+    private final MetricsPolicy policy;
+    private final LongSupplier clock;
+    private final TimeUnit timeoutUnit;
+    private final List<ExporterRegistration> registrations;
+    private volatile boolean running = true;
 
-	MetricsExporterDispatcher(MetricsPolicy policy) {
-		this(
-			policy,
-			System::currentTimeMillis,
-			MetricsExporterDispatcher::newExecutor,
-			TimeUnit.SECONDS
-		);
-	}
+    MetricsExporterDispatcher(MetricsPolicy policy) {
+        this(
+                policy,
+                System::currentTimeMillis,
+                MetricsExporterDispatcher::newExecutor,
+                TimeUnit.SECONDS
+        );
+    }
 
-	MetricsExporterDispatcher(
-		MetricsPolicy policy,
-		LongSupplier clock,
-		Supplier<ExecutorService> executorFactory,
-		TimeUnit timeoutUnit
-	) {
-		this.policy = policy;
-		this.clock = clock;
-		this.timeoutUnit = timeoutUnit;
-		List<ExporterRegistration> registrations = new ArrayList<>();
+    MetricsExporterDispatcher(
+            MetricsPolicy policy,
+            LongSupplier clock,
+            Supplier<ExecutorService> executorFactory,
+            TimeUnit timeoutUnit
+    ) {
+        this.policy = policy;
+        this.clock = clock;
+        this.timeoutUnit = timeoutUnit;
+        List<ExporterRegistration> registrations = new ArrayList<>();
 
-		for (IMetricsExporter exporter : policy.getExporters()) {
-			registrations.add(new ExporterRegistration(exporter, executorFactory.get()));
-		}
-		this.registrations = Collections.unmodifiableList(registrations);
-	}
+        for (IMetricsExporter exporter : policy.getExporters()) {
+            registrations.add(new ExporterRegistration(exporter, executorFactory.get()));
+        }
+        this.registrations = Collections.unmodifiableList(registrations);
+    }
 
-	void dispatch(MetricsSnapshot snapshot) {
-		for (ExporterRegistration registration : registrations) {
-			if (!running) {
-				return;
-			}
+    void dispatch(MetricsSnapshot snapshot) {
+        for (ExporterRegistration registration : registrations) {
+            if (!running) {
+                return;
+            }
 
-			if (!isReady(registration)) {
-				continue;
-			}
+            if (!isReady(registration)) {
+                continue;
+            }
 
-			Future<?> future;
+            Future<?> future;
 
-			try {
-				future = registration.submit(
-					() -> registration.exporter.export(snapshot));
-			}
-			catch (RejectedExecutionException ignored) {
-				continue;
-			}
+            try {
+                future = registration.submit(
+                        () -> registration.exporter.export(snapshot));
+            } catch (RejectedExecutionException ignored) {
+                continue;
+            }
 
-			if (!awaitExport(registration, future)) {
-				return;
-			}
-		}
-	}
+            if (!awaitExport(registration, future)) {
+                return;
+            }
+        }
+    }
 
-	void shutdown() {
-		if (!running) {
-			return;
-		}
+    void shutdown() {
+        if (!running) {
+            return;
+        }
 
-		running = false;
+        running = false;
 
-		for (ExporterRegistration registration : registrations) {
-			registration.shutdown();
-		}
-	}
+        for (ExporterRegistration registration : registrations) {
+            registration.shutdown();
+        }
+    }
 
-	private boolean isReady(ExporterRegistration registration) {
-		if (!registration.suspended) {
-			return true;
-		}
+    private boolean isReady(ExporterRegistration registration) {
+        if (!registration.suspended) {
+            return true;
+        }
 
-		long elapsed = clock.getAsLong() - registration.suspendedAt;
+        long elapsed = clock.getAsLong() - registration.suspendedAt;
 
-		if (elapsed < TimeUnit.SECONDS.toMillis(policy.suspendRetryInterval)) {
-			return false;
-		}
+        if (elapsed < TimeUnit.SECONDS.toMillis(policy.suspendRetryInterval)) {
+            return false;
+        }
 
-		Log.info("Retrying suspended exporter: "
-			+ exporterName(registration.exporter));
-		return true;
-	}
+        Log.info("Retrying suspended exporter: "
+                + exporterName(registration.exporter));
+        return true;
+    }
 
-	/**
-	 * Wait for one exporter invocation to finish.
-	 *
-	 * @return {@code true} when dispatch may continue to the remaining
-	 * exporters, including after an exporter-specific failure; {@code false}
-	 * when cancellation or interruption requires dispatch to stop
-	 */
-	private boolean awaitExport(
-		ExporterRegistration registration,
-		Future<?> future
-	) {
-		try {
-			future.get(policy.exportTimeout, timeoutUnit);
+    /**
+     * Wait for one exporter invocation to finish.
+     *
+     * @return {@code true} when dispatch may continue to the remaining
+     * exporters, including after an exporter-specific failure; {@code false}
+     * when cancellation or interruption requires dispatch to stop
+     */
+    private boolean awaitExport(
+            ExporterRegistration registration,
+            Future<?> future
+    ) {
+        try {
+            future.get(policy.exportTimeout, timeoutUnit);
 
-			if (registration.suspended) {
-				Log.info("Exporter " + exporterName(registration.exporter)
-					+ " resumed after successful retry");
-			}
-			registration.reset();
-			return true;
-		}
-		catch (TimeoutException e) {
-			future.cancel(true);
-			recordFailure(registration, " timed out after "
-				+ policy.exportTimeout + timeoutSuffix() + ", snapshot dropped");
-			return true;
-		}
-		catch (ExecutionException e) {
-			// The task has already completed exceptionally, so cancellation
-			// would have no effect.
-			recordFailure(registration,
-				" failed: " + Util.getErrorMessage(e.getCause()));
-			return true;
-		}
-		catch (CancellationException ignored) {
-			// Cancellation is expected during shutdown.
-			return false;
-		}
-		catch (InterruptedException e) {
-			future.cancel(true);
+            if (registration.suspended) {
+                Log.info("Exporter " + exporterName(registration.exporter)
+                        + " resumed after successful retry");
+            }
+            registration.reset();
+            return true;
+        } catch (TimeoutException e) {
+            future.cancel(true);
+            recordFailure(registration, " timed out after "
+                    + policy.exportTimeout + timeoutSuffix() + ", snapshot dropped");
+            return true;
+        } catch (ExecutionException e) {
+            // The task has already completed exceptionally, so cancellation
+            // would have no effect.
+            recordFailure(registration,
+                    " failed: " + Util.getErrorMessage(e.getCause()));
+            return true;
+        } catch (CancellationException ignored) {
+            // Cancellation is expected during shutdown.
+            return false;
+        } catch (InterruptedException e) {
+            future.cancel(true);
 
-			if (running) {
-				// Future.get() clears the interrupt status when it throws.
-				// Restore an unexpected interrupt on the metrics thread.
-				Thread.currentThread().interrupt();
-			}
-			return false;
-		}
-		finally {
-			registration.clear(future);
-		}
-	}
+            if (running) {
+                // Future.get() clears the interrupt status when it throws.
+                // Restore an unexpected interrupt on the metrics thread.
+                Thread.currentThread().interrupt();
+            }
+            return false;
+        } finally {
+            registration.clear(future);
+        }
+    }
 
-	private void recordFailure(
-		ExporterRegistration registration,
-		String message
-	) {
-		registration.consecutiveFailures++;
-		Log.warn("Exporter " + exporterName(registration.exporter) + message
-			+ " (consecutive=" + registration.consecutiveFailures + ")");
+    private void recordFailure(
+            ExporterRegistration registration,
+            String message
+    ) {
+        registration.consecutiveFailures++;
+        Log.warn("Exporter " + exporterName(registration.exporter) + message
+                + " (consecutive=" + registration.consecutiveFailures + ")");
 
-		if (registration.consecutiveFailures >= policy.maxConsecutiveFailures) {
-			registration.suspended = true;
-			registration.suspendedAt = clock.getAsLong();
-			Log.error("Exporter " + exporterName(registration.exporter)
-				+ " suspended after " + registration.consecutiveFailures
-				+ " consecutive failures");
-		}
-	}
+        if (registration.consecutiveFailures >= policy.maxConsecutiveFailures) {
+            registration.suspended = true;
+            registration.suspendedAt = clock.getAsLong();
+            Log.error("Exporter " + exporterName(registration.exporter)
+                    + " suspended after " + registration.consecutiveFailures
+                    + " consecutive failures");
+        }
+    }
 
-	private static String exporterName(IMetricsExporter exporter) {
-		String name = exporter.getClass().getSimpleName();
-		return name.isEmpty() ? exporter.getClass().getName() : name;
-	}
+    private static String exporterName(IMetricsExporter exporter) {
+        String name = exporter.getClass().getSimpleName();
+        return name.isEmpty() ? exporter.getClass().getName() : name;
+    }
 
-	private String timeoutSuffix() {
-		return timeoutUnit == TimeUnit.SECONDS
-			? "s"
-			: " " + timeoutUnit.name().toLowerCase(Locale.ROOT);
-	}
+    private String timeoutSuffix() {
+        return timeoutUnit == TimeUnit.SECONDS
+                ? "s"
+                : " " + timeoutUnit.name().toLowerCase(Locale.ROOT);
+    }
 
-	private static ExecutorService newExecutor() {
-		return Executors.newSingleThreadExecutor(runnable -> {
-			Thread thread = new Thread(runnable, "aerospike-metrics-dispatch");
-			thread.setDaemon(true);
-			return thread;
-		});
-	}
+    private static ExecutorService newExecutor() {
+        return Executors.newSingleThreadExecutor(runnable -> {
+            Thread thread = new Thread(runnable, "aerospike-metrics-dispatch");
+            thread.setDaemon(true);
+            return thread;
+        });
+    }
 
-	private static final class ExporterRegistration {
-		final IMetricsExporter exporter;
-		final ExecutorService executor;
-		int consecutiveFailures;
-		boolean suspended;
-		long suspendedAt;
-		Future<?> inFlight;
+    private static final class ExporterRegistration {
+        final IMetricsExporter exporter;
+        final ExecutorService executor;
+        int consecutiveFailures;
+        boolean suspended;
+        long suspendedAt;
+        Future<?> inFlight;
 
-		ExporterRegistration(
-			IMetricsExporter exporter,
-			ExecutorService executor
-		) {
-			this.exporter = exporter;
-			this.executor = executor;
-		}
+        ExporterRegistration(
+                IMetricsExporter exporter,
+                ExecutorService executor
+        ) {
+            this.exporter = exporter;
+            this.executor = executor;
+        }
 
-		synchronized Future<?> submit(Runnable task) {
-			inFlight = executor.submit(task);
-			return inFlight;
-		}
+        synchronized Future<?> submit(Runnable task) {
+            inFlight = executor.submit(task);
+            return inFlight;
+        }
 
-		synchronized void shutdown() {
-			if (inFlight != null) {
-				inFlight.cancel(true);
-			}
-			executor.shutdownNow();
-		}
+        synchronized void shutdown() {
+            if (inFlight != null) {
+                inFlight.cancel(true);
+            }
+            executor.shutdownNow();
+        }
 
-		synchronized void clear(Future<?> future) {
-			if (inFlight == future) {
-				inFlight = null;
-			}
-		}
+        synchronized void clear(Future<?> future) {
+            if (inFlight == future) {
+                inFlight = null;
+            }
+        }
 
-		void reset() {
-			consecutiveFailures = 0;
-			suspended = false;
-			suspendedAt = 0;
-		}
-	}
+        void reset() {
+            consecutiveFailures = 0;
+            suspended = false;
+            suspendedAt = 0;
+        }
+    }
 }

--- a/client/src/com/aerospike/client/metrics/MetricsExporterDispatcher.java
+++ b/client/src/com/aerospike/client/metrics/MetricsExporterDispatcher.java
@@ -1,0 +1,256 @@
+/*
+ * Copyright 2012-2026 Aerospike, Inc.
+ *
+ * Portions may be licensed to Aerospike, Inc. under one or more contributor
+ * license agreements WHICH ARE COMPATIBLE WITH THE APACHE LICENSE, VERSION 2.0.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.aerospike.client.metrics;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.LongSupplier;
+import java.util.function.Supplier;
+
+import com.aerospike.client.Log;
+import com.aerospike.client.util.Util;
+
+/**
+ * Delivers snapshots to exporters with independent timeout and failure state.
+ */
+final class MetricsExporterDispatcher {
+	private final MetricsPolicy policy;
+	private final LongSupplier clock;
+	private final TimeUnit timeoutUnit;
+	private final List<ExporterRegistration> registrations;
+	private volatile boolean running = true;
+
+	MetricsExporterDispatcher(MetricsPolicy policy) {
+		this(
+			policy,
+			System::currentTimeMillis,
+			MetricsExporterDispatcher::newExecutor,
+			TimeUnit.SECONDS
+		);
+	}
+
+	MetricsExporterDispatcher(
+		MetricsPolicy policy,
+		LongSupplier clock,
+		Supplier<ExecutorService> executorFactory,
+		TimeUnit timeoutUnit
+	) {
+		this.policy = policy;
+		this.clock = clock;
+		this.timeoutUnit = timeoutUnit;
+		List<ExporterRegistration> registrations = new ArrayList<>();
+
+		for (IMetricsExporter exporter : policy.getExporters()) {
+			registrations.add(new ExporterRegistration(exporter, executorFactory.get()));
+		}
+		this.registrations = Collections.unmodifiableList(registrations);
+	}
+
+	void dispatch(MetricsSnapshot snapshot) {
+		for (ExporterRegistration registration : registrations) {
+			if (!running) {
+				return;
+			}
+
+			if (!isReady(registration)) {
+				continue;
+			}
+
+			Future<?> future;
+
+			try {
+				future = registration.submit(
+					() -> registration.exporter.export(snapshot));
+			}
+			catch (RejectedExecutionException ignored) {
+				continue;
+			}
+
+			if (!awaitExport(registration, future)) {
+				return;
+			}
+		}
+	}
+
+	void shutdown() {
+		if (!running) {
+			return;
+		}
+
+		running = false;
+
+		for (ExporterRegistration registration : registrations) {
+			registration.shutdown();
+		}
+	}
+
+	private boolean isReady(ExporterRegistration registration) {
+		if (!registration.suspended) {
+			return true;
+		}
+
+		long elapsed = clock.getAsLong() - registration.suspendedAt;
+
+		if (elapsed < TimeUnit.SECONDS.toMillis(policy.suspendRetryInterval)) {
+			return false;
+		}
+
+		Log.info("Retrying suspended exporter: "
+			+ exporterName(registration.exporter));
+		return true;
+	}
+
+	/**
+	 * Wait for one exporter invocation to finish.
+	 *
+	 * @return {@code true} when dispatch may continue to the remaining
+	 * exporters, including after an exporter-specific failure; {@code false}
+	 * when cancellation or interruption requires dispatch to stop
+	 */
+	private boolean awaitExport(
+		ExporterRegistration registration,
+		Future<?> future
+	) {
+		try {
+			future.get(policy.exportTimeout, timeoutUnit);
+
+			if (registration.suspended) {
+				Log.info("Exporter " + exporterName(registration.exporter)
+					+ " resumed after successful retry");
+			}
+			registration.reset();
+			return true;
+		}
+		catch (TimeoutException e) {
+			future.cancel(true);
+			recordFailure(registration, " timed out after "
+				+ policy.exportTimeout + timeoutSuffix() + ", snapshot dropped");
+			return true;
+		}
+		catch (ExecutionException e) {
+			// The task has already completed exceptionally, so cancellation
+			// would have no effect.
+			recordFailure(registration,
+				" failed: " + Util.getErrorMessage(e.getCause()));
+			return true;
+		}
+		catch (CancellationException ignored) {
+			// Cancellation is expected during shutdown.
+			return false;
+		}
+		catch (InterruptedException e) {
+			future.cancel(true);
+
+			if (running) {
+				// Future.get() clears the interrupt status when it throws.
+				// Restore an unexpected interrupt on the metrics thread.
+				Thread.currentThread().interrupt();
+			}
+			return false;
+		}
+		finally {
+			registration.clear(future);
+		}
+	}
+
+	private void recordFailure(
+		ExporterRegistration registration,
+		String message
+	) {
+		registration.consecutiveFailures++;
+		Log.warn("Exporter " + exporterName(registration.exporter) + message
+			+ " (consecutive=" + registration.consecutiveFailures + ")");
+
+		if (registration.consecutiveFailures >= policy.maxConsecutiveFailures) {
+			registration.suspended = true;
+			registration.suspendedAt = clock.getAsLong();
+			Log.error("Exporter " + exporterName(registration.exporter)
+				+ " suspended after " + registration.consecutiveFailures
+				+ " consecutive failures");
+		}
+	}
+
+	private static String exporterName(IMetricsExporter exporter) {
+		String name = exporter.getClass().getSimpleName();
+		return name.isEmpty() ? exporter.getClass().getName() : name;
+	}
+
+	private String timeoutSuffix() {
+		return timeoutUnit == TimeUnit.SECONDS
+			? "s"
+			: " " + timeoutUnit.name().toLowerCase(Locale.ROOT);
+	}
+
+	private static ExecutorService newExecutor() {
+		return Executors.newSingleThreadExecutor(runnable -> {
+			Thread thread = new Thread(runnable, "aerospike-metrics-dispatch");
+			thread.setDaemon(true);
+			return thread;
+		});
+	}
+
+	private static final class ExporterRegistration {
+		final IMetricsExporter exporter;
+		final ExecutorService executor;
+		int consecutiveFailures;
+		boolean suspended;
+		long suspendedAt;
+		Future<?> inFlight;
+
+		ExporterRegistration(
+			IMetricsExporter exporter,
+			ExecutorService executor
+		) {
+			this.exporter = exporter;
+			this.executor = executor;
+		}
+
+		synchronized Future<?> submit(Runnable task) {
+			inFlight = executor.submit(task);
+			return inFlight;
+		}
+
+		synchronized void shutdown() {
+			if (inFlight != null) {
+				inFlight.cancel(true);
+			}
+			executor.shutdownNow();
+		}
+
+		synchronized void clear(Future<?> future) {
+			if (inFlight == future) {
+				inFlight = null;
+			}
+		}
+
+		void reset() {
+			consecutiveFailures = 0;
+			suspended = false;
+			suspendedAt = 0;
+		}
+	}
+}

--- a/client/src/com/aerospike/client/metrics/MetricsExporterThread.java
+++ b/client/src/com/aerospike/client/metrics/MetricsExporterThread.java
@@ -42,8 +42,8 @@ public class MetricsExporterThread extends Thread {
 
     @Override
     public void run() {
-        Log.info("Metrics exporter thread started, interval=" + policy.interval
-                + "s, exporters=" + policy.getExporters().size());
+        Log.info("Metrics exporter thread started, interval=" + policy.interval +
+                "s, exporters=" + policy.getExporters().size());
 
         try {
             while (sleepUntilNextSnapshot()) {
@@ -52,7 +52,8 @@ public class MetricsExporterThread extends Thread {
                 try {
                     snapshot = snapshotBuilder.build();
                 } catch (Exception e) {
-                    Log.warn("Failed to capture metrics snapshot: " + Util.getErrorMessage(e));
+                    Log.warn("Failed to capture metrics snapshot: " +
+                            Util.getErrorMessage(e));
                     continue;
                 }
 

--- a/client/src/com/aerospike/client/metrics/MetricsExporterThread.java
+++ b/client/src/com/aerospike/client/metrics/MetricsExporterThread.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2012-2026 Aerospike, Inc.
+ *
+ * Portions may be licensed to Aerospike, Inc. under one or more contributor
+ * license agreements WHICH ARE COMPATIBLE WITH THE APACHE LICENSE, VERSION 2.0.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.aerospike.client.metrics;
+
+import com.aerospike.client.Log;
+import com.aerospike.client.cluster.Cluster;
+import com.aerospike.client.util.Util;
+
+/**
+ * Schedules periodic snapshot capture and exporter delivery outside the tend
+ * thread and command hot path.
+ */
+public class MetricsExporterThread extends Thread {
+    private final MetricsPolicy policy;
+    private final MetricsSnapshotBuilder snapshotBuilder;
+    private final MetricsExporterDispatcher dispatcher;
+    private volatile boolean running = true;
+
+    public MetricsExporterThread(Cluster cluster, MetricsPolicy policy) {
+        super("aerospike-metrics-exporter");
+        setDaemon(true);
+
+        policy.validateExporterSettings();
+        this.policy = policy;
+        this.snapshotBuilder = new MetricsSnapshotBuilder(cluster, policy);
+        this.dispatcher = new MetricsExporterDispatcher(policy);
+    }
+
+    @Override
+    public void run() {
+        Log.info("Metrics exporter thread started, interval=" + policy.interval
+                + "s, exporters=" + policy.getExporters().size());
+
+        try {
+            while (sleepUntilNextSnapshot()) {
+                MetricsSnapshot snapshot;
+
+                try {
+                    snapshot = snapshotBuilder.build();
+                } catch (Exception e) {
+                    Log.warn("Failed to capture metrics snapshot: " + Util.getErrorMessage(e));
+                    continue;
+                }
+
+                dispatcher.dispatch(snapshot);
+            }
+        } finally {
+            running = false;
+            dispatcher.shutdown();
+            Log.info("Metrics exporter thread stopped");
+        }
+    }
+
+    /**
+     * Signal the metrics exporter thread and all exporter dispatchers to stop.
+     * This method is safe to call more than once.
+     */
+    public void shutdown() {
+        running = false;
+
+        try {
+            dispatcher.shutdown();
+        } finally {
+            interrupt();
+        }
+    }
+
+    private boolean sleepUntilNextSnapshot() {
+        if (!running) {
+            return false;
+        }
+
+        try {
+            Thread.sleep(policy.interval * 1000L);
+            return running;
+        } catch (InterruptedException e) {
+            if (running) {
+                // Thread.sleep() clears the interrupt status when it throws.
+                // Restore an unexpected interrupt before terminating the thread.
+                Thread.currentThread().interrupt();
+            }
+            return false;
+        }
+    }
+}

--- a/client/src/com/aerospike/client/metrics/MetricsPolicy.java
+++ b/client/src/com/aerospike/client/metrics/MetricsPolicy.java
@@ -16,6 +16,9 @@
  */
 package com.aerospike.client.metrics;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 import com.aerospike.client.Log;
@@ -60,6 +63,7 @@ public final class MetricsPolicy {
 	 * Number of cluster tend iterations between metrics notification events. One tend iteration
 	 * is defined as {@link ClientPolicy#tendInterval} (default 1 second) plus the time to tend all
 	 * nodes.
+	 * Must be greater than zero when exporters are configured.
 	 * <p>
 	 * Default: 30
 	 */
@@ -87,9 +91,63 @@ public final class MetricsPolicy {
 	public int latencyShift = 1;
 
 	/**
+	 * Enable collection of extended metrics such as CPU usage, memory usage, command count,
+	 * per-namespace error/timeout/byte counters, and latency histograms. Extended metrics
+	 * provide detailed diagnostics but may add overhead on the command hot path.
+	 * <p>
+	 * When {@code false}, only standard low-overhead metrics (connection pool gauges, retry
+	 * counts, cluster health counters) are collected and exported.
+	 * <p>
+	 * Default: true (all metrics collected when metrics are enabled)
+	 */
+	public boolean enableExtendedMetrics = true;
+
+	/**
 	 * Labels that can be sent to the metrics output
 	 */
 	public Map<String,String> labels;
+
+	/**
+	 * Registered metrics exporters. Invoked in registration order by the
+	 * dedicated metrics thread. Registrations are captured when metrics are
+	 * enabled and remain fixed until metrics are disabled and enabled again.
+	 * If non-empty, a metrics thread is started alongside the existing
+	 * MetricsListener path.
+	 */
+	private final List<IMetricsExporter> exporters = new ArrayList<>();
+
+	/**
+	 * Maximum consecutive export failures before an exporter is suspended.
+	 * Must be greater than zero.
+	 * <p>
+	 * Default: 3
+	 */
+	public int maxConsecutiveFailures = 3;
+
+	/**
+	 * Seconds to wait before retrying a suspended exporter.
+	 * Zero retries the exporter on the next snapshot interval.
+	 * Must not be negative.
+	 * <p>
+	 * Default: 60
+	 */
+	public int suspendRetryInterval = 60;
+
+	/**
+	 * Maximum seconds to wait for a single {@link IMetricsExporter#export(MetricsSnapshot)}
+	 * call to complete. If the exporter does not return within this time, the call is
+	 * cancelled, the snapshot is dropped, and the timeout is counted as a consecutive
+	 * failure (subject to {@link #maxConsecutiveFailures} suspension logic).
+	 * <p>
+	 * This protects the metrics thread from being blocked indefinitely by a slow or
+	 * unresponsive exporter (e.g., a custom exporter performing a synchronous network call).
+	 * Well-behaved exporters (like the OpenTelemetry exporter) store the snapshot reference
+	 * and return immediately, so this timeout is a safety net for custom implementations.
+	 * Must be greater than zero.
+	 * <p>
+	 * Default: 10
+	 */
+	public int exportTimeout = 10;
 
 	private boolean metricsRestartRequired = false;
 
@@ -142,6 +200,17 @@ public final class MetricsPolicy {
 			Log.error("An invalid # of latency columns was provided. Setting latency columns to default (7).");
 			latencyColumns = 7;
 		}
+		if (dynMC.enableExtendedMetrics != null) {
+			if (dynMC.enableExtendedMetrics.value != this.enableExtendedMetrics) {
+				this.enableExtendedMetrics = dynMC.enableExtendedMetrics.value;
+				if (metricsEnabled) {
+					metricsRestartRequired = true;
+				}
+				if (logUpdate) {
+					Log.info("Set MetricsPolicy.enableExtendedMetrics = " + this.enableExtendedMetrics);
+				}
+			}
+		}
 	}
 
 	/**
@@ -154,8 +223,13 @@ public final class MetricsPolicy {
 		this.interval = other.interval;
 		this.latencyColumns = other.latencyColumns;
 		this.latencyShift = other.latencyShift;
+		this.enableExtendedMetrics = other.enableExtendedMetrics;
 		this.labels = other.labels;
 		this.metricsRestartRequired = other.metricsRestartRequired;
+		this.exporters.addAll(other.exporters);
+		this.maxConsecutiveFailures = other.maxConsecutiveFailures;
+		this.suspendRetryInterval = other.suspendRetryInterval;
+		this.exportTimeout = other.exportTimeout;
 	}
 
 	/**
@@ -188,6 +262,10 @@ public final class MetricsPolicy {
 
 	public void setLatencyShift(int latencyShift) { this.latencyShift = latencyShift; }
 
+	public void setEnableExtendedMetrics(boolean enableExtendedMetrics) {
+		this.enableExtendedMetrics = enableExtendedMetrics;
+	}
+
 	public void setLabels(Map<String, String> labels) { this.labels = labels; }
 
 	public boolean isMetricsRestartRequired() {
@@ -196,5 +274,63 @@ public final class MetricsPolicy {
 
 	public void setMetricsRestartRequired(boolean metricsRestartRequired) {
 		this.metricsRestartRequired = metricsRestartRequired;
+	}
+
+	/**
+	 * Register a metrics exporter. Exporters are invoked in registration order.
+	 * If metrics are already enabled, the exporter is used the next time metrics
+	 * are disabled and enabled.
+	 *
+	 * @param exporter the exporter to add; must not be null
+	 * @throws IllegalArgumentException if exporter is null
+	 */
+	public void addExporter(IMetricsExporter exporter) {
+		if (exporter == null) {
+			throw new IllegalArgumentException("exporter must not be null");
+		}
+		exporters.add(exporter);
+	}
+
+	/**
+	 * Return an unmodifiable view of the registered exporters.
+	 */
+	public List<IMetricsExporter> getExporters() {
+		return Collections.unmodifiableList(exporters);
+	}
+
+	/**
+	 * Validate settings used by the metrics exporter runtime.
+	 *
+	 * @throws IllegalArgumentException if an exporter setting is outside its
+	 * supported range
+	 */
+	public void validateExporterSettings() {
+		if (interval <= 0) {
+			throw new IllegalArgumentException("MetricsPolicy.interval must be greater than zero");
+		}
+		if (maxConsecutiveFailures <= 0) {
+			throw new IllegalArgumentException(
+				"MetricsPolicy.maxConsecutiveFailures must be greater than zero");
+		}
+		if (suspendRetryInterval < 0) {
+			throw new IllegalArgumentException(
+				"MetricsPolicy.suspendRetryInterval must not be negative");
+		}
+		if (exportTimeout <= 0) {
+			throw new IllegalArgumentException(
+				"MetricsPolicy.exportTimeout must be greater than zero");
+		}
+	}
+
+	public void setMaxConsecutiveFailures(int maxConsecutiveFailures) {
+		this.maxConsecutiveFailures = maxConsecutiveFailures;
+	}
+
+	public void setSuspendRetryInterval(int suspendRetryInterval) {
+		this.suspendRetryInterval = suspendRetryInterval;
+	}
+
+	public void setExportTimeout(int exportTimeout) {
+		this.exportTimeout = exportTimeout;
 	}
 }

--- a/client/src/com/aerospike/client/metrics/MetricsSnapshot.java
+++ b/client/src/com/aerospike/client/metrics/MetricsSnapshot.java
@@ -1,0 +1,541 @@
+/*
+ * Copyright 2012-2026 Aerospike, Inc.
+ *
+ * Portions may be licensed to Aerospike, Inc. under one or more contributor
+ * license agreements WHICH ARE COMPATIBLE WITH THE APACHE LICENSE, VERSION 2.0.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.aerospike.client.metrics;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Immutable point-in-time snapshot of client metrics.
+ * <p>
+ * Standard metrics are exact counters or current gauges collected with negligible
+ * overhead. Extended metrics (CPU, memory, command count, per-namespace counters,
+ * latency histograms) may carry a performance cost and are only populated when
+ * {@link #extendedMetricsEnabled} is {@code true}.
+ */
+public final class MetricsSnapshot {
+
+	// ── Snapshot information ───────────────────────────────────────
+
+	public final Instant timestamp;
+	public final boolean extendedMetricsEnabled;
+
+	// ── Identifying metadata ───────────────────────────────────────
+
+	public final String clusterName;
+	public final String clientType;
+	public final String clientVersion;
+	public final String appId;
+	public final Map<String, String> labels;
+
+	// ── Standard cluster-level gauges and cumulative counters ──────
+
+	public final int recoverQueueSize;
+	public final int invalidNodeCount;
+	public final long retryCount;
+	public final long delayQueueTimeoutCount;
+	public final int totalNodes;
+	public final long openConnections;
+	public final long exceededMaxRetries;
+	public final long exceededTotalTimeout;
+
+	// ── Extended cluster-level metrics ──────────────────────────────
+
+	public final double cpuPercent;
+	public final long memoryBytes;
+	public final long commandCount;
+
+	// ── Event loop snapshots (Java-specific) ───────────────────────
+
+	public final List<EventLoopSnapshot> eventLoops;
+
+	// ── Per-node and cluster-aggregated snapshots ──────────────────
+
+	public final List<NodeSnapshot> nodes;
+	public final NodeSnapshot clusterAggregated;
+
+	// ── Histogram configuration ────────────────────────────────────
+
+	public final HistogramType histogramType;
+	public final LatencyUnit latencyUnit;
+	public final int latencyBase;
+	public final int latencyColumns;
+
+	public MetricsSnapshot(
+		Instant timestamp,
+		boolean extendedMetricsEnabled,
+		String clusterName,
+		String clientType,
+		String clientVersion,
+		String appId,
+		Map<String, String> labels,
+		int recoverQueueSize,
+		int invalidNodeCount,
+		long retryCount,
+		long delayQueueTimeoutCount,
+		int totalNodes,
+		long openConnections,
+		long exceededMaxRetries,
+		long exceededTotalTimeout,
+		double cpuPercent,
+		long memoryBytes,
+		long commandCount,
+		List<EventLoopSnapshot> eventLoops,
+		List<NodeSnapshot> nodes,
+		NodeSnapshot clusterAggregated,
+		HistogramType histogramType,
+		LatencyUnit latencyUnit,
+		int latencyBase,
+		int latencyColumns
+	) {
+		this.timestamp = timestamp;
+		this.extendedMetricsEnabled = extendedMetricsEnabled;
+		this.clusterName = clusterName;
+		this.clientType = clientType;
+		this.clientVersion = clientVersion;
+		this.appId = appId;
+		this.labels = labels != null
+			? Collections.unmodifiableMap(new HashMap<>(labels))
+			: Collections.emptyMap();
+		this.recoverQueueSize = recoverQueueSize;
+		this.invalidNodeCount = invalidNodeCount;
+		this.retryCount = retryCount;
+		this.delayQueueTimeoutCount = delayQueueTimeoutCount;
+		this.totalNodes = totalNodes;
+		this.openConnections = openConnections;
+		this.exceededMaxRetries = exceededMaxRetries;
+		this.exceededTotalTimeout = exceededTotalTimeout;
+		this.cpuPercent = cpuPercent;
+		this.memoryBytes = memoryBytes;
+		this.commandCount = commandCount;
+		this.eventLoops = Collections.unmodifiableList(new ArrayList<>(eventLoops));
+		this.nodes = Collections.unmodifiableList(new ArrayList<>(nodes));
+		this.clusterAggregated = clusterAggregated;
+		this.histogramType = histogramType;
+		this.latencyUnit = latencyUnit;
+		this.latencyBase = latencyBase;
+		this.latencyColumns = latencyColumns;
+	}
+
+	// ── Inner classes ──────────────────────────────────────────────
+
+	/**
+	 * Metrics snapshot for a single cluster node. Counter fields are cumulative
+	 * unless their names describe a current gauge.
+	 */
+	public static final class NodeSnapshot {
+		public final String nodeName;
+		public final String nodeAddress;
+		public final int nodePort;
+
+		/** Standard connection pool metrics for synchronous connections. */
+		public final ConnectionSnapshot syncConnections;
+
+		/** Standard connection pool metrics for asynchronous connections. */
+		public final ConnectionSnapshot asyncConnections;
+
+		/**
+		 * Reserved: total connection attempts to this node since node creation.
+		 * Not tracked by the Java client. Defined in the Rust reference model.
+		 * Currently always 0.
+		 */
+		public final long connectionAttempts;
+
+		/**
+		 * Reserved: successful connection attempts to this node.
+		 * Not tracked by the Java client. Defined in the Rust reference model.
+		 * Currently always 0.
+		 */
+		public final long connectionsSuccessful;
+
+		/**
+		 * Reserved: failed connection attempts to this node.
+		 * Not tracked by the Java client. Defined in the Rust reference model.
+		 * Currently always 0.
+		 */
+		public final long connectionsFailed;
+
+		/**
+		 * Reserved: connection timeout errors for this node.
+		 * Not tracked by the Java client. Defined in the Rust reference model.
+		 * Currently always 0.
+		 */
+		public final long connectionTimeoutErrors;
+
+		/**
+		 * Reserved: non-timeout connection errors for this node.
+		 * Not tracked by the Java client. Defined in the Rust reference model.
+		 * Currently always 0.
+		 */
+		public final long connectionOtherErrors;
+
+		/**
+		 * Reserved: circuit breaker hit count for this node.
+		 * Not tracked by the Java client. Defined in the Rust reference model.
+		 * Currently always 0.
+		 */
+		public final long circuitBreakerHits;
+
+		/**
+		 * Reserved: count of times a connection was requested but the pool was empty.
+		 * Not tracked by the Java client. Defined in the Rust reference model.
+		 * Currently always 0.
+		 */
+		public final long connectionPoolEmptyCount;
+
+		/**
+		 * Reserved: count of times a connection was returned but the pool was full.
+		 * Not tracked by the Java client. Defined in the Rust reference model.
+		 * Currently always 0.
+		 */
+		public final long connectionPoolOverflowCount;
+
+		/**
+		 * Reserved: count of idle connections dropped from the pool.
+		 * Not tracked by the Java client. Defined in the Rust reference model.
+		 * Currently always 0.
+		 */
+		public final long idleConnectionsDropped;
+
+		/**
+		 * Current number of open connections to this node.
+		 * Calculated as syncConnections.inUse + syncConnections.inPool
+		 * + asyncConnections.inUse + asyncConnections.inPool.
+		 */
+		public final long openConnections;
+
+		/**
+		 * Reserved: node-level aggregate of closed connections.
+		 * Per-pool closed counts are available via {@link #syncConnections} and
+		 * {@link #asyncConnections} ({@code ConnectionSnapshot.closed}).
+		 * This field is reserved for a separate node-level aggregate not currently
+		 * tracked by the Java client. Currently always 0.
+		 */
+		public final long closedConnections;
+
+		/**
+		 * Reserved: count of connections recovered after transient errors.
+		 * Not tracked by the Java client. Defined in the Rust reference model.
+		 * Currently always 0.
+		 */
+		public final long recoveredConnections;
+
+		/**
+		 * Reserved: total tend cycles executed for this node.
+		 * Tend counters are not tracked per-node in the Java client.
+		 * Currently always 0.
+		 */
+		public final long tendsTotal;
+
+		/**
+		 * Reserved: successful tend cycles for this node.
+		 * Tend counters are not tracked per-node in the Java client.
+		 * Currently always 0.
+		 */
+		public final long tendsSuccessful;
+
+		/**
+		 * Reserved: failed tend cycles for this node.
+		 * Tend counters are not tracked per-node in the Java client.
+		 * Currently always 0.
+		 */
+		public final long tendsFailed;
+
+		/**
+		 * Reserved: number of partition map updates received for this node.
+		 * Not tracked per-node in the Java client. Defined in the Rust reference model.
+		 * Currently always 0.
+		 */
+		public final long partitionMapUpdates;
+
+		/**
+		 * Reserved: number of times nodes were added to the cluster during tending.
+		 * Not tracked per-node in the Java client. Defined in the Rust reference model.
+		 * Currently always 0.
+		 */
+		public final long nodesAdded;
+
+		/**
+		 * Reserved: number of times nodes were removed from the cluster during tending.
+		 * Not tracked per-node in the Java client. Defined in the Rust reference model.
+		 * Currently always 0.
+		 */
+		public final long nodesRemoved;
+
+		/**
+		 * Reserved: per-node transaction retry count.
+		 * Not tracked separately from the cluster-level {@link MetricsSnapshot#retryCount}.
+		 * Currently always 0.
+		 */
+		public final long transactionRetryCount;
+
+		/**
+		 * Reserved: per-node transaction error count.
+		 * Not tracked separately from per-namespace error counters.
+		 * Currently always 0.
+		 */
+		public final long transactionErrorCount;
+
+		/**
+		 * Reserved: detailed per-command-type latency histograms (GET, PUT, DELETE, etc.).
+		 * Requires client-side instrumentation of command hot paths to populate.
+		 * Currently always an empty map. The fine-grained {@link CommandType} categories
+		 * will replace the legacy broad categories (CONN, READ, WRITE, BATCH, QUERY)
+		 * available in {@link NamespaceSnapshot#compatibilityLatencies}.
+		 */
+		public final Map<CommandType, HistogramSnapshot> commandLatencies;
+
+		/**
+		 * Extended: per-namespace metrics for this node. Only populated when
+		 * {@link MetricsPolicy#enableExtendedMetrics} is {@code true}.
+		 */
+		public final List<NamespaceSnapshot> namespaces;
+
+		public NodeSnapshot(
+			String nodeName,
+			String nodeAddress,
+			int nodePort,
+			ConnectionSnapshot syncConnections,
+			ConnectionSnapshot asyncConnections,
+			long connectionAttempts,
+			long connectionsSuccessful,
+			long connectionsFailed,
+			long connectionTimeoutErrors,
+			long connectionOtherErrors,
+			long circuitBreakerHits,
+			long connectionPoolEmptyCount,
+			long connectionPoolOverflowCount,
+			long idleConnectionsDropped,
+			long openConnections,
+			long closedConnections,
+			long recoveredConnections,
+			long tendsTotal,
+			long tendsSuccessful,
+			long tendsFailed,
+			long partitionMapUpdates,
+			long nodesAdded,
+			long nodesRemoved,
+			long transactionRetryCount,
+			long transactionErrorCount,
+			Map<CommandType, HistogramSnapshot> commandLatencies,
+			List<NamespaceSnapshot> namespaces
+		) {
+			this.nodeName = nodeName;
+			this.nodeAddress = nodeAddress;
+			this.nodePort = nodePort;
+			this.syncConnections = syncConnections;
+			this.asyncConnections = asyncConnections;
+			this.connectionAttempts = connectionAttempts;
+			this.connectionsSuccessful = connectionsSuccessful;
+			this.connectionsFailed = connectionsFailed;
+			this.connectionTimeoutErrors = connectionTimeoutErrors;
+			this.connectionOtherErrors = connectionOtherErrors;
+			this.circuitBreakerHits = circuitBreakerHits;
+			this.connectionPoolEmptyCount = connectionPoolEmptyCount;
+			this.connectionPoolOverflowCount = connectionPoolOverflowCount;
+			this.idleConnectionsDropped = idleConnectionsDropped;
+			this.openConnections = openConnections;
+			this.closedConnections = closedConnections;
+			this.recoveredConnections = recoveredConnections;
+			this.tendsTotal = tendsTotal;
+			this.tendsSuccessful = tendsSuccessful;
+			this.tendsFailed = tendsFailed;
+			this.partitionMapUpdates = partitionMapUpdates;
+			this.nodesAdded = nodesAdded;
+			this.nodesRemoved = nodesRemoved;
+			this.transactionRetryCount = transactionRetryCount;
+			this.transactionErrorCount = transactionErrorCount;
+			this.commandLatencies = Collections.unmodifiableMap(new HashMap<>(commandLatencies));
+			this.namespaces = Collections.unmodifiableList(new ArrayList<>(namespaces));
+		}
+	}
+
+	/**
+	 * Standard connection pool statistics.
+	 */
+	public static final class ConnectionSnapshot {
+		public final int inUse;
+		public final int inPool;
+		public final int opened;
+		public final int closed;
+
+		public ConnectionSnapshot(int inUse, int inPool, int opened, int closed) {
+			this.inUse = inUse;
+			this.inPool = inPool;
+			this.opened = opened;
+			this.closed = closed;
+		}
+	}
+
+	/**
+	 * Java event-loop measurements.
+	 */
+	public static final class EventLoopSnapshot {
+		public final int processSize;
+		public final int queueSize;
+
+		public EventLoopSnapshot(int processSize, int queueSize) {
+			this.processSize = processSize;
+			this.queueSize = queueSize;
+		}
+	}
+
+	/**
+	 * Extended metrics for one namespace on one node.
+	 */
+	public static final class NamespaceSnapshot {
+		public final String namespace;
+		public final long errors;
+		public final long timeouts;
+		public final long keyBusy;
+		public final long bytesIn;
+		public final long bytesOut;
+
+		/**
+		 * Compatibility latency histograms for broad operation types
+		 * (conn, read, write, batch, query).
+		 */
+		public final Map<LatencyType, HistogramSnapshot> compatibilityLatencies;
+
+		/**
+		 * Detailed sampled measurements by command type.
+		 * Empty when no detailed measurements are available.
+		 */
+		public final Map<CommandType, CommandSnapshot> commands;
+
+		public NamespaceSnapshot(
+			String namespace,
+			long errors,
+			long timeouts,
+			long keyBusy,
+			long bytesIn,
+			long bytesOut,
+			Map<LatencyType, HistogramSnapshot> compatibilityLatencies,
+			Map<CommandType, CommandSnapshot> commands
+		) {
+			this.namespace = namespace;
+			this.errors = errors;
+			this.timeouts = timeouts;
+			this.keyBusy = keyBusy;
+			this.bytesIn = bytesIn;
+			this.bytesOut = bytesOut;
+			this.compatibilityLatencies = Collections.unmodifiableMap(new HashMap<>(compatibilityLatencies));
+			this.commands = Collections.unmodifiableMap(new HashMap<>(commands));
+		}
+	}
+
+	/**
+	 * Reserved: detailed sampled measurements for one command type within a namespace.
+	 * <p>
+	 * Requires per-command phase-level timing instrumentation (connection acquisition,
+	 * request write, response parse) in the client command pipeline. These measurements
+	 * are defined in the Rust reference model and are not yet implemented in the Java client.
+	 * <p>
+	 * Fields in this class will be populated when the client team adds the necessary
+	 * instrumentation to command hot paths (SyncCommand, NioCommand, NettyCommand, etc.).
+	 */
+	public static final class CommandSnapshot {
+		public final CommandType commandType;
+		public final HistogramSnapshot connectionAcquisition;
+		public final HistogramSnapshot requestWrite;
+		public final HistogramSnapshot responseParse;
+		public final HistogramSnapshot latency;
+		public final HistogramSnapshot bytesSent;
+		public final HistogramSnapshot bytesReceived;
+		public final long retryCount;
+		public final long errorCount;
+		public final Map<Integer, Long> resultCodeCounts;
+
+		public CommandSnapshot(
+			CommandType commandType,
+			HistogramSnapshot connectionAcquisition,
+			HistogramSnapshot requestWrite,
+			HistogramSnapshot responseParse,
+			HistogramSnapshot latency,
+			HistogramSnapshot bytesSent,
+			HistogramSnapshot bytesReceived,
+			long retryCount,
+			long errorCount,
+			Map<Integer, Long> resultCodeCounts
+		) {
+			this.commandType = commandType;
+			this.connectionAcquisition = connectionAcquisition;
+			this.requestWrite = requestWrite;
+			this.responseParse = responseParse;
+			this.latency = latency;
+			this.bytesSent = bytesSent;
+			this.bytesReceived = bytesReceived;
+			this.retryCount = retryCount;
+			this.errorCount = errorCount;
+			this.resultCodeCounts = Collections.unmodifiableMap(new HashMap<>(resultCodeCounts));
+		}
+	}
+
+	/**
+	 * Histogram bucket counts and summary statistics. Latency histograms use
+	 * {@link MetricsSnapshot#latencyUnit}; byte histograms use bytes.
+	 */
+	public static final class HistogramSnapshot {
+		private final long[] buckets;
+		public final long min;
+		public final long max;
+		public final double sum;
+		public final long count;
+
+		public HistogramSnapshot(long[] buckets, long min, long max, double sum, long count) {
+			this.buckets = buckets.clone();
+			this.min = min;
+			this.max = max;
+			this.sum = sum;
+			this.count = count;
+		}
+
+		public long[] getBuckets() {
+			return buckets.clone();
+		}
+	}
+
+	// ── Enums ──────────────────────────────────────────────────────
+
+	public enum HistogramType {
+		LINEAR,
+		LOGARITHMIC
+	}
+
+	public enum LatencyUnit {
+		MILLISECONDS,
+		MICROSECONDS
+	}
+
+	public enum CommandType {
+		GET,
+		GET_HEADER,
+		EXISTS,
+		PUT,
+		DELETE,
+		OPERATE,
+		QUERY,
+		SCAN,
+		UDF,
+		BATCH_READ,
+		BATCH_WRITE
+	}
+}

--- a/client/src/com/aerospike/client/metrics/MetricsSnapshot.java
+++ b/client/src/com/aerospike/client/metrics/MetricsSnapshot.java
@@ -33,509 +33,513 @@ import java.util.Map;
  */
 public final class MetricsSnapshot {
 
-	// ── Snapshot information ───────────────────────────────────────
+    // Snapshot information.
 
-	public final Instant timestamp;
-	public final boolean extendedMetricsEnabled;
+    public final Instant timestamp;
+    public final boolean extendedMetricsEnabled;
 
-	// ── Identifying metadata ───────────────────────────────────────
+    // Identifying metadata.
 
-	public final String clusterName;
-	public final String clientType;
-	public final String clientVersion;
-	public final String appId;
-	public final Map<String, String> labels;
+    public final String clusterName;
+    public final String clientType;
+    public final String clientVersion;
+    public final String appId;
+    public final Map<String, String> labels;
 
-	// ── Standard cluster-level gauges and cumulative counters ──────
+    // Standard cluster-level gauges and cumulative counters.
 
-	public final int recoverQueueSize;
-	public final int invalidNodeCount;
-	public final long retryCount;
-	public final long delayQueueTimeoutCount;
-	public final int totalNodes;
-	public final long openConnections;
-	public final long exceededMaxRetries;
-	public final long exceededTotalTimeout;
+    public final int recoverQueueSize;
+    public final int invalidNodeCount;
+    public final long retryCount;
+    public final long delayQueueTimeoutCount;
+    public final int totalNodes;
+    public final long openConnections;
+    public final long exceededMaxRetries;
+    public final long exceededTotalTimeout;
 
-	// ── Extended cluster-level metrics ──────────────────────────────
+    // Extended cluster-level metrics.
 
-	public final double cpuPercent;
-	public final long memoryBytes;
-	public final long commandCount;
+    public final double cpuPercent;
+    public final long memoryBytes;
+    public final long commandCount;
 
-	// ── Event loop snapshots (Java-specific) ───────────────────────
+    // Event loop snapshots (Java-specific).
 
-	public final List<EventLoopSnapshot> eventLoops;
+    public final List<EventLoopSnapshot> eventLoops;
 
-	// ── Per-node and cluster-aggregated snapshots ──────────────────
+    // Per-node and cluster-aggregated snapshots.
 
-	public final List<NodeSnapshot> nodes;
-	public final NodeSnapshot clusterAggregated;
+    public final List<NodeSnapshot> nodes;
+    public final NodeSnapshot clusterAggregated;
 
-	// ── Histogram configuration ────────────────────────────────────
+    // Histogram configuration.
 
-	public final HistogramType histogramType;
-	public final LatencyUnit latencyUnit;
-	public final int latencyBase;
-	public final int latencyColumns;
+    public final HistogramType histogramType;
+    public final LatencyUnit latencyUnit;
+    public final int latencyBase;
+    public final int latencyColumns;
 
-	public MetricsSnapshot(
-		Instant timestamp,
-		boolean extendedMetricsEnabled,
-		String clusterName,
-		String clientType,
-		String clientVersion,
-		String appId,
-		Map<String, String> labels,
-		int recoverQueueSize,
-		int invalidNodeCount,
-		long retryCount,
-		long delayQueueTimeoutCount,
-		int totalNodes,
-		long openConnections,
-		long exceededMaxRetries,
-		long exceededTotalTimeout,
-		double cpuPercent,
-		long memoryBytes,
-		long commandCount,
-		List<EventLoopSnapshot> eventLoops,
-		List<NodeSnapshot> nodes,
-		NodeSnapshot clusterAggregated,
-		HistogramType histogramType,
-		LatencyUnit latencyUnit,
-		int latencyBase,
-		int latencyColumns
-	) {
-		this.timestamp = timestamp;
-		this.extendedMetricsEnabled = extendedMetricsEnabled;
-		this.clusterName = clusterName;
-		this.clientType = clientType;
-		this.clientVersion = clientVersion;
-		this.appId = appId;
-		this.labels = labels != null
-			? Collections.unmodifiableMap(new HashMap<>(labels))
-			: Collections.emptyMap();
-		this.recoverQueueSize = recoverQueueSize;
-		this.invalidNodeCount = invalidNodeCount;
-		this.retryCount = retryCount;
-		this.delayQueueTimeoutCount = delayQueueTimeoutCount;
-		this.totalNodes = totalNodes;
-		this.openConnections = openConnections;
-		this.exceededMaxRetries = exceededMaxRetries;
-		this.exceededTotalTimeout = exceededTotalTimeout;
-		this.cpuPercent = cpuPercent;
-		this.memoryBytes = memoryBytes;
-		this.commandCount = commandCount;
-		this.eventLoops = Collections.unmodifiableList(new ArrayList<>(eventLoops));
-		this.nodes = Collections.unmodifiableList(new ArrayList<>(nodes));
-		this.clusterAggregated = clusterAggregated;
-		this.histogramType = histogramType;
-		this.latencyUnit = latencyUnit;
-		this.latencyBase = latencyBase;
-		this.latencyColumns = latencyColumns;
-	}
+    public MetricsSnapshot(
+            Instant timestamp,
+            boolean extendedMetricsEnabled,
+            String clusterName,
+            String clientType,
+            String clientVersion,
+            String appId,
+            Map<String, String> labels,
+            int recoverQueueSize,
+            int invalidNodeCount,
+            long retryCount,
+            long delayQueueTimeoutCount,
+            int totalNodes,
+            long openConnections,
+            long exceededMaxRetries,
+            long exceededTotalTimeout,
+            double cpuPercent,
+            long memoryBytes,
+            long commandCount,
+            List<EventLoopSnapshot> eventLoops,
+            List<NodeSnapshot> nodes,
+            NodeSnapshot clusterAggregated,
+            HistogramType histogramType,
+            LatencyUnit latencyUnit,
+            int latencyBase,
+            int latencyColumns
+    ) {
+        this.timestamp = timestamp;
+        this.extendedMetricsEnabled = extendedMetricsEnabled;
+        this.clusterName = clusterName;
+        this.clientType = clientType;
+        this.clientVersion = clientVersion;
+        this.appId = appId;
+        this.labels = labels != null
+                ? Collections.unmodifiableMap(new HashMap<>(labels))
+                : Collections.emptyMap();
+        this.recoverQueueSize = recoverQueueSize;
+        this.invalidNodeCount = invalidNodeCount;
+        this.retryCount = retryCount;
+        this.delayQueueTimeoutCount = delayQueueTimeoutCount;
+        this.totalNodes = totalNodes;
+        this.openConnections = openConnections;
+        this.exceededMaxRetries = exceededMaxRetries;
+        this.exceededTotalTimeout = exceededTotalTimeout;
+        this.cpuPercent = cpuPercent;
+        this.memoryBytes = memoryBytes;
+        this.commandCount = commandCount;
+        this.eventLoops = Collections.unmodifiableList(new ArrayList<>(eventLoops));
+        this.nodes = Collections.unmodifiableList(new ArrayList<>(nodes));
+        this.clusterAggregated = clusterAggregated;
+        this.histogramType = histogramType;
+        this.latencyUnit = latencyUnit;
+        this.latencyBase = latencyBase;
+        this.latencyColumns = latencyColumns;
+    }
 
-	// ── Inner classes ──────────────────────────────────────────────
+    // Inner classes.
 
-	/**
-	 * Metrics snapshot for a single cluster node. Counter fields are cumulative
-	 * unless their names describe a current gauge.
-	 */
-	public static final class NodeSnapshot {
-		public final String nodeName;
-		public final String nodeAddress;
-		public final int nodePort;
+    /**
+     * Metrics snapshot for a single cluster node. Counter fields are cumulative
+     * unless their names describe a current gauge.
+     */
+    public static final class NodeSnapshot {
+        public final String nodeName;
+        public final String nodeAddress;
+        public final int nodePort;
 
-		/** Standard connection pool metrics for synchronous connections. */
-		public final ConnectionSnapshot syncConnections;
+        /**
+         * Standard connection pool metrics for synchronous connections.
+         */
+        public final ConnectionSnapshot syncConnections;
 
-		/** Standard connection pool metrics for asynchronous connections. */
-		public final ConnectionSnapshot asyncConnections;
+        /**
+         * Standard connection pool metrics for asynchronous connections.
+         */
+        public final ConnectionSnapshot asyncConnections;
 
-		/**
-		 * Reserved: total connection attempts to this node since node creation.
-		 * Not tracked by the Java client. Defined in the Rust reference model.
-		 * Currently always 0.
-		 */
-		public final long connectionAttempts;
+        /**
+         * Reserved: total connection attempts to this node since node creation.
+         * Not tracked by the Java client. Defined in the Rust reference model.
+         * Currently always 0.
+         */
+        public final long connectionAttempts;
 
-		/**
-		 * Reserved: successful connection attempts to this node.
-		 * Not tracked by the Java client. Defined in the Rust reference model.
-		 * Currently always 0.
-		 */
-		public final long connectionsSuccessful;
+        /**
+         * Reserved: successful connection attempts to this node.
+         * Not tracked by the Java client. Defined in the Rust reference model.
+         * Currently always 0.
+         */
+        public final long connectionsSuccessful;
 
-		/**
-		 * Reserved: failed connection attempts to this node.
-		 * Not tracked by the Java client. Defined in the Rust reference model.
-		 * Currently always 0.
-		 */
-		public final long connectionsFailed;
+        /**
+         * Reserved: failed connection attempts to this node.
+         * Not tracked by the Java client. Defined in the Rust reference model.
+         * Currently always 0.
+         */
+        public final long connectionsFailed;
 
-		/**
-		 * Reserved: connection timeout errors for this node.
-		 * Not tracked by the Java client. Defined in the Rust reference model.
-		 * Currently always 0.
-		 */
-		public final long connectionTimeoutErrors;
+        /**
+         * Reserved: connection timeout errors for this node.
+         * Not tracked by the Java client. Defined in the Rust reference model.
+         * Currently always 0.
+         */
+        public final long connectionTimeoutErrors;
 
-		/**
-		 * Reserved: non-timeout connection errors for this node.
-		 * Not tracked by the Java client. Defined in the Rust reference model.
-		 * Currently always 0.
-		 */
-		public final long connectionOtherErrors;
+        /**
+         * Reserved: non-timeout connection errors for this node.
+         * Not tracked by the Java client. Defined in the Rust reference model.
+         * Currently always 0.
+         */
+        public final long connectionOtherErrors;
 
-		/**
-		 * Reserved: circuit breaker hit count for this node.
-		 * Not tracked by the Java client. Defined in the Rust reference model.
-		 * Currently always 0.
-		 */
-		public final long circuitBreakerHits;
+        /**
+         * Reserved: circuit breaker hit count for this node.
+         * Not tracked by the Java client. Defined in the Rust reference model.
+         * Currently always 0.
+         */
+        public final long circuitBreakerHits;
 
-		/**
-		 * Reserved: count of times a connection was requested but the pool was empty.
-		 * Not tracked by the Java client. Defined in the Rust reference model.
-		 * Currently always 0.
-		 */
-		public final long connectionPoolEmptyCount;
+        /**
+         * Reserved: count of times a connection was requested but the pool was empty.
+         * Not tracked by the Java client. Defined in the Rust reference model.
+         * Currently always 0.
+         */
+        public final long connectionPoolEmptyCount;
 
-		/**
-		 * Reserved: count of times a connection was returned but the pool was full.
-		 * Not tracked by the Java client. Defined in the Rust reference model.
-		 * Currently always 0.
-		 */
-		public final long connectionPoolOverflowCount;
+        /**
+         * Reserved: count of times a connection was returned but the pool was full.
+         * Not tracked by the Java client. Defined in the Rust reference model.
+         * Currently always 0.
+         */
+        public final long connectionPoolOverflowCount;
 
-		/**
-		 * Reserved: count of idle connections dropped from the pool.
-		 * Not tracked by the Java client. Defined in the Rust reference model.
-		 * Currently always 0.
-		 */
-		public final long idleConnectionsDropped;
+        /**
+         * Reserved: count of idle connections dropped from the pool.
+         * Not tracked by the Java client. Defined in the Rust reference model.
+         * Currently always 0.
+         */
+        public final long idleConnectionsDropped;
 
-		/**
-		 * Current number of open connections to this node.
-		 * Calculated as syncConnections.inUse + syncConnections.inPool
-		 * + asyncConnections.inUse + asyncConnections.inPool.
-		 */
-		public final long openConnections;
+        /**
+         * Current number of open connections to this node.
+         * Calculated as syncConnections.inUse + syncConnections.inPool
+         * + asyncConnections.inUse + asyncConnections.inPool.
+         */
+        public final long openConnections;
 
-		/**
-		 * Reserved: node-level aggregate of closed connections.
-		 * Per-pool closed counts are available via {@link #syncConnections} and
-		 * {@link #asyncConnections} ({@code ConnectionSnapshot.closed}).
-		 * This field is reserved for a separate node-level aggregate not currently
-		 * tracked by the Java client. Currently always 0.
-		 */
-		public final long closedConnections;
+        /**
+         * Reserved: node-level aggregate of closed connections.
+         * Per-pool closed counts are available via {@link #syncConnections} and
+         * {@link #asyncConnections} ({@code ConnectionSnapshot.closed}).
+         * This field is reserved for a separate node-level aggregate not currently
+         * tracked by the Java client. Currently always 0.
+         */
+        public final long closedConnections;
 
-		/**
-		 * Reserved: count of connections recovered after transient errors.
-		 * Not tracked by the Java client. Defined in the Rust reference model.
-		 * Currently always 0.
-		 */
-		public final long recoveredConnections;
+        /**
+         * Reserved: count of connections recovered after transient errors.
+         * Not tracked by the Java client. Defined in the Rust reference model.
+         * Currently always 0.
+         */
+        public final long recoveredConnections;
 
-		/**
-		 * Reserved: total tend cycles executed for this node.
-		 * Tend counters are not tracked per-node in the Java client.
-		 * Currently always 0.
-		 */
-		public final long tendsTotal;
+        /**
+         * Reserved: total tend cycles executed for this node.
+         * Tend counters are not tracked per-node in the Java client.
+         * Currently always 0.
+         */
+        public final long tendsTotal;
 
-		/**
-		 * Reserved: successful tend cycles for this node.
-		 * Tend counters are not tracked per-node in the Java client.
-		 * Currently always 0.
-		 */
-		public final long tendsSuccessful;
+        /**
+         * Reserved: successful tend cycles for this node.
+         * Tend counters are not tracked per-node in the Java client.
+         * Currently always 0.
+         */
+        public final long tendsSuccessful;
 
-		/**
-		 * Reserved: failed tend cycles for this node.
-		 * Tend counters are not tracked per-node in the Java client.
-		 * Currently always 0.
-		 */
-		public final long tendsFailed;
+        /**
+         * Reserved: failed tend cycles for this node.
+         * Tend counters are not tracked per-node in the Java client.
+         * Currently always 0.
+         */
+        public final long tendsFailed;
 
-		/**
-		 * Reserved: number of partition map updates received for this node.
-		 * Not tracked per-node in the Java client. Defined in the Rust reference model.
-		 * Currently always 0.
-		 */
-		public final long partitionMapUpdates;
+        /**
+         * Reserved: number of partition map updates received for this node.
+         * Not tracked per-node in the Java client. Defined in the Rust reference model.
+         * Currently always 0.
+         */
+        public final long partitionMapUpdates;
 
-		/**
-		 * Reserved: number of times nodes were added to the cluster during tending.
-		 * Not tracked per-node in the Java client. Defined in the Rust reference model.
-		 * Currently always 0.
-		 */
-		public final long nodesAdded;
+        /**
+         * Reserved: number of times nodes were added to the cluster during tending.
+         * Not tracked per-node in the Java client. Defined in the Rust reference model.
+         * Currently always 0.
+         */
+        public final long nodesAdded;
 
-		/**
-		 * Reserved: number of times nodes were removed from the cluster during tending.
-		 * Not tracked per-node in the Java client. Defined in the Rust reference model.
-		 * Currently always 0.
-		 */
-		public final long nodesRemoved;
+        /**
+         * Reserved: number of times nodes were removed from the cluster during tending.
+         * Not tracked per-node in the Java client. Defined in the Rust reference model.
+         * Currently always 0.
+         */
+        public final long nodesRemoved;
 
-		/**
-		 * Reserved: per-node transaction retry count.
-		 * Not tracked separately from the cluster-level {@link MetricsSnapshot#retryCount}.
-		 * Currently always 0.
-		 */
-		public final long transactionRetryCount;
+        /**
+         * Reserved: per-node transaction retry count.
+         * Not tracked separately from the cluster-level {@link MetricsSnapshot#retryCount}.
+         * Currently always 0.
+         */
+        public final long transactionRetryCount;
 
-		/**
-		 * Reserved: per-node transaction error count.
-		 * Not tracked separately from per-namespace error counters.
-		 * Currently always 0.
-		 */
-		public final long transactionErrorCount;
+        /**
+         * Reserved: per-node transaction error count.
+         * Not tracked separately from per-namespace error counters.
+         * Currently always 0.
+         */
+        public final long transactionErrorCount;
 
-		/**
-		 * Reserved: detailed per-command-type latency histograms (GET, PUT, DELETE, etc.).
-		 * Requires client-side instrumentation of command hot paths to populate.
-		 * Currently always an empty map. The fine-grained {@link CommandType} categories
-		 * will replace the legacy broad categories (CONN, READ, WRITE, BATCH, QUERY)
-		 * available in {@link NamespaceSnapshot#compatibilityLatencies}.
-		 */
-		public final Map<CommandType, HistogramSnapshot> commandLatencies;
+        /**
+         * Reserved: detailed per-command-type latency histograms (GET, PUT, DELETE, etc.).
+         * Requires client-side instrumentation of command hot paths to populate.
+         * Currently always an empty map. The fine-grained {@link CommandType} categories
+         * will replace the legacy broad categories (CONN, READ, WRITE, BATCH, QUERY)
+         * available in {@link NamespaceSnapshot#compatibilityLatencies}.
+         */
+        public final Map<CommandType, HistogramSnapshot> commandLatencies;
 
-		/**
-		 * Extended: per-namespace metrics for this node. Only populated when
-		 * {@link MetricsPolicy#enableExtendedMetrics} is {@code true}.
-		 */
-		public final List<NamespaceSnapshot> namespaces;
+        /**
+         * Extended: per-namespace metrics for this node. Only populated when
+         * {@link MetricsPolicy#enableExtendedMetrics} is {@code true}.
+         */
+        public final List<NamespaceSnapshot> namespaces;
 
-		public NodeSnapshot(
-			String nodeName,
-			String nodeAddress,
-			int nodePort,
-			ConnectionSnapshot syncConnections,
-			ConnectionSnapshot asyncConnections,
-			long connectionAttempts,
-			long connectionsSuccessful,
-			long connectionsFailed,
-			long connectionTimeoutErrors,
-			long connectionOtherErrors,
-			long circuitBreakerHits,
-			long connectionPoolEmptyCount,
-			long connectionPoolOverflowCount,
-			long idleConnectionsDropped,
-			long openConnections,
-			long closedConnections,
-			long recoveredConnections,
-			long tendsTotal,
-			long tendsSuccessful,
-			long tendsFailed,
-			long partitionMapUpdates,
-			long nodesAdded,
-			long nodesRemoved,
-			long transactionRetryCount,
-			long transactionErrorCount,
-			Map<CommandType, HistogramSnapshot> commandLatencies,
-			List<NamespaceSnapshot> namespaces
-		) {
-			this.nodeName = nodeName;
-			this.nodeAddress = nodeAddress;
-			this.nodePort = nodePort;
-			this.syncConnections = syncConnections;
-			this.asyncConnections = asyncConnections;
-			this.connectionAttempts = connectionAttempts;
-			this.connectionsSuccessful = connectionsSuccessful;
-			this.connectionsFailed = connectionsFailed;
-			this.connectionTimeoutErrors = connectionTimeoutErrors;
-			this.connectionOtherErrors = connectionOtherErrors;
-			this.circuitBreakerHits = circuitBreakerHits;
-			this.connectionPoolEmptyCount = connectionPoolEmptyCount;
-			this.connectionPoolOverflowCount = connectionPoolOverflowCount;
-			this.idleConnectionsDropped = idleConnectionsDropped;
-			this.openConnections = openConnections;
-			this.closedConnections = closedConnections;
-			this.recoveredConnections = recoveredConnections;
-			this.tendsTotal = tendsTotal;
-			this.tendsSuccessful = tendsSuccessful;
-			this.tendsFailed = tendsFailed;
-			this.partitionMapUpdates = partitionMapUpdates;
-			this.nodesAdded = nodesAdded;
-			this.nodesRemoved = nodesRemoved;
-			this.transactionRetryCount = transactionRetryCount;
-			this.transactionErrorCount = transactionErrorCount;
-			this.commandLatencies = Collections.unmodifiableMap(new HashMap<>(commandLatencies));
-			this.namespaces = Collections.unmodifiableList(new ArrayList<>(namespaces));
-		}
-	}
+        public NodeSnapshot(
+                String nodeName,
+                String nodeAddress,
+                int nodePort,
+                ConnectionSnapshot syncConnections,
+                ConnectionSnapshot asyncConnections,
+                long connectionAttempts,
+                long connectionsSuccessful,
+                long connectionsFailed,
+                long connectionTimeoutErrors,
+                long connectionOtherErrors,
+                long circuitBreakerHits,
+                long connectionPoolEmptyCount,
+                long connectionPoolOverflowCount,
+                long idleConnectionsDropped,
+                long openConnections,
+                long closedConnections,
+                long recoveredConnections,
+                long tendsTotal,
+                long tendsSuccessful,
+                long tendsFailed,
+                long partitionMapUpdates,
+                long nodesAdded,
+                long nodesRemoved,
+                long transactionRetryCount,
+                long transactionErrorCount,
+                Map<CommandType, HistogramSnapshot> commandLatencies,
+                List<NamespaceSnapshot> namespaces
+        ) {
+            this.nodeName = nodeName;
+            this.nodeAddress = nodeAddress;
+            this.nodePort = nodePort;
+            this.syncConnections = syncConnections;
+            this.asyncConnections = asyncConnections;
+            this.connectionAttempts = connectionAttempts;
+            this.connectionsSuccessful = connectionsSuccessful;
+            this.connectionsFailed = connectionsFailed;
+            this.connectionTimeoutErrors = connectionTimeoutErrors;
+            this.connectionOtherErrors = connectionOtherErrors;
+            this.circuitBreakerHits = circuitBreakerHits;
+            this.connectionPoolEmptyCount = connectionPoolEmptyCount;
+            this.connectionPoolOverflowCount = connectionPoolOverflowCount;
+            this.idleConnectionsDropped = idleConnectionsDropped;
+            this.openConnections = openConnections;
+            this.closedConnections = closedConnections;
+            this.recoveredConnections = recoveredConnections;
+            this.tendsTotal = tendsTotal;
+            this.tendsSuccessful = tendsSuccessful;
+            this.tendsFailed = tendsFailed;
+            this.partitionMapUpdates = partitionMapUpdates;
+            this.nodesAdded = nodesAdded;
+            this.nodesRemoved = nodesRemoved;
+            this.transactionRetryCount = transactionRetryCount;
+            this.transactionErrorCount = transactionErrorCount;
+            this.commandLatencies = Collections.unmodifiableMap(new HashMap<>(commandLatencies));
+            this.namespaces = Collections.unmodifiableList(new ArrayList<>(namespaces));
+        }
+    }
 
-	/**
-	 * Standard connection pool statistics.
-	 */
-	public static final class ConnectionSnapshot {
-		public final int inUse;
-		public final int inPool;
-		public final int opened;
-		public final int closed;
+    /**
+     * Standard connection pool statistics.
+     */
+    public static final class ConnectionSnapshot {
+        public final int inUse;
+        public final int inPool;
+        public final int opened;
+        public final int closed;
 
-		public ConnectionSnapshot(int inUse, int inPool, int opened, int closed) {
-			this.inUse = inUse;
-			this.inPool = inPool;
-			this.opened = opened;
-			this.closed = closed;
-		}
-	}
+        public ConnectionSnapshot(int inUse, int inPool, int opened, int closed) {
+            this.inUse = inUse;
+            this.inPool = inPool;
+            this.opened = opened;
+            this.closed = closed;
+        }
+    }
 
-	/**
-	 * Java event-loop measurements.
-	 */
-	public static final class EventLoopSnapshot {
-		public final int processSize;
-		public final int queueSize;
+    /**
+     * Java event-loop measurements.
+     */
+    public static final class EventLoopSnapshot {
+        public final int processSize;
+        public final int queueSize;
 
-		public EventLoopSnapshot(int processSize, int queueSize) {
-			this.processSize = processSize;
-			this.queueSize = queueSize;
-		}
-	}
+        public EventLoopSnapshot(int processSize, int queueSize) {
+            this.processSize = processSize;
+            this.queueSize = queueSize;
+        }
+    }
 
-	/**
-	 * Extended metrics for one namespace on one node.
-	 */
-	public static final class NamespaceSnapshot {
-		public final String namespace;
-		public final long errors;
-		public final long timeouts;
-		public final long keyBusy;
-		public final long bytesIn;
-		public final long bytesOut;
+    /**
+     * Extended metrics for one namespace on one node.
+     */
+    public static final class NamespaceSnapshot {
+        public final String namespace;
+        public final long errors;
+        public final long timeouts;
+        public final long keyBusy;
+        public final long bytesIn;
+        public final long bytesOut;
 
-		/**
-		 * Compatibility latency histograms for broad operation types
-		 * (conn, read, write, batch, query).
-		 */
-		public final Map<LatencyType, HistogramSnapshot> compatibilityLatencies;
+        /**
+         * Compatibility latency histograms for broad operation types
+         * (conn, read, write, batch, query).
+         */
+        public final Map<LatencyType, HistogramSnapshot> compatibilityLatencies;
 
-		/**
-		 * Detailed sampled measurements by command type.
-		 * Empty when no detailed measurements are available.
-		 */
-		public final Map<CommandType, CommandSnapshot> commands;
+        /**
+         * Detailed sampled measurements by command type.
+         * Empty when no detailed measurements are available.
+         */
+        public final Map<CommandType, CommandSnapshot> commands;
 
-		public NamespaceSnapshot(
-			String namespace,
-			long errors,
-			long timeouts,
-			long keyBusy,
-			long bytesIn,
-			long bytesOut,
-			Map<LatencyType, HistogramSnapshot> compatibilityLatencies,
-			Map<CommandType, CommandSnapshot> commands
-		) {
-			this.namespace = namespace;
-			this.errors = errors;
-			this.timeouts = timeouts;
-			this.keyBusy = keyBusy;
-			this.bytesIn = bytesIn;
-			this.bytesOut = bytesOut;
-			this.compatibilityLatencies = Collections.unmodifiableMap(new HashMap<>(compatibilityLatencies));
-			this.commands = Collections.unmodifiableMap(new HashMap<>(commands));
-		}
-	}
+        public NamespaceSnapshot(
+                String namespace,
+                long errors,
+                long timeouts,
+                long keyBusy,
+                long bytesIn,
+                long bytesOut,
+                Map<LatencyType, HistogramSnapshot> compatibilityLatencies,
+                Map<CommandType, CommandSnapshot> commands
+        ) {
+            this.namespace = namespace;
+            this.errors = errors;
+            this.timeouts = timeouts;
+            this.keyBusy = keyBusy;
+            this.bytesIn = bytesIn;
+            this.bytesOut = bytesOut;
+            this.compatibilityLatencies = Collections.unmodifiableMap(new HashMap<>(compatibilityLatencies));
+            this.commands = Collections.unmodifiableMap(new HashMap<>(commands));
+        }
+    }
 
-	/**
-	 * Reserved: detailed sampled measurements for one command type within a namespace.
-	 * <p>
-	 * Requires per-command phase-level timing instrumentation (connection acquisition,
-	 * request write, response parse) in the client command pipeline. These measurements
-	 * are defined in the Rust reference model and are not yet implemented in the Java client.
-	 * <p>
-	 * Fields in this class will be populated when the client team adds the necessary
-	 * instrumentation to command hot paths (SyncCommand, NioCommand, NettyCommand, etc.).
-	 */
-	public static final class CommandSnapshot {
-		public final CommandType commandType;
-		public final HistogramSnapshot connectionAcquisition;
-		public final HistogramSnapshot requestWrite;
-		public final HistogramSnapshot responseParse;
-		public final HistogramSnapshot latency;
-		public final HistogramSnapshot bytesSent;
-		public final HistogramSnapshot bytesReceived;
-		public final long retryCount;
-		public final long errorCount;
-		public final Map<Integer, Long> resultCodeCounts;
+    /**
+     * Reserved: detailed sampled measurements for one command type within a namespace.
+     * <p>
+     * Requires per-command phase-level timing instrumentation (connection acquisition,
+     * request write, response parse) in the client command pipeline. These measurements
+     * are defined in the Rust reference model and are not yet implemented in the Java client.
+     * <p>
+     * Fields in this class will be populated when the client team adds the necessary
+     * instrumentation to command hot paths (SyncCommand, NioCommand, NettyCommand, etc.).
+     */
+    public static final class CommandSnapshot {
+        public final CommandType commandType;
+        public final HistogramSnapshot connectionAcquisition;
+        public final HistogramSnapshot requestWrite;
+        public final HistogramSnapshot responseParse;
+        public final HistogramSnapshot latency;
+        public final HistogramSnapshot bytesSent;
+        public final HistogramSnapshot bytesReceived;
+        public final long retryCount;
+        public final long errorCount;
+        public final Map<Integer, Long> resultCodeCounts;
 
-		public CommandSnapshot(
-			CommandType commandType,
-			HistogramSnapshot connectionAcquisition,
-			HistogramSnapshot requestWrite,
-			HistogramSnapshot responseParse,
-			HistogramSnapshot latency,
-			HistogramSnapshot bytesSent,
-			HistogramSnapshot bytesReceived,
-			long retryCount,
-			long errorCount,
-			Map<Integer, Long> resultCodeCounts
-		) {
-			this.commandType = commandType;
-			this.connectionAcquisition = connectionAcquisition;
-			this.requestWrite = requestWrite;
-			this.responseParse = responseParse;
-			this.latency = latency;
-			this.bytesSent = bytesSent;
-			this.bytesReceived = bytesReceived;
-			this.retryCount = retryCount;
-			this.errorCount = errorCount;
-			this.resultCodeCounts = Collections.unmodifiableMap(new HashMap<>(resultCodeCounts));
-		}
-	}
+        public CommandSnapshot(
+                CommandType commandType,
+                HistogramSnapshot connectionAcquisition,
+                HistogramSnapshot requestWrite,
+                HistogramSnapshot responseParse,
+                HistogramSnapshot latency,
+                HistogramSnapshot bytesSent,
+                HistogramSnapshot bytesReceived,
+                long retryCount,
+                long errorCount,
+                Map<Integer, Long> resultCodeCounts
+        ) {
+            this.commandType = commandType;
+            this.connectionAcquisition = connectionAcquisition;
+            this.requestWrite = requestWrite;
+            this.responseParse = responseParse;
+            this.latency = latency;
+            this.bytesSent = bytesSent;
+            this.bytesReceived = bytesReceived;
+            this.retryCount = retryCount;
+            this.errorCount = errorCount;
+            this.resultCodeCounts = Collections.unmodifiableMap(new HashMap<>(resultCodeCounts));
+        }
+    }
 
-	/**
-	 * Histogram bucket counts and summary statistics. Latency histograms use
-	 * {@link MetricsSnapshot#latencyUnit}; byte histograms use bytes.
-	 */
-	public static final class HistogramSnapshot {
-		private final long[] buckets;
-		public final long min;
-		public final long max;
-		public final double sum;
-		public final long count;
+    /**
+     * Histogram bucket counts and summary statistics. Latency histograms use
+     * {@link MetricsSnapshot#latencyUnit}; byte histograms use bytes.
+     */
+    public static final class HistogramSnapshot {
+        private final long[] buckets;
+        public final long min;
+        public final long max;
+        public final double sum;
+        public final long count;
 
-		public HistogramSnapshot(long[] buckets, long min, long max, double sum, long count) {
-			this.buckets = buckets.clone();
-			this.min = min;
-			this.max = max;
-			this.sum = sum;
-			this.count = count;
-		}
+        public HistogramSnapshot(long[] buckets, long min, long max, double sum, long count) {
+            this.buckets = buckets.clone();
+            this.min = min;
+            this.max = max;
+            this.sum = sum;
+            this.count = count;
+        }
 
-		public long[] getBuckets() {
-			return buckets.clone();
-		}
-	}
+        public long[] getBuckets() {
+            return buckets.clone();
+        }
+    }
 
-	// ── Enums ──────────────────────────────────────────────────────
+    // Enums.
 
-	public enum HistogramType {
-		LINEAR,
-		LOGARITHMIC
-	}
+    public enum HistogramType {
+        LINEAR,
+        LOGARITHMIC
+    }
 
-	public enum LatencyUnit {
-		MILLISECONDS,
-		MICROSECONDS
-	}
+    public enum LatencyUnit {
+        MILLISECONDS,
+        MICROSECONDS
+    }
 
-	public enum CommandType {
-		GET,
-		GET_HEADER,
-		EXISTS,
-		PUT,
-		DELETE,
-		OPERATE,
-		QUERY,
-		SCAN,
-		UDF,
-		BATCH_READ,
-		BATCH_WRITE
-	}
+    public enum CommandType {
+        GET,
+        GET_HEADER,
+        EXISTS,
+        PUT,
+        DELETE,
+        OPERATE,
+        QUERY,
+        SCAN,
+        UDF,
+        BATCH_READ,
+        BATCH_WRITE
+    }
 }

--- a/client/src/com/aerospike/client/metrics/MetricsSnapshotBuilder.java
+++ b/client/src/com/aerospike/client/metrics/MetricsSnapshotBuilder.java
@@ -1,0 +1,288 @@
+/*
+ * Copyright 2012-2026 Aerospike, Inc.
+ *
+ * Portions may be licensed to Aerospike, Inc. under one or more contributor
+ * license agreements WHICH ARE COMPATIBLE WITH THE APACHE LICENSE, VERSION 2.0.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.aerospike.client.metrics;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import com.aerospike.client.Host;
+import com.aerospike.client.async.EventLoop;
+import com.aerospike.client.cluster.Cluster;
+import com.aerospike.client.cluster.ConnectionStats;
+import com.aerospike.client.cluster.Node;
+import com.aerospike.client.policy.ClientPolicy;
+import com.aerospike.client.util.Util;
+
+/**
+ * Builds immutable point-in-time metrics snapshots from client state.
+ */
+final class MetricsSnapshotBuilder {
+	private final Cluster cluster;
+	private final MetricsPolicy policy;
+
+	MetricsSnapshotBuilder(Cluster cluster, MetricsPolicy policy) {
+		this.cluster = cluster;
+		this.policy = policy;
+	}
+
+	MetricsSnapshot build() {
+		Node[] clusterNodes = cluster.getNodes();
+		boolean extendedMetricsEnabled = policy.enableExtendedMetrics;
+		long totalOpenConnections = 0;
+		List<MetricsSnapshot.NodeSnapshot> nodeSnapshots = new ArrayList<>(clusterNodes.length);
+
+		for (Node node : clusterNodes) {
+			MetricsSnapshot.NodeSnapshot nodeSnapshot =
+				buildNodeSnapshot(node, extendedMetricsEnabled);
+			nodeSnapshots.add(nodeSnapshot);
+			totalOpenConnections += nodeSnapshot.openConnections;
+		}
+
+		MetricsSnapshot.NodeSnapshot aggregatedSnapshot =
+			buildAggregatedSnapshot(nodeSnapshots);
+		double cpuPercent = extendedMetricsEnabled ? Util.getProcessCpuLoad() : 0.0;
+		long usedMemoryBytes = extendedMetricsEnabled
+			? Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()
+			: 0L;
+		long commandCount = extendedMetricsEnabled ? cluster.getCommandCount() : 0L;
+		String clusterName = cluster.getClusterName();
+
+		if (clusterName == null) {
+			clusterName = "";
+		}
+
+		ClientPolicy clientPolicy = cluster.client.getClientPolicy();
+		String applicationId = clientPolicy.appId != null ? clientPolicy.appId : "";
+		int latencyBase = 1 << policy.latencyShift;
+
+		return new MetricsSnapshot(
+			Instant.now(),
+			extendedMetricsEnabled,
+			clusterName,
+			"java",
+			cluster.client.getVersion(),
+			applicationId,
+			policy.labels,
+			cluster.getRecoverQueueSize(),
+			cluster.getInvalidNodeCount(),
+			cluster.getRetryCount(),
+			cluster.getDelayQueueTimeoutCount(),
+			clusterNodes.length,
+			totalOpenConnections,
+			0, // exceededMaxRetries — not yet tracked by client
+			0, // exceededTotalTimeout — not yet tracked by client
+			cpuPercent,
+			usedMemoryBytes,
+			commandCount,
+			buildEventLoopSnapshots(),
+			nodeSnapshots,
+			aggregatedSnapshot,
+			MetricsSnapshot.HistogramType.LOGARITHMIC,
+			MetricsSnapshot.LatencyUnit.MILLISECONDS,
+			latencyBase,
+			policy.latencyColumns
+		);
+	}
+
+	private MetricsSnapshot.NodeSnapshot buildNodeSnapshot(
+		Node node,
+		boolean extendedMetricsEnabled
+	) {
+		Host nodeHost = node.getHost();
+		ConnectionStats syncStats = node.getConnectionStats();
+		ConnectionStats asyncStats = node.getAsyncConnectionStats();
+		MetricsSnapshot.ConnectionSnapshot syncSnapshot = buildConnectionSnapshot(syncStats);
+		MetricsSnapshot.ConnectionSnapshot asyncSnapshot = buildConnectionSnapshot(asyncStats);
+		long openConnections = (long)(syncStats.inUse + syncStats.inPool
+			+ asyncStats.inUse + asyncStats.inPool);
+		List<MetricsSnapshot.NamespaceSnapshot> namespaces = extendedMetricsEnabled
+			? buildNamespaceSnapshots(node)
+			: Collections.emptyList();
+
+		return new MetricsSnapshot.NodeSnapshot(
+			node.getName(),
+			nodeHost.name,
+			nodeHost.port,
+			syncSnapshot,
+			asyncSnapshot,
+			0, // connectionAttempts — not yet tracked
+			0, // connectionsSuccessful — not yet tracked
+			0, // connectionsFailed — not yet tracked
+			0, // connectionTimeoutErrors — not yet tracked
+			0, // connectionOtherErrors — not yet tracked
+			0, // circuitBreakerHits — not yet tracked
+			0, // connectionPoolEmptyCount — not yet tracked
+			0, // connectionPoolOverflowCount — not yet tracked
+			0, // idleConnectionsDropped — not yet tracked
+			openConnections,
+			0, // closedConnections — not yet tracked separately
+			0, // recoveredConnections — not yet tracked
+			0, // tendsTotal — not yet tracked per-node
+			0, // tendsSuccessful — not yet tracked per-node
+			0, // tendsFailed — not yet tracked per-node
+			0, // partitionMapUpdates — not yet tracked per-node
+			0, // nodesAdded — not yet tracked per-node
+			0, // nodesRemoved — not yet tracked per-node
+			0, // transactionRetryCount — not yet tracked per-node
+			0, // transactionErrorCount — not yet tracked per-node
+			Collections.emptyMap(),
+			namespaces
+		);
+	}
+
+	private MetricsSnapshot.ConnectionSnapshot buildConnectionSnapshot(ConnectionStats stats) {
+		return new MetricsSnapshot.ConnectionSnapshot(
+			stats.inUse, stats.inPool, stats.opened, stats.closed
+		);
+	}
+
+	private List<MetricsSnapshot.NamespaceSnapshot> buildNamespaceSnapshots(Node node) {
+		NodeMetrics nodeMetrics = node.getMetrics();
+
+		if (nodeMetrics == null) {
+			return Collections.emptyList();
+		}
+
+		Histograms histograms = nodeMetrics.getHistograms();
+		ConcurrentHashMap<String, LatencyBuckets[]> histogramsByNamespace =
+			histograms.getMap();
+		List<MetricsSnapshot.NamespaceSnapshot> namespaceSnapshots =
+			new ArrayList<>(histogramsByNamespace.size());
+		int latencyTypeCount = LatencyType.getMax();
+
+		for (Map.Entry<String, LatencyBuckets[]> entry : histogramsByNamespace.entrySet()) {
+			String namespace = entry.getKey();
+			LatencyBuckets[] latencyBucketsByType = entry.getValue();
+			Map<LatencyType, MetricsSnapshot.HistogramSnapshot> compatibilityLatencies =
+				new HashMap<>(latencyTypeCount);
+
+			for (int typeIndex = 0; typeIndex < latencyTypeCount; typeIndex++) {
+				LatencyType latencyType = LatencyType.values()[typeIndex];
+				LatencyBuckets buckets = latencyBucketsByType[typeIndex];
+				int bucketCount = buckets.getMax();
+				long[] bucketCounts = new long[bucketCount];
+				long totalCount = 0;
+
+				for (int bucketIndex = 0; bucketIndex < bucketCount; bucketIndex++) {
+					bucketCounts[bucketIndex] = buckets.getBucket(bucketIndex);
+					totalCount += bucketCounts[bucketIndex];
+				}
+
+				compatibilityLatencies.put(latencyType,
+					new MetricsSnapshot.HistogramSnapshot(
+						bucketCounts, 0, 0, 0.0, totalCount
+					)
+				);
+			}
+
+			namespaceSnapshots.add(new MetricsSnapshot.NamespaceSnapshot(
+				namespace,
+				node.getErrorCountByNS(namespace),
+				node.getTimeoutCountbyNS(namespace),
+				node.getKeyBusyCountByNS(namespace),
+				node.getBytesInByNS(namespace),
+				node.getBytesOutByNS(namespace),
+				compatibilityLatencies,
+				Collections.emptyMap()
+			));
+		}
+		return namespaceSnapshots;
+	}
+
+	private MetricsSnapshot.NodeSnapshot buildAggregatedSnapshot(
+		List<MetricsSnapshot.NodeSnapshot> nodeSnapshots
+	) {
+		int syncInUse = 0;
+		int syncInPool = 0;
+		int syncOpened = 0;
+		int syncClosed = 0;
+		int asyncInUse = 0;
+		int asyncInPool = 0;
+		int asyncOpened = 0;
+		int asyncClosed = 0;
+		long openConnections = 0;
+
+		for (MetricsSnapshot.NodeSnapshot node : nodeSnapshots) {
+			syncInUse += node.syncConnections.inUse;
+			syncInPool += node.syncConnections.inPool;
+			syncOpened += node.syncConnections.opened;
+			syncClosed += node.syncConnections.closed;
+			asyncInUse += node.asyncConnections.inUse;
+			asyncInPool += node.asyncConnections.inPool;
+			asyncOpened += node.asyncConnections.opened;
+			asyncClosed += node.asyncConnections.closed;
+			openConnections += node.openConnections;
+		}
+
+		return new MetricsSnapshot.NodeSnapshot(
+			"",
+			"",
+			0,
+			new MetricsSnapshot.ConnectionSnapshot(
+				syncInUse, syncInPool, syncOpened, syncClosed
+			),
+			new MetricsSnapshot.ConnectionSnapshot(
+				asyncInUse, asyncInPool, asyncOpened, asyncClosed
+			),
+			0, // connectionAttempts
+			0, // connectionsSuccessful
+			0, // connectionsFailed
+			0, // connectionTimeoutErrors
+			0, // connectionOtherErrors
+			0, // circuitBreakerHits
+			0, // connectionPoolEmptyCount
+			0, // connectionPoolOverflowCount
+			0, // idleConnectionsDropped
+			openConnections,
+			0, // closedConnections
+			0, // recoveredConnections
+			0, // tendsTotal
+			0, // tendsSuccessful
+			0, // tendsFailed
+			0, // partitionMapUpdates
+			0, // nodesAdded
+			0, // nodesRemoved
+			0, // transactionRetryCount
+			0, // transactionErrorCount
+			Collections.emptyMap(),
+			Collections.emptyList()
+		);
+	}
+
+	private List<MetricsSnapshot.EventLoopSnapshot> buildEventLoopSnapshots() {
+		EventLoop[] eventLoops = cluster.getEventLoopArray();
+
+		if (eventLoops == null) {
+			return Collections.emptyList();
+		}
+
+		List<MetricsSnapshot.EventLoopSnapshot> snapshots =
+			new ArrayList<>(eventLoops.length);
+
+		for (EventLoop eventLoop : eventLoops) {
+			snapshots.add(new MetricsSnapshot.EventLoopSnapshot(
+				eventLoop.getProcessSize(), eventLoop.getQueueSize()
+			));
+		}
+		return snapshots;
+	}
+}

--- a/client/src/com/aerospike/client/metrics/MetricsSnapshotBuilder.java
+++ b/client/src/com/aerospike/client/metrics/MetricsSnapshotBuilder.java
@@ -36,253 +36,253 @@ import com.aerospike.client.util.Util;
  * Builds immutable point-in-time metrics snapshots from client state.
  */
 final class MetricsSnapshotBuilder {
-	private final Cluster cluster;
-	private final MetricsPolicy policy;
+    private final Cluster cluster;
+    private final MetricsPolicy policy;
 
-	MetricsSnapshotBuilder(Cluster cluster, MetricsPolicy policy) {
-		this.cluster = cluster;
-		this.policy = policy;
-	}
+    MetricsSnapshotBuilder(Cluster cluster, MetricsPolicy policy) {
+        this.cluster = cluster;
+        this.policy = policy;
+    }
 
-	MetricsSnapshot build() {
-		Node[] clusterNodes = cluster.getNodes();
-		boolean extendedMetricsEnabled = policy.enableExtendedMetrics;
-		long totalOpenConnections = 0;
-		List<MetricsSnapshot.NodeSnapshot> nodeSnapshots = new ArrayList<>(clusterNodes.length);
+    MetricsSnapshot build() {
+        Node[] clusterNodes = cluster.getNodes();
+        boolean extendedMetricsEnabled = policy.enableExtendedMetrics;
+        long totalOpenConnections = 0;
+        List<MetricsSnapshot.NodeSnapshot> nodeSnapshots = new ArrayList<>(clusterNodes.length);
 
-		for (Node node : clusterNodes) {
-			MetricsSnapshot.NodeSnapshot nodeSnapshot =
-				buildNodeSnapshot(node, extendedMetricsEnabled);
-			nodeSnapshots.add(nodeSnapshot);
-			totalOpenConnections += nodeSnapshot.openConnections;
-		}
+        for (Node node : clusterNodes) {
+            MetricsSnapshot.NodeSnapshot nodeSnapshot =
+                    buildNodeSnapshot(node, extendedMetricsEnabled);
+            nodeSnapshots.add(nodeSnapshot);
+            totalOpenConnections += nodeSnapshot.openConnections;
+        }
 
-		MetricsSnapshot.NodeSnapshot aggregatedSnapshot =
-			buildAggregatedSnapshot(nodeSnapshots);
-		double cpuPercent = extendedMetricsEnabled ? Util.getProcessCpuLoad() : 0.0;
-		long usedMemoryBytes = extendedMetricsEnabled
-			? Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()
-			: 0L;
-		long commandCount = extendedMetricsEnabled ? cluster.getCommandCount() : 0L;
-		String clusterName = cluster.getClusterName();
+        MetricsSnapshot.NodeSnapshot aggregatedSnapshot =
+                buildAggregatedSnapshot(nodeSnapshots);
+        double cpuPercent = extendedMetricsEnabled ? Util.getProcessCpuLoad() : 0.0;
+        long usedMemoryBytes = extendedMetricsEnabled
+                ? Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()
+                : 0L;
+        long commandCount = extendedMetricsEnabled ? cluster.getCommandCount() : 0L;
+        String clusterName = cluster.getClusterName();
 
-		if (clusterName == null) {
-			clusterName = "";
-		}
+        if (clusterName == null) {
+            clusterName = "";
+        }
 
-		ClientPolicy clientPolicy = cluster.client.getClientPolicy();
-		String applicationId = clientPolicy.appId != null ? clientPolicy.appId : "";
-		int latencyBase = 1 << policy.latencyShift;
+        ClientPolicy clientPolicy = cluster.client.getClientPolicy();
+        String applicationId = clientPolicy.appId != null ? clientPolicy.appId : "";
+        int latencyBase = 1 << policy.latencyShift;
 
-		return new MetricsSnapshot(
-			Instant.now(),
-			extendedMetricsEnabled,
-			clusterName,
-			"java",
-			cluster.client.getVersion(),
-			applicationId,
-			policy.labels,
-			cluster.getRecoverQueueSize(),
-			cluster.getInvalidNodeCount(),
-			cluster.getRetryCount(),
-			cluster.getDelayQueueTimeoutCount(),
-			clusterNodes.length,
-			totalOpenConnections,
-			0, // exceededMaxRetries — not yet tracked by client
-			0, // exceededTotalTimeout — not yet tracked by client
-			cpuPercent,
-			usedMemoryBytes,
-			commandCount,
-			buildEventLoopSnapshots(),
-			nodeSnapshots,
-			aggregatedSnapshot,
-			MetricsSnapshot.HistogramType.LOGARITHMIC,
-			MetricsSnapshot.LatencyUnit.MILLISECONDS,
-			latencyBase,
-			policy.latencyColumns
-		);
-	}
+        return new MetricsSnapshot(
+                Instant.now(),
+                extendedMetricsEnabled,
+                clusterName,
+                "java",
+                cluster.client.getVersion(),
+                applicationId,
+                policy.labels,
+                cluster.getRecoverQueueSize(),
+                cluster.getInvalidNodeCount(),
+                cluster.getRetryCount(),
+                cluster.getDelayQueueTimeoutCount(),
+                clusterNodes.length,
+                totalOpenConnections,
+                0, // exceededMaxRetries — not yet tracked by client
+                0, // exceededTotalTimeout — not yet tracked by client
+                cpuPercent,
+                usedMemoryBytes,
+                commandCount,
+                buildEventLoopSnapshots(),
+                nodeSnapshots,
+                aggregatedSnapshot,
+                MetricsSnapshot.HistogramType.LOGARITHMIC,
+                MetricsSnapshot.LatencyUnit.MILLISECONDS,
+                latencyBase,
+                policy.latencyColumns
+        );
+    }
 
-	private MetricsSnapshot.NodeSnapshot buildNodeSnapshot(
-		Node node,
-		boolean extendedMetricsEnabled
-	) {
-		Host nodeHost = node.getHost();
-		ConnectionStats syncStats = node.getConnectionStats();
-		ConnectionStats asyncStats = node.getAsyncConnectionStats();
-		MetricsSnapshot.ConnectionSnapshot syncSnapshot = buildConnectionSnapshot(syncStats);
-		MetricsSnapshot.ConnectionSnapshot asyncSnapshot = buildConnectionSnapshot(asyncStats);
-		long openConnections = (long)(syncStats.inUse + syncStats.inPool
-			+ asyncStats.inUse + asyncStats.inPool);
-		List<MetricsSnapshot.NamespaceSnapshot> namespaces = extendedMetricsEnabled
-			? buildNamespaceSnapshots(node)
-			: Collections.emptyList();
+    private MetricsSnapshot.NodeSnapshot buildNodeSnapshot(
+            Node node,
+            boolean extendedMetricsEnabled
+    ) {
+        Host nodeHost = node.getHost();
+        ConnectionStats syncStats = node.getConnectionStats();
+        ConnectionStats asyncStats = node.getAsyncConnectionStats();
+        MetricsSnapshot.ConnectionSnapshot syncSnapshot = buildConnectionSnapshot(syncStats);
+        MetricsSnapshot.ConnectionSnapshot asyncSnapshot = buildConnectionSnapshot(asyncStats);
+        long openConnections = (long) (syncStats.inUse + syncStats.inPool
+                + asyncStats.inUse + asyncStats.inPool);
+        List<MetricsSnapshot.NamespaceSnapshot> namespaces = extendedMetricsEnabled
+                ? buildNamespaceSnapshots(node)
+                : Collections.emptyList();
 
-		return new MetricsSnapshot.NodeSnapshot(
-			node.getName(),
-			nodeHost.name,
-			nodeHost.port,
-			syncSnapshot,
-			asyncSnapshot,
-			0, // connectionAttempts — not yet tracked
-			0, // connectionsSuccessful — not yet tracked
-			0, // connectionsFailed — not yet tracked
-			0, // connectionTimeoutErrors — not yet tracked
-			0, // connectionOtherErrors — not yet tracked
-			0, // circuitBreakerHits — not yet tracked
-			0, // connectionPoolEmptyCount — not yet tracked
-			0, // connectionPoolOverflowCount — not yet tracked
-			0, // idleConnectionsDropped — not yet tracked
-			openConnections,
-			0, // closedConnections — not yet tracked separately
-			0, // recoveredConnections — not yet tracked
-			0, // tendsTotal — not yet tracked per-node
-			0, // tendsSuccessful — not yet tracked per-node
-			0, // tendsFailed — not yet tracked per-node
-			0, // partitionMapUpdates — not yet tracked per-node
-			0, // nodesAdded — not yet tracked per-node
-			0, // nodesRemoved — not yet tracked per-node
-			0, // transactionRetryCount — not yet tracked per-node
-			0, // transactionErrorCount — not yet tracked per-node
-			Collections.emptyMap(),
-			namespaces
-		);
-	}
+        return new MetricsSnapshot.NodeSnapshot(
+                node.getName(),
+                nodeHost.name,
+                nodeHost.port,
+                syncSnapshot,
+                asyncSnapshot,
+                0, // connectionAttempts — not yet tracked
+                0, // connectionsSuccessful — not yet tracked
+                0, // connectionsFailed — not yet tracked
+                0, // connectionTimeoutErrors — not yet tracked
+                0, // connectionOtherErrors — not yet tracked
+                0, // circuitBreakerHits — not yet tracked
+                0, // connectionPoolEmptyCount — not yet tracked
+                0, // connectionPoolOverflowCount — not yet tracked
+                0, // idleConnectionsDropped — not yet tracked
+                openConnections,
+                0, // closedConnections — not yet tracked separately
+                0, // recoveredConnections — not yet tracked
+                0, // tendsTotal — not yet tracked per-node
+                0, // tendsSuccessful — not yet tracked per-node
+                0, // tendsFailed — not yet tracked per-node
+                0, // partitionMapUpdates — not yet tracked per-node
+                0, // nodesAdded — not yet tracked per-node
+                0, // nodesRemoved — not yet tracked per-node
+                0, // transactionRetryCount — not yet tracked per-node
+                0, // transactionErrorCount — not yet tracked per-node
+                Collections.emptyMap(),
+                namespaces
+        );
+    }
 
-	private MetricsSnapshot.ConnectionSnapshot buildConnectionSnapshot(ConnectionStats stats) {
-		return new MetricsSnapshot.ConnectionSnapshot(
-			stats.inUse, stats.inPool, stats.opened, stats.closed
-		);
-	}
+    private MetricsSnapshot.ConnectionSnapshot buildConnectionSnapshot(ConnectionStats stats) {
+        return new MetricsSnapshot.ConnectionSnapshot(
+                stats.inUse, stats.inPool, stats.opened, stats.closed
+        );
+    }
 
-	private List<MetricsSnapshot.NamespaceSnapshot> buildNamespaceSnapshots(Node node) {
-		NodeMetrics nodeMetrics = node.getMetrics();
+    private List<MetricsSnapshot.NamespaceSnapshot> buildNamespaceSnapshots(Node node) {
+        NodeMetrics nodeMetrics = node.getMetrics();
 
-		if (nodeMetrics == null) {
-			return Collections.emptyList();
-		}
+        if (nodeMetrics == null) {
+            return Collections.emptyList();
+        }
 
-		Histograms histograms = nodeMetrics.getHistograms();
-		ConcurrentHashMap<String, LatencyBuckets[]> histogramsByNamespace =
-			histograms.getMap();
-		List<MetricsSnapshot.NamespaceSnapshot> namespaceSnapshots =
-			new ArrayList<>(histogramsByNamespace.size());
-		int latencyTypeCount = LatencyType.getMax();
+        Histograms histograms = nodeMetrics.getHistograms();
+        ConcurrentHashMap<String, LatencyBuckets[]> histogramsByNamespace =
+                histograms.getMap();
+        List<MetricsSnapshot.NamespaceSnapshot> namespaceSnapshots =
+                new ArrayList<>(histogramsByNamespace.size());
+        int latencyTypeCount = LatencyType.getMax();
 
-		for (Map.Entry<String, LatencyBuckets[]> entry : histogramsByNamespace.entrySet()) {
-			String namespace = entry.getKey();
-			LatencyBuckets[] latencyBucketsByType = entry.getValue();
-			Map<LatencyType, MetricsSnapshot.HistogramSnapshot> compatibilityLatencies =
-				new HashMap<>(latencyTypeCount);
+        for (Map.Entry<String, LatencyBuckets[]> entry : histogramsByNamespace.entrySet()) {
+            String namespace = entry.getKey();
+            LatencyBuckets[] latencyBucketsByType = entry.getValue();
+            Map<LatencyType, MetricsSnapshot.HistogramSnapshot> compatibilityLatencies =
+                    new HashMap<>(latencyTypeCount);
 
-			for (int typeIndex = 0; typeIndex < latencyTypeCount; typeIndex++) {
-				LatencyType latencyType = LatencyType.values()[typeIndex];
-				LatencyBuckets buckets = latencyBucketsByType[typeIndex];
-				int bucketCount = buckets.getMax();
-				long[] bucketCounts = new long[bucketCount];
-				long totalCount = 0;
+            for (int typeIndex = 0; typeIndex < latencyTypeCount; typeIndex++) {
+                LatencyType latencyType = LatencyType.values()[typeIndex];
+                LatencyBuckets buckets = latencyBucketsByType[typeIndex];
+                int bucketCount = buckets.getMax();
+                long[] bucketCounts = new long[bucketCount];
+                long totalCount = 0;
 
-				for (int bucketIndex = 0; bucketIndex < bucketCount; bucketIndex++) {
-					bucketCounts[bucketIndex] = buckets.getBucket(bucketIndex);
-					totalCount += bucketCounts[bucketIndex];
-				}
+                for (int bucketIndex = 0; bucketIndex < bucketCount; bucketIndex++) {
+                    bucketCounts[bucketIndex] = buckets.getBucket(bucketIndex);
+                    totalCount += bucketCounts[bucketIndex];
+                }
 
-				compatibilityLatencies.put(latencyType,
-					new MetricsSnapshot.HistogramSnapshot(
-						bucketCounts, 0, 0, 0.0, totalCount
-					)
-				);
-			}
+                compatibilityLatencies.put(latencyType,
+                        new MetricsSnapshot.HistogramSnapshot(
+                                bucketCounts, 0, 0, 0.0, totalCount
+                        )
+                );
+            }
 
-			namespaceSnapshots.add(new MetricsSnapshot.NamespaceSnapshot(
-				namespace,
-				node.getErrorCountByNS(namespace),
-				node.getTimeoutCountbyNS(namespace),
-				node.getKeyBusyCountByNS(namespace),
-				node.getBytesInByNS(namespace),
-				node.getBytesOutByNS(namespace),
-				compatibilityLatencies,
-				Collections.emptyMap()
-			));
-		}
-		return namespaceSnapshots;
-	}
+            namespaceSnapshots.add(new MetricsSnapshot.NamespaceSnapshot(
+                    namespace,
+                    node.getErrorCountByNS(namespace),
+                    node.getTimeoutCountbyNS(namespace),
+                    node.getKeyBusyCountByNS(namespace),
+                    node.getBytesInByNS(namespace),
+                    node.getBytesOutByNS(namespace),
+                    compatibilityLatencies,
+                    Collections.emptyMap()
+            ));
+        }
+        return namespaceSnapshots;
+    }
 
-	private MetricsSnapshot.NodeSnapshot buildAggregatedSnapshot(
-		List<MetricsSnapshot.NodeSnapshot> nodeSnapshots
-	) {
-		int syncInUse = 0;
-		int syncInPool = 0;
-		int syncOpened = 0;
-		int syncClosed = 0;
-		int asyncInUse = 0;
-		int asyncInPool = 0;
-		int asyncOpened = 0;
-		int asyncClosed = 0;
-		long openConnections = 0;
+    private MetricsSnapshot.NodeSnapshot buildAggregatedSnapshot(
+            List<MetricsSnapshot.NodeSnapshot> nodeSnapshots
+    ) {
+        int syncInUse = 0;
+        int syncInPool = 0;
+        int syncOpened = 0;
+        int syncClosed = 0;
+        int asyncInUse = 0;
+        int asyncInPool = 0;
+        int asyncOpened = 0;
+        int asyncClosed = 0;
+        long openConnections = 0;
 
-		for (MetricsSnapshot.NodeSnapshot node : nodeSnapshots) {
-			syncInUse += node.syncConnections.inUse;
-			syncInPool += node.syncConnections.inPool;
-			syncOpened += node.syncConnections.opened;
-			syncClosed += node.syncConnections.closed;
-			asyncInUse += node.asyncConnections.inUse;
-			asyncInPool += node.asyncConnections.inPool;
-			asyncOpened += node.asyncConnections.opened;
-			asyncClosed += node.asyncConnections.closed;
-			openConnections += node.openConnections;
-		}
+        for (MetricsSnapshot.NodeSnapshot node : nodeSnapshots) {
+            syncInUse += node.syncConnections.inUse;
+            syncInPool += node.syncConnections.inPool;
+            syncOpened += node.syncConnections.opened;
+            syncClosed += node.syncConnections.closed;
+            asyncInUse += node.asyncConnections.inUse;
+            asyncInPool += node.asyncConnections.inPool;
+            asyncOpened += node.asyncConnections.opened;
+            asyncClosed += node.asyncConnections.closed;
+            openConnections += node.openConnections;
+        }
 
-		return new MetricsSnapshot.NodeSnapshot(
-			"",
-			"",
-			0,
-			new MetricsSnapshot.ConnectionSnapshot(
-				syncInUse, syncInPool, syncOpened, syncClosed
-			),
-			new MetricsSnapshot.ConnectionSnapshot(
-				asyncInUse, asyncInPool, asyncOpened, asyncClosed
-			),
-			0, // connectionAttempts
-			0, // connectionsSuccessful
-			0, // connectionsFailed
-			0, // connectionTimeoutErrors
-			0, // connectionOtherErrors
-			0, // circuitBreakerHits
-			0, // connectionPoolEmptyCount
-			0, // connectionPoolOverflowCount
-			0, // idleConnectionsDropped
-			openConnections,
-			0, // closedConnections
-			0, // recoveredConnections
-			0, // tendsTotal
-			0, // tendsSuccessful
-			0, // tendsFailed
-			0, // partitionMapUpdates
-			0, // nodesAdded
-			0, // nodesRemoved
-			0, // transactionRetryCount
-			0, // transactionErrorCount
-			Collections.emptyMap(),
-			Collections.emptyList()
-		);
-	}
+        return new MetricsSnapshot.NodeSnapshot(
+                "",
+                "",
+                0,
+                new MetricsSnapshot.ConnectionSnapshot(
+                        syncInUse, syncInPool, syncOpened, syncClosed
+                ),
+                new MetricsSnapshot.ConnectionSnapshot(
+                        asyncInUse, asyncInPool, asyncOpened, asyncClosed
+                ),
+                0, // connectionAttempts
+                0, // connectionsSuccessful
+                0, // connectionsFailed
+                0, // connectionTimeoutErrors
+                0, // connectionOtherErrors
+                0, // circuitBreakerHits
+                0, // connectionPoolEmptyCount
+                0, // connectionPoolOverflowCount
+                0, // idleConnectionsDropped
+                openConnections,
+                0, // closedConnections
+                0, // recoveredConnections
+                0, // tendsTotal
+                0, // tendsSuccessful
+                0, // tendsFailed
+                0, // partitionMapUpdates
+                0, // nodesAdded
+                0, // nodesRemoved
+                0, // transactionRetryCount
+                0, // transactionErrorCount
+                Collections.emptyMap(),
+                Collections.emptyList()
+        );
+    }
 
-	private List<MetricsSnapshot.EventLoopSnapshot> buildEventLoopSnapshots() {
-		EventLoop[] eventLoops = cluster.getEventLoopArray();
+    private List<MetricsSnapshot.EventLoopSnapshot> buildEventLoopSnapshots() {
+        EventLoop[] eventLoops = cluster.getEventLoopArray();
 
-		if (eventLoops == null) {
-			return Collections.emptyList();
-		}
+        if (eventLoops == null) {
+            return Collections.emptyList();
+        }
 
-		List<MetricsSnapshot.EventLoopSnapshot> snapshots =
-			new ArrayList<>(eventLoops.length);
+        List<MetricsSnapshot.EventLoopSnapshot> snapshots =
+                new ArrayList<>(eventLoops.length);
 
-		for (EventLoop eventLoop : eventLoops) {
-			snapshots.add(new MetricsSnapshot.EventLoopSnapshot(
-				eventLoop.getProcessSize(), eventLoop.getQueueSize()
-			));
-		}
-		return snapshots;
-	}
+        for (EventLoop eventLoop : eventLoops) {
+            snapshots.add(new MetricsSnapshot.EventLoopSnapshot(
+                    eventLoop.getProcessSize(), eventLoop.getQueueSize()
+            ));
+        }
+        return snapshots;
+    }
 }

--- a/examples/src/com/aerospike/examples/ExampleRegistry.java
+++ b/examples/src/com/aerospike/examples/ExampleRegistry.java
@@ -106,6 +106,7 @@ public final class ExampleRegistry {
 		registerSync(examples, "QueryRegionFilter", QueryRegionFilter.class, QueryExampleFixtures.queryRegionFilterExample());
 		registerSync(examples, "QueryGeoCollection", QueryGeoCollection.class, QueryExampleFixtures.queryGeoCollectionExample());
 		registerSync(examples, "QueryExecute", QueryExecute.class, QueryExampleFixtures.queryExecuteExample());
+		registerSync(examples, "Metrics", Metrics.class);
 		registerSync(examples, "BatchOperate", BatchOperate.class, AdvancedExampleFixtures.batchOperateExample());
 		registerSync(
 			examples,

--- a/examples/src/com/aerospike/examples/Metrics.java
+++ b/examples/src/com/aerospike/examples/Metrics.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright 2012-2026 Aerospike, Inc.
+ *
+ * Portions may be licensed to Aerospike, Inc. under one or more contributor
+ * license agreements WHICH ARE COMPATIBLE WITH THE APACHE LICENSE, VERSION 2.0.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.aerospike.examples;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import com.aerospike.client.Bin;
+import com.aerospike.client.IAerospikeClient;
+import com.aerospike.client.Key;
+import com.aerospike.client.Record;
+import com.aerospike.client.metrics.IMetricsExporter;
+import com.aerospike.client.metrics.MetricsPolicy;
+import com.aerospike.client.metrics.MetricsSnapshot;
+
+/**
+ * Demonstrate IMetricsExporter integration. Registers a sample exporter that
+ * prints snapshot summaries, enables metrics, performs some operations, and
+ * shows the snapshot data that the exporter receives.
+ */
+public class Metrics extends Example {
+
+	@Override
+	public void runExample() throws Exception {
+		IAerospikeClient client = client();
+		Parameters params = params();
+		SampleMetricsExporter extendedExporter =
+			runMetricsPhase(client, params, "extended-on", true);
+		SampleMetricsExporter standardExporter =
+			runMetricsPhase(client, params, "extended-off", false);
+
+		console.info("");
+		console.info("=== Comparison ===");
+		console.info("Extended ON  — snapshots: %d, last CPU: %.2f%%, last namespaces: %d",
+			extendedExporter.snapshotCount.get(), extendedExporter.lastCpuPercent,
+			extendedExporter.lastNamespaceCount);
+		console.info("Extended OFF — snapshots: %d, last CPU: %.2f%%, last namespaces: %d",
+			standardExporter.snapshotCount.get(), standardExporter.lastCpuPercent,
+			standardExporter.lastNamespaceCount);
+	}
+
+	private SampleMetricsExporter runMetricsPhase(
+		IAerospikeClient client,
+		Parameters params,
+		String label,
+		boolean enableExtendedMetrics
+	) throws Exception {
+		console.info("");
+		console.info("=== Extended metrics %s ===",
+			enableExtendedMetrics ? "ENABLED" : "DISABLED");
+
+		SampleMetricsExporter exporter = new SampleMetricsExporter(label);
+		MetricsPolicy policy = new MetricsPolicy();
+		policy.interval = 5;
+		policy.enableExtendedMetrics = enableExtendedMetrics;
+		policy.addExporter(exporter);
+
+		// The legacy file listener remains enabled for backwards compatibility.
+		// Set policy.reportDir to choose where those log files are written.
+		try {
+			client.enableMetrics(policy);
+			runOperations(client, params, 12_000);
+			console.info("Phase complete: %d snapshots received",
+				exporter.snapshotCount.get());
+			return exporter;
+		}
+		finally {
+			try {
+				client.disableMetrics();
+			}
+			finally {
+				exporter.close();
+			}
+		}
+	}
+
+	/**
+	 * Perform put/get operations for the specified duration in milliseconds.
+	 */
+	private void runOperations(IAerospikeClient client, Parameters params, long durationMs) throws Exception {
+		long endTime = System.currentTimeMillis() + durationMs;
+		int operationCount = 0;
+
+		while (System.currentTimeMillis() < endTime) {
+			Key key = new Key(params.namespace, params.set, "metrics-test-" + operationCount);
+			Bin bin = new Bin("val", operationCount);
+			client.put(params.writePolicy, key, bin);
+
+			Record record = client.get(params.policy, key);
+
+			if (record == null) {
+				console.error("Failed to get key: metrics-test-" + operationCount);
+			}
+			operationCount++;
+			Thread.sleep(100);
+		}
+		console.info("Performed %d put/get operations", operationCount);
+	}
+
+	/**
+	 * Sample IMetricsExporter that prints snapshot summaries to the console.
+	 * Tracks the last CPU percentage and namespace count for comparison.
+	 */
+	private class SampleMetricsExporter implements IMetricsExporter {
+		final String label;
+		final AtomicInteger snapshotCount = new AtomicInteger();
+		volatile double lastCpuPercent;
+		volatile int lastNamespaceCount;
+
+		SampleMetricsExporter(String label) {
+			this.label = label;
+		}
+
+		@Override
+		public void export(MetricsSnapshot snapshot) {
+			int currentSnapshot = snapshotCount.incrementAndGet();
+			lastCpuPercent = snapshot.cpuPercent;
+			int namespaceCount = 0;
+
+			console.info("[%s] --- Metrics Snapshot #%d ---", label, currentSnapshot);
+			console.info("  Timestamp:      %s", snapshot.timestamp);
+			console.info("  Extended:       %s", snapshot.extendedMetricsEnabled);
+			console.info("  Cluster:        %s", snapshot.clusterName);
+			console.info("  Nodes:          %d", snapshot.totalNodes);
+			console.info("  Open conns:     %d", snapshot.openConnections);
+			console.info("  CPU:            %.2f%%", snapshot.cpuPercent);
+			console.info("  Memory (bytes): %d", snapshot.memoryBytes);
+			console.info("  Retry count:    %d", snapshot.retryCount);
+			console.info("  Command count:  %d", snapshot.commandCount);
+
+			for (MetricsSnapshot.NodeSnapshot nodeSnapshot : snapshot.nodes) {
+				console.info("  Node %s (%s:%d):", nodeSnapshot.nodeName,
+					nodeSnapshot.nodeAddress, nodeSnapshot.nodePort);
+				console.info("    Sync conns:  inUse=%d inPool=%d opened=%d closed=%d",
+					nodeSnapshot.syncConnections.inUse, nodeSnapshot.syncConnections.inPool,
+					nodeSnapshot.syncConnections.opened, nodeSnapshot.syncConnections.closed);
+				console.info("    Async conns: inUse=%d inPool=%d opened=%d closed=%d",
+					nodeSnapshot.asyncConnections.inUse, nodeSnapshot.asyncConnections.inPool,
+					nodeSnapshot.asyncConnections.opened, nodeSnapshot.asyncConnections.closed);
+				console.info("    Open conns:  %d", nodeSnapshot.openConnections);
+
+				namespaceCount += nodeSnapshot.namespaces.size();
+
+				for (MetricsSnapshot.NamespaceSnapshot namespaceSnapshot : nodeSnapshot.namespaces) {
+					console.info("    Namespace %s: errors=%d timeouts=%d keyBusy=%d bytesIn=%d bytesOut=%d",
+						namespaceSnapshot.namespace, namespaceSnapshot.errors,
+						namespaceSnapshot.timeouts, namespaceSnapshot.keyBusy,
+						namespaceSnapshot.bytesIn, namespaceSnapshot.bytesOut);
+				}
+			}
+			lastNamespaceCount = namespaceCount;
+		}
+
+		@Override
+		public void close() {
+			console.info("[%s] Sample exporter closed", label);
+		}
+	}
+}

--- a/test/src/com/aerospike/client/metrics/TestMetricsExporterDispatcher.java
+++ b/test/src/com/aerospike/client/metrics/TestMetricsExporterDispatcher.java
@@ -1,0 +1,342 @@
+/*
+ * Copyright 2012-2026 Aerospike, Inc.
+ *
+ * Portions may be licensed to Aerospike, Inc. under one or more contributor
+ * license agreements WHICH ARE COMPATIBLE WITH THE APACHE LICENSE, VERSION 2.0.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.aerospike.client.metrics;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.time.Instant;
+import java.util.Collections;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.junit.Test;
+
+public class TestMetricsExporterDispatcher {
+
+	@Test
+	public void testDispatchCallsAllExporters() {
+		CountingExporter first = new CountingExporter();
+		CountingExporter second = new CountingExporter();
+		MetricsPolicy policy = policy(first, second);
+		MetricsExporterDispatcher dispatcher = dispatcher(policy, new AtomicLong());
+
+		try {
+			dispatcher.dispatch(snapshot());
+			assertEquals(1, first.callCount.get());
+			assertEquals(1, second.callCount.get());
+		}
+		finally {
+			dispatcher.shutdown();
+		}
+	}
+
+	@Test
+	public void testExporterRegistrationsAreFrozenAtConstruction() {
+		CountingExporter initial = new CountingExporter();
+		CountingExporter added = new CountingExporter();
+		MetricsPolicy policy = policy(initial);
+		MetricsExporterDispatcher dispatcher = dispatcher(policy, new AtomicLong());
+
+		try {
+			policy.addExporter(added);
+			dispatcher.dispatch(snapshot());
+
+			assertEquals(1, initial.callCount.get());
+			assertEquals(0, added.callCount.get());
+		}
+		finally {
+			dispatcher.shutdown();
+		}
+	}
+
+	@Test
+	public void testExceptionDoesNotPreventHealthyExporter() {
+		SequenceExporter failing = new SequenceExporter(true);
+		CountingExporter healthy = new CountingExporter();
+		MetricsPolicy policy = policy(failing, healthy);
+		MetricsExporterDispatcher dispatcher = dispatcher(policy, new AtomicLong());
+
+		try {
+			dispatcher.dispatch(snapshot());
+			assertEquals(1, failing.callCount.get());
+			assertEquals(1, healthy.callCount.get());
+		}
+		finally {
+			dispatcher.shutdown();
+		}
+	}
+
+	@Test
+	public void testSuccessResetsConsecutiveFailures() {
+		SequenceExporter exporter = new SequenceExporter(true, false, true, false);
+		MetricsPolicy policy = policy(exporter);
+		policy.maxConsecutiveFailures = 2;
+		MetricsExporterDispatcher dispatcher = dispatcher(policy, new AtomicLong());
+
+		try {
+			for (int i = 0; i < 4; i++) {
+				dispatcher.dispatch(snapshot());
+			}
+			assertEquals(4, exporter.callCount.get());
+		}
+		finally {
+			dispatcher.shutdown();
+		}
+	}
+
+	@Test
+	public void testExporterSuspendedAfterConsecutiveFailures() {
+		SequenceExporter exporter = new SequenceExporter(true, true, true);
+		MetricsPolicy policy = policy(exporter);
+		policy.maxConsecutiveFailures = 2;
+		policy.suspendRetryInterval = 60;
+		AtomicLong clock = new AtomicLong();
+		MetricsExporterDispatcher dispatcher = dispatcher(policy, clock);
+
+		try {
+			dispatcher.dispatch(snapshot());
+			dispatcher.dispatch(snapshot());
+			dispatcher.dispatch(snapshot());
+			assertEquals(2, exporter.callCount.get());
+		}
+		finally {
+			dispatcher.shutdown();
+		}
+	}
+
+	@Test
+	public void testSuspendedExporterRetriesAndResumes() {
+		SequenceExporter exporter = new SequenceExporter(true, true, false, false);
+		MetricsPolicy policy = policy(exporter);
+		policy.maxConsecutiveFailures = 2;
+		policy.suspendRetryInterval = 60;
+		AtomicLong clock = new AtomicLong();
+		MetricsExporterDispatcher dispatcher = dispatcher(policy, clock);
+
+		try {
+			dispatcher.dispatch(snapshot());
+			dispatcher.dispatch(snapshot());
+			dispatcher.dispatch(snapshot());
+			assertEquals(2, exporter.callCount.get());
+
+			clock.addAndGet(TimeUnit.SECONDS.toMillis(60));
+			dispatcher.dispatch(snapshot());
+			dispatcher.dispatch(snapshot());
+
+			assertEquals(4, exporter.callCount.get());
+		}
+		finally {
+			dispatcher.shutdown();
+		}
+	}
+
+	@Test
+	public void testTimeoutDoesNotBlockHealthyExporter() throws Exception {
+		UninterruptibleExporter stuck = new UninterruptibleExporter();
+		CountingExporter healthy = new CountingExporter();
+		MetricsPolicy policy = policy(stuck, healthy);
+		policy.exportTimeout = 10;
+		MetricsExporterDispatcher dispatcher = dispatcher(policy, new AtomicLong());
+
+		try {
+			dispatcher.dispatch(snapshot());
+			assertEquals(1, stuck.callCount.get());
+			assertTrue("Stuck exporter should observe cancellation",
+				stuck.interruptedLatch.await(1, TimeUnit.SECONDS));
+			assertEquals(1, healthy.callCount.get());
+		}
+		finally {
+			stuck.release();
+			dispatcher.shutdown();
+		}
+	}
+
+	@Test
+	public void testShutdownIsIdempotentAndStopsDispatch() {
+		CountingExporter exporter = new CountingExporter();
+		MetricsPolicy policy = policy(exporter);
+		MetricsExporterDispatcher dispatcher = dispatcher(policy, new AtomicLong());
+
+		dispatcher.shutdown();
+		dispatcher.shutdown();
+		dispatcher.dispatch(snapshot());
+
+		assertEquals(0, exporter.callCount.get());
+	}
+
+	@Test
+	public void testShutdownCancelsInFlightDispatch() throws Exception {
+		UninterruptibleExporter stuck = new UninterruptibleExporter();
+		MetricsPolicy policy = policy(stuck);
+		policy.exportTimeout = 10000;
+		MetricsExporterDispatcher dispatcher = dispatcher(policy, new AtomicLong());
+		Thread caller = new Thread(() -> dispatcher.dispatch(snapshot()));
+
+		try {
+			caller.start();
+			assertTrue("Exporter should start", stuck.startedLatch.await(1, TimeUnit.SECONDS));
+
+			dispatcher.shutdown();
+			caller.join(1000);
+
+			assertFalse("Dispatch caller should stop after shutdown", caller.isAlive());
+		}
+		finally {
+			stuck.release();
+			dispatcher.shutdown();
+		}
+	}
+
+	@Test
+	public void testInterruptedDispatchStopsBeforeNextExporter() throws Exception {
+		UninterruptibleExporter stuck = new UninterruptibleExporter();
+		CountingExporter next = new CountingExporter();
+		MetricsPolicy policy = policy(stuck, next);
+		policy.exportTimeout = 10000;
+		MetricsExporterDispatcher dispatcher = dispatcher(policy, new AtomicLong());
+		Thread caller = new Thread(() -> dispatcher.dispatch(snapshot()));
+
+		try {
+			caller.start();
+			assertTrue("Exporter should start", stuck.startedLatch.await(1, TimeUnit.SECONDS));
+
+			caller.interrupt();
+			caller.join(1000);
+
+			assertFalse("Interrupted dispatch should stop", caller.isAlive());
+			assertTrue("Interrupt status should be preserved", caller.isInterrupted());
+			assertEquals("No later exporter should run", 0, next.callCount.get());
+		}
+		finally {
+			stuck.release();
+			dispatcher.shutdown();
+		}
+	}
+
+	private static MetricsPolicy policy(IMetricsExporter... exporters) {
+		MetricsPolicy policy = new MetricsPolicy();
+
+		for (IMetricsExporter exporter : exporters) {
+			policy.addExporter(exporter);
+		}
+		return policy;
+	}
+
+	private static MetricsExporterDispatcher dispatcher(
+		MetricsPolicy policy,
+		AtomicLong clock
+	) {
+		return new MetricsExporterDispatcher(
+			policy,
+			clock::get,
+			TestMetricsExporterDispatcher::newExecutor,
+			TimeUnit.MILLISECONDS
+		);
+	}
+
+	private static ExecutorService newExecutor() {
+		return Executors.newSingleThreadExecutor(runnable -> {
+			Thread thread = new Thread(runnable, "metrics-dispatch-test");
+			thread.setDaemon(true);
+			return thread;
+		});
+	}
+
+	private static MetricsSnapshot snapshot() {
+		return new MetricsSnapshot(
+			Instant.EPOCH,
+			false,
+			"cluster",
+			"java",
+			"1.0",
+			"app",
+			Collections.emptyMap(),
+			0, 0, 0, 0, 0, 0, 0, 0,
+			0.0, 0, 0,
+			Collections.emptyList(),
+			Collections.emptyList(),
+			null,
+			MetricsSnapshot.HistogramType.LOGARITHMIC,
+			MetricsSnapshot.LatencyUnit.MILLISECONDS,
+			2,
+			7
+		);
+	}
+
+	private static class CountingExporter implements IMetricsExporter {
+		final AtomicInteger callCount = new AtomicInteger();
+
+		@Override
+		public void export(MetricsSnapshot snapshot) {
+			callCount.incrementAndGet();
+		}
+
+		@Override
+		public void close() {
+		}
+	}
+
+	private static final class SequenceExporter extends CountingExporter {
+		final boolean[] failures;
+
+		SequenceExporter(boolean... failures) {
+			this.failures = failures;
+		}
+
+		@Override
+		public void export(MetricsSnapshot snapshot) {
+			int call = callCount.getAndIncrement();
+
+			if (call < failures.length && failures[call]) {
+				throw new RuntimeException("expected failure");
+			}
+		}
+	}
+
+	private static final class UninterruptibleExporter extends CountingExporter {
+		final CountDownLatch startedLatch = new CountDownLatch(1);
+		final CountDownLatch interruptedLatch = new CountDownLatch(1);
+		final CountDownLatch releaseLatch = new CountDownLatch(1);
+
+		@Override
+		public void export(MetricsSnapshot snapshot) {
+			callCount.incrementAndGet();
+			startedLatch.countDown();
+			boolean released = false;
+
+			while (!released) {
+				try {
+					releaseLatch.await();
+					released = true;
+				}
+				catch (InterruptedException e) {
+					interruptedLatch.countDown();
+				}
+			}
+		}
+
+		void release() {
+			releaseLatch.countDown();
+		}
+	}
+}

--- a/test/src/com/aerospike/test/SuiteSync.java
+++ b/test/src/com/aerospike/test/SuiteSync.java
@@ -26,6 +26,7 @@ import com.aerospike.client.AerospikeClient;
 import com.aerospike.client.Host;
 import com.aerospike.client.IAerospikeClient;
 import com.aerospike.client.Log;
+import com.aerospike.client.metrics.TestMetricsExporterDispatcher;
 import com.aerospike.client.policy.ClientPolicy;
 import com.aerospike.test.sync.basic.TestAdd;
 import com.aerospike.test.sync.basic.TestAppend;
@@ -49,6 +50,9 @@ import com.aerospike.test.sync.basic.TestHLLExp;
 import com.aerospike.test.sync.basic.TestListExp;
 import com.aerospike.test.sync.basic.TestListMap;
 import com.aerospike.test.sync.basic.TestMapExp;
+import com.aerospike.test.sync.basic.TestMetricsExporter;
+import com.aerospike.test.sync.basic.TestMetricsPolicy;
+import com.aerospike.test.sync.basic.TestMetricsSnapshot;
 import com.aerospike.test.sync.basic.TestOperate;
 import com.aerospike.test.sync.basic.TestOperateBit;
 import com.aerospike.test.sync.basic.TestOperateHll;
@@ -110,6 +114,10 @@ import com.aerospike.client.AerospikeClientIndexTypeTest;
 	TestListExp.class,
 	TestListMap.class,
 	TestMapExp.class,
+	TestMetricsExporterDispatcher.class,
+	TestMetricsExporter.class,
+	TestMetricsPolicy.class,
+	TestMetricsSnapshot.class,
 	TestOperate.class,
 	TestOperateBit.class,
 	TestOperateHll.class,

--- a/test/src/com/aerospike/test/sync/basic/TestMetricsExporter.java
+++ b/test/src/com/aerospike/test/sync/basic/TestMetricsExporter.java
@@ -1,0 +1,354 @@
+/*
+ * Copyright 2012-2026 Aerospike, Inc.
+ *
+ * Portions may be licensed to Aerospike, Inc. under one or more contributor
+ * license agreements WHICH ARE COMPATIBLE WITH THE APACHE LICENSE, VERSION 2.0.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.aerospike.test.sync.basic;
+
+import static org.junit.Assume.assumeTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.FileTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Predicate;
+
+import org.junit.Test;
+
+import com.aerospike.client.AerospikeClient;
+import com.aerospike.client.Host;
+import com.aerospike.client.IAerospikeClient;
+import com.aerospike.client.metrics.IMetricsExporter;
+import com.aerospike.client.metrics.MetricsPolicy;
+import com.aerospike.client.metrics.MetricsSnapshot;
+import com.aerospike.client.policy.ClientPolicy;
+import com.aerospike.test.sync.TestSync;
+
+/**
+ * Integration tests for the metrics exporter framework.
+ * These tests require a running Aerospike server.
+ */
+public class TestMetricsExporter extends TestSync {
+
+	private static final long SNAPSHOT_TIMEOUT_MILLIS = 5000;
+
+	@Test
+	public void testExporterReceivesValidSnapshot() throws Exception {
+		RecordingExporter exporter = new RecordingExporter();
+		MetricsPolicy policy = newMetricsPolicy();
+		policy.addExporter(exporter);
+
+		MetricsSnapshot snapshot;
+		try {
+			client.enableMetrics(policy);
+			snapshot = waitForSnapshot(exporter, value -> true);
+		}
+		finally {
+			client.disableMetrics();
+		}
+
+		assertNotNull("Exporter should receive a snapshot", snapshot);
+		assertTrue("Extended metrics should be enabled by default",
+			snapshot.extendedMetricsEnabled);
+		assertTrue("Should have at least 1 node", snapshot.totalNodes >= 1);
+		assertNotNull("Cluster name should not be null", snapshot.clusterName);
+		assertTrue("Open connections should be > 0", snapshot.openConnections > 0);
+		assertFalse("Nodes list should not be empty", snapshot.nodes.isEmpty());
+
+		MetricsSnapshot.NodeSnapshot nodeSnapshot = snapshot.nodes.get(0);
+		assertFalse("Node name should not be empty", nodeSnapshot.nodeName.isEmpty());
+		assertTrue("Node should have open connections", nodeSnapshot.openConnections > 0);
+
+		long openConnections = 0;
+		long syncInUse = 0;
+		long syncInPool = 0;
+
+		for (MetricsSnapshot.NodeSnapshot node : snapshot.nodes) {
+			openConnections += node.openConnections;
+			syncInUse += node.syncConnections.inUse;
+			syncInPool += node.syncConnections.inPool;
+		}
+
+		assertTrue("Aggregated snapshot should be present",
+			snapshot.clusterAggregated != null);
+		assertEquals(openConnections, snapshot.clusterAggregated.openConnections);
+		assertEquals(syncInUse, snapshot.clusterAggregated.syncConnections.inUse);
+		assertEquals(syncInPool, snapshot.clusterAggregated.syncConnections.inPool);
+	}
+
+	@Test
+	public void testExtendedMetricsDisabled() throws Exception {
+		RecordingExporter exporter = new RecordingExporter();
+		MetricsPolicy policy = newMetricsPolicy();
+		policy.enableExtendedMetrics = false;
+		policy.addExporter(exporter);
+
+		MetricsSnapshot snapshot;
+		try {
+			client.enableMetrics(policy);
+			snapshot = waitForSnapshot(exporter,
+				value -> !value.extendedMetricsEnabled);
+		}
+		finally {
+			client.disableMetrics();
+		}
+
+		assertNotNull("Exporter should receive a standard metrics snapshot", snapshot);
+		assertFalse("Extended flag should be false", snapshot.extendedMetricsEnabled);
+		assertEquals("CPU should be 0 when extended disabled", 0.0, snapshot.cpuPercent, 0.001);
+		assertEquals("Memory should be 0 when extended disabled", 0, snapshot.memoryBytes);
+		assertEquals("Command count should be 0 when extended disabled", 0, snapshot.commandCount);
+
+		for (MetricsSnapshot.NodeSnapshot nodeSnapshot : snapshot.nodes) {
+			assertTrue("Namespaces should be empty when extended disabled",
+				nodeSnapshot.namespaces.isEmpty());
+		}
+	}
+
+	@Test
+	public void testDynamicConfigReloadsExtendedMetricsSetting() throws Exception {
+		final String configProperty = "AEROSPIKE_CLIENT_CONFIG_SYS_PROP";
+		assumeTrue("External client config takes precedence over the test config",
+			System.getenv("AEROSPIKE_CLIENT_CONFIG_URL") == null);
+
+		String originalConfig = System.getProperty(configProperty);
+		Path configFile = Files.createTempFile("aerospike-metrics-", ".yaml");
+		IAerospikeClient configuredClient = null;
+
+		try {
+			writeMetricsConfig(configFile, true);
+			System.setProperty(configProperty, configFile.toUri().toString());
+
+			ClientPolicy cp = new ClientPolicy();
+			cp.user = args.user;
+			cp.password = args.password;
+			cp.authMode = args.authMode;
+			cp.tlsPolicy = args.tlsPolicy;
+			configuredClient = new AerospikeClient(
+				cp, Host.parseHosts(args.host, args.port));
+
+			RecordingExporter exporter = new RecordingExporter();
+			MetricsPolicy policy = newMetricsPolicy();
+			policy.addExporter(exporter);
+			configuredClient.enableMetrics(policy);
+
+			assertNotNull("Expected an extended metrics snapshot",
+				waitForSnapshot(exporter, snapshot -> snapshot.extendedMetricsEnabled));
+
+			writeMetricsConfig(configFile, false);
+			Files.setLastModifiedTime(configFile,
+				FileTime.fromMillis(System.currentTimeMillis() + 2000));
+
+			assertNotNull("Expected dynamic config to restart metrics in standard mode",
+				waitForSnapshot(exporter, snapshot -> !snapshot.extendedMetricsEnabled));
+		}
+		finally {
+			if (configuredClient != null) {
+				configuredClient.close();
+			}
+			Files.deleteIfExists(configFile);
+
+			if (originalConfig == null) {
+				System.clearProperty(configProperty);
+			}
+			else {
+				System.setProperty(configProperty, originalConfig);
+			}
+		}
+	}
+
+	@Test
+	public void testDisableMetricsStopsExporter() throws Exception {
+		RecordingExporter exporter = new RecordingExporter();
+		MetricsPolicy policy = newMetricsPolicy();
+		policy.addExporter(exporter);
+
+		try {
+			client.enableMetrics(policy);
+			assertNotNull("Should receive a snapshot before disable",
+				waitForSnapshot(exporter, value -> true));
+		}
+		finally {
+			client.disableMetrics();
+		}
+
+		int countAfterDisable = exporter.snapshots.size();
+		Thread.sleep(1500);
+		assertEquals("No new snapshots after disable",
+			countAfterDisable, exporter.snapshots.size());
+	}
+
+	@Test
+	public void testEnableDisableEnableUsesNewExporter() throws Exception {
+		RecordingExporter first = new RecordingExporter();
+		MetricsPolicy firstPolicy = newMetricsPolicy();
+		firstPolicy.addExporter(first);
+
+		try {
+			client.enableMetrics(firstPolicy);
+			assertNotNull("First exporter should receive a snapshot",
+				waitForSnapshot(first, value -> true));
+		}
+		finally {
+			client.disableMetrics();
+		}
+
+		int firstCount = first.snapshots.size();
+		RecordingExporter second = new RecordingExporter();
+		MetricsPolicy secondPolicy = newMetricsPolicy();
+		secondPolicy.addExporter(second);
+
+		try {
+			client.enableMetrics(secondPolicy);
+			assertNotNull("Second exporter should receive a snapshot",
+				waitForSnapshot(second, value -> true));
+		}
+		finally {
+			client.disableMetrics();
+		}
+
+		assertEquals("Disabled exporter should not receive later snapshots",
+			firstCount, first.snapshots.size());
+	}
+
+	@Test
+	public void testClientsKeepIndependentSettingsWithSharedExporter()
+		throws Exception {
+		RecordingExporter exporter = new RecordingExporter();
+		IAerospikeClient extendedClient = newClient("metrics-extended");
+		IAerospikeClient standardClient = newClient("metrics-standard");
+
+		try {
+			MetricsPolicy extendedPolicy = newMetricsPolicy();
+			extendedPolicy.addExporter(exporter);
+
+			MetricsPolicy standardPolicy = newMetricsPolicy();
+			standardPolicy.enableExtendedMetrics = false;
+			standardPolicy.addExporter(exporter);
+
+			extendedClient.enableMetrics(extendedPolicy);
+			standardClient.enableMetrics(standardPolicy);
+
+			assertNotNull("Expected extended snapshot from first client",
+				waitForSnapshot(exporter, snapshot ->
+					"metrics-extended".equals(snapshot.appId)
+						&& snapshot.extendedMetricsEnabled));
+			MetricsSnapshot standardSnapshot = waitForSnapshot(
+				exporter,
+				snapshot -> "metrics-standard".equals(snapshot.appId)
+					&& !snapshot.extendedMetricsEnabled
+			);
+			assertNotNull("Expected standard snapshot from second client",
+				standardSnapshot);
+			assertEquals(0.0, standardSnapshot.cpuPercent, 0.001);
+			assertEquals(0, standardSnapshot.memoryBytes);
+		}
+		finally {
+			extendedClient.close();
+			standardClient.close();
+		}
+	}
+
+	@Test
+	public void testClientClosedWhileMetricsEnabled() throws Exception {
+		RecordingExporter exporter = new RecordingExporter();
+		IAerospikeClient tempClient = newClient("metrics-close");
+
+		try {
+			MetricsPolicy policy = newMetricsPolicy();
+			policy.addExporter(exporter);
+			tempClient.enableMetrics(policy);
+			assertNotNull("Should receive a snapshot before close",
+				waitForSnapshot(exporter, value -> true));
+
+			tempClient.close();
+			int countAfterClose = exporter.snapshots.size();
+			Thread.sleep(1500);
+			assertEquals("No new snapshots after client close",
+				countAfterClose, exporter.snapshots.size());
+		}
+		finally {
+			tempClient.close();
+		}
+	}
+
+	private static IAerospikeClient newClient(String appId) {
+		ClientPolicy policy = new ClientPolicy();
+		policy.user = args.user;
+		policy.password = args.password;
+		policy.authMode = args.authMode;
+		policy.tlsPolicy = args.tlsPolicy;
+		policy.appId = appId;
+		return new AerospikeClient(
+			policy, Host.parseHosts(args.host, args.port));
+	}
+
+	private static MetricsPolicy newMetricsPolicy() {
+		MetricsPolicy policy = new MetricsPolicy();
+		policy.interval = 1;
+		policy.reportDir = "target/metrics-tests";
+		return policy;
+	}
+
+	private static void writeMetricsConfig(Path path, boolean enableExtendedMetrics)
+		throws Exception {
+		String yaml = "version: 1.0.0\n"
+			+ "static:\n"
+			+ "  client:\n"
+			+ "    config_interval: 1000\n"
+			+ "dynamic:\n"
+			+ "  metrics:\n"
+			+ "    enable: true\n"
+			+ "    enable_extended_metrics: " + enableExtendedMetrics + "\n";
+		Files.writeString(path, yaml);
+	}
+
+	private static MetricsSnapshot waitForSnapshot(
+		RecordingExporter exporter,
+		Predicate<MetricsSnapshot> predicate
+	) throws InterruptedException {
+		long deadline = System.currentTimeMillis() + SNAPSHOT_TIMEOUT_MILLIS;
+
+		while (System.currentTimeMillis() < deadline) {
+			synchronized (exporter.snapshots) {
+				for (MetricsSnapshot snapshot : exporter.snapshots) {
+					if (predicate.test(snapshot)) {
+						return snapshot;
+					}
+				}
+			}
+			Thread.sleep(50);
+		}
+		return null;
+	}
+
+	private static class RecordingExporter implements IMetricsExporter {
+		final List<MetricsSnapshot> snapshots = Collections.synchronizedList(new ArrayList<>());
+
+		@Override
+		public void export(MetricsSnapshot snapshot) {
+			snapshots.add(snapshot);
+		}
+
+		@Override
+		public void close() {
+		}
+	}
+}

--- a/test/src/com/aerospike/test/sync/basic/TestMetricsPolicy.java
+++ b/test/src/com/aerospike/test/sync/basic/TestMetricsPolicy.java
@@ -1,0 +1,253 @@
+/*
+ * Copyright 2012-2026 Aerospike, Inc.
+ *
+ * Portions may be licensed to Aerospike, Inc. under one or more contributor
+ * license agreements WHICH ARE COMPATIBLE WITH THE APACHE LICENSE, VERSION 2.0.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.aerospike.test.sync.basic;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+
+import org.junit.Test;
+
+import com.aerospike.client.configuration.primitiveprops.BooleanProperty;
+import com.aerospike.client.configuration.serializers.Configuration;
+import com.aerospike.client.configuration.serializers.DynamicConfiguration;
+import com.aerospike.client.configuration.serializers.dynamicconfig.DynamicMetricsConfig;
+import com.aerospike.client.metrics.IMetricsExporter;
+import com.aerospike.client.metrics.MetricsPolicy;
+import com.aerospike.client.metrics.MetricsSnapshot;
+
+public class TestMetricsPolicy {
+
+	@Test
+	public void testDefaultValues() {
+		MetricsPolicy policy = new MetricsPolicy();
+
+		assertTrue(policy.enableExtendedMetrics);
+		assertEquals(30, policy.interval);
+		assertEquals(7, policy.latencyColumns);
+		assertEquals(1, policy.latencyShift);
+		assertEquals(3, policy.maxConsecutiveFailures);
+		assertEquals(60, policy.suspendRetryInterval);
+		assertEquals(10, policy.exportTimeout);
+		assertTrue(policy.getExporters().isEmpty());
+		assertFalse(policy.isMetricsRestartRequired());
+	}
+
+	@Test
+	public void testCopyConstructor() {
+		MetricsPolicy original = new MetricsPolicy();
+		original.enableExtendedMetrics = false;
+		original.interval = 10;
+		original.latencyColumns = 5;
+		original.latencyShift = 3;
+		original.maxConsecutiveFailures = 5;
+		original.suspendRetryInterval = 120;
+		original.exportTimeout = 15;
+
+		IMetricsExporter exporter = new NoOpExporter();
+		original.addExporter(exporter);
+
+		MetricsPolicy copy = new MetricsPolicy(original);
+
+		assertFalse(copy.enableExtendedMetrics);
+		assertEquals(10, copy.interval);
+		assertEquals(5, copy.latencyColumns);
+		assertEquals(3, copy.latencyShift);
+		assertEquals(5, copy.maxConsecutiveFailures);
+		assertEquals(120, copy.suspendRetryInterval);
+		assertEquals(15, copy.exportTimeout);
+		assertEquals(1, copy.getExporters().size());
+		assertEquals(exporter, copy.getExporters().get(0));
+	}
+
+	@Test
+	public void testAddExporter() {
+		MetricsPolicy policy = new MetricsPolicy();
+		IMetricsExporter first = new NoOpExporter();
+		IMetricsExporter second = new NoOpExporter();
+
+		policy.addExporter(first);
+		policy.addExporter(second);
+
+		List<IMetricsExporter> exporters = policy.getExporters();
+		assertEquals(2, exporters.size());
+		assertEquals(first, exporters.get(0));
+		assertEquals(second, exporters.get(1));
+	}
+
+	@Test(expected = UnsupportedOperationException.class)
+	public void testGetExportersUnmodifiable() {
+		MetricsPolicy policy = new MetricsPolicy();
+		policy.addExporter(new NoOpExporter());
+
+		policy.getExporters().add(new NoOpExporter());
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testAddNullExporterThrows() {
+		MetricsPolicy policy = new MetricsPolicy();
+		policy.addExporter(null);
+	}
+
+	@Test
+	public void testConfigMergeEnableExtendedMetrics() {
+		MetricsPolicy original = new MetricsPolicy();
+		assertTrue(original.enableExtendedMetrics);
+
+		Configuration config = buildConfigWithExtendedMetrics(false);
+
+		MetricsPolicy merged = new MetricsPolicy(original, config, true);
+
+		assertFalse(merged.enableExtendedMetrics);
+		assertTrue(merged.isMetricsRestartRequired());
+	}
+
+	@Test
+	public void testConfigMergeNoChange() {
+		MetricsPolicy original = new MetricsPolicy();
+		assertTrue(original.enableExtendedMetrics);
+
+		Configuration config = buildConfigWithExtendedMetrics(true);
+
+		MetricsPolicy merged = new MetricsPolicy(original, config, true);
+
+		assertTrue(merged.enableExtendedMetrics);
+		assertFalse(merged.isMetricsRestartRequired());
+	}
+
+	@Test
+	public void testConfigMergeNullConfig() {
+		MetricsPolicy original = new MetricsPolicy();
+		original.enableExtendedMetrics = false;
+		original.interval = 15;
+
+		MetricsPolicy merged = new MetricsPolicy(original, null, true);
+
+		assertFalse(merged.enableExtendedMetrics);
+		assertEquals(15, merged.interval);
+		assertFalse(merged.isMetricsRestartRequired());
+	}
+
+	@Test
+	public void testConfigMergeNullDynamicMetricsConfig() {
+		MetricsPolicy original = new MetricsPolicy();
+
+		DynamicConfiguration dynConfig = new DynamicConfiguration();
+		dynConfig.dynamicMetricsConfig = null;
+
+		Configuration config = new Configuration();
+		config.dynamicConfiguration = dynConfig;
+
+		MetricsPolicy merged = new MetricsPolicy(original, config, true);
+
+		assertTrue(merged.enableExtendedMetrics);
+		assertFalse(merged.isMetricsRestartRequired());
+	}
+
+	@Test
+	public void testConfigMergeLatencyColumnsValidation() {
+		MetricsPolicy original = new MetricsPolicy();
+		original.latencyColumns = 7;
+
+		DynamicMetricsConfig dynMC = new DynamicMetricsConfig();
+		dynMC.latencyColumns = new com.aerospike.client.configuration.primitiveprops.IntProperty();
+		dynMC.latencyColumns.value = 0;
+
+		DynamicConfiguration dynConfig = new DynamicConfiguration();
+		dynConfig.dynamicMetricsConfig = dynMC;
+
+		Configuration config = new Configuration();
+		config.dynamicConfiguration = dynConfig;
+
+		MetricsPolicy merged = new MetricsPolicy(original, config, true);
+
+		assertEquals(7, merged.latencyColumns);
+	}
+
+	private static Configuration buildConfigWithExtendedMetrics(boolean value) {
+		DynamicMetricsConfig dynMC = new DynamicMetricsConfig();
+		dynMC.enableExtendedMetrics = new BooleanProperty(value);
+
+		DynamicConfiguration dynConfig = new DynamicConfiguration();
+		dynConfig.dynamicMetricsConfig = dynMC;
+
+		Configuration config = new Configuration();
+		config.dynamicConfiguration = dynConfig;
+		return config;
+	}
+
+	@Test
+	public void testDynamicMetricsConfigToStringNullSafe() {
+		DynamicMetricsConfig dynMC = new DynamicMetricsConfig();
+		dynMC.enable = new BooleanProperty(true);
+		dynMC.enableExtendedMetrics = null;
+
+		String result = dynMC.toString();
+		assertTrue(result.contains("enable_extended_metrics=null"));
+	}
+
+	@Test
+	public void testExporterSettingsAcceptBoundaryValues() {
+		MetricsPolicy policy = new MetricsPolicy();
+		policy.interval = 1;
+		policy.maxConsecutiveFailures = 1;
+		policy.suspendRetryInterval = 0;
+		policy.exportTimeout = 1;
+
+		policy.validateExporterSettings();
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testExporterSettingsRejectNonPositiveInterval() {
+		MetricsPolicy policy = new MetricsPolicy();
+		policy.interval = 0;
+		policy.validateExporterSettings();
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testExporterSettingsRejectNonPositiveFailureLimit() {
+		MetricsPolicy policy = new MetricsPolicy();
+		policy.maxConsecutiveFailures = 0;
+		policy.validateExporterSettings();
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testExporterSettingsRejectNegativeRetryInterval() {
+		MetricsPolicy policy = new MetricsPolicy();
+		policy.suspendRetryInterval = -1;
+		policy.validateExporterSettings();
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testExporterSettingsRejectNonPositiveTimeout() {
+		MetricsPolicy policy = new MetricsPolicy();
+		policy.exportTimeout = 0;
+		policy.validateExporterSettings();
+	}
+
+	private static class NoOpExporter implements IMetricsExporter {
+		@Override
+		public void export(MetricsSnapshot snapshot) {
+		}
+
+		@Override
+		public void close() {
+		}
+	}
+}

--- a/test/src/com/aerospike/test/sync/basic/TestMetricsSnapshot.java
+++ b/test/src/com/aerospike/test/sync/basic/TestMetricsSnapshot.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright 2012-2026 Aerospike, Inc.
+ *
+ * Portions may be licensed to Aerospike, Inc. under one or more contributor
+ * license agreements WHICH ARE COMPATIBLE WITH THE APACHE LICENSE, VERSION 2.0.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.aerospike.test.sync.basic;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Test;
+
+import com.aerospike.client.metrics.MetricsSnapshot;
+import com.aerospike.client.metrics.MetricsSnapshot.CommandSnapshot;
+import com.aerospike.client.metrics.MetricsSnapshot.CommandType;
+import com.aerospike.client.metrics.MetricsSnapshot.ConnectionSnapshot;
+import com.aerospike.client.metrics.MetricsSnapshot.EventLoopSnapshot;
+import com.aerospike.client.metrics.MetricsSnapshot.HistogramSnapshot;
+import com.aerospike.client.metrics.MetricsSnapshot.HistogramType;
+import com.aerospike.client.metrics.LatencyType;
+import com.aerospike.client.metrics.MetricsSnapshot.LatencyUnit;
+import com.aerospike.client.metrics.MetricsSnapshot.NamespaceSnapshot;
+import com.aerospike.client.metrics.MetricsSnapshot.NodeSnapshot;
+
+public class TestMetricsSnapshot {
+
+	@Test
+	public void testSnapshotCollectionsAreUnmodifiable() {
+		MetricsSnapshot snapshot = buildMinimalSnapshot();
+		NodeSnapshot node = snapshot.nodes.get(0);
+		HistogramSnapshot histogram =
+			new HistogramSnapshot(new long[]{0}, 0, 0, 0.0, 0);
+		NamespaceSnapshot namespace = new NamespaceSnapshot(
+			"test", 0, 0, 0, 0, 0,
+			Collections.emptyMap(), Collections.emptyMap()
+		);
+		CommandSnapshot command = new CommandSnapshot(
+			CommandType.GET,
+			histogram, histogram, histogram, histogram, histogram, histogram,
+			0, 0, Collections.emptyMap()
+		);
+
+		assertThrows(UnsupportedOperationException.class,
+			() -> snapshot.labels.put("env", "test"));
+		assertThrows(UnsupportedOperationException.class,
+			() -> snapshot.eventLoops.add(new EventLoopSnapshot(0, 0)));
+		assertThrows(UnsupportedOperationException.class,
+			() -> snapshot.nodes.add(buildMinimalNodeSnapshot()));
+		assertThrows(UnsupportedOperationException.class,
+			() -> node.namespaces.add(namespace));
+		assertThrows(UnsupportedOperationException.class,
+			() -> node.commandLatencies.put(CommandType.GET, histogram));
+		assertThrows(UnsupportedOperationException.class,
+			() -> namespace.compatibilityLatencies.put(LatencyType.READ, histogram));
+		assertThrows(UnsupportedOperationException.class,
+			() -> command.resultCodeCounts.put(0, 1L));
+	}
+
+	@Test
+	public void testHistogramSnapshotDefensiveCopy() {
+		long[] originalBuckets = {10, 20, 30, 40};
+		HistogramSnapshot histogram = new HistogramSnapshot(originalBuckets, 1, 100, 500.0, 4);
+
+		long[] returnedBuckets = histogram.getBuckets();
+		assertArrayEquals(originalBuckets, returnedBuckets);
+
+		returnedBuckets[0] = 999;
+		long[] freshBuckets = histogram.getBuckets();
+		assertEquals(10, freshBuckets[0]);
+
+		originalBuckets[0] = 888;
+		long[] freshBuckets2 = histogram.getBuckets();
+		assertEquals(10, freshBuckets2[0]);
+	}
+
+	@Test
+	public void testSnapshotDefensivelyCopiesSourceCollections() {
+		Map<String, String> labels = new HashMap<>();
+		labels.put("env", "test");
+		List<EventLoopSnapshot> eventLoops = new ArrayList<>();
+		eventLoops.add(new EventLoopSnapshot(1, 2));
+		List<NodeSnapshot> nodes = new ArrayList<>();
+		nodes.add(buildMinimalNodeSnapshot());
+
+		MetricsSnapshot snapshot = new MetricsSnapshot(
+			Instant.now(), true, "cluster", "java", "1.0", "app",
+			labels,
+			0, 0, 0, 0, 1, 1, 0, 0,
+			0.0, 0, 0,
+			eventLoops,
+			nodes, null,
+			HistogramType.LOGARITHMIC, LatencyUnit.MILLISECONDS, 2, 7
+		);
+
+		labels.put("injected", "value");
+		eventLoops.clear();
+		nodes.clear();
+
+		assertFalse(snapshot.labels.containsKey("injected"));
+		assertEquals(1, snapshot.eventLoops.size());
+		assertEquals(1, snapshot.nodes.size());
+	}
+
+	@Test
+	public void testNodeSnapshotDefensivelyCopiesSourceCollections() {
+		Map<CommandType, HistogramSnapshot> latencies = new HashMap<>();
+		List<NamespaceSnapshot> namespaces = new ArrayList<>();
+		NodeSnapshot snapshot = buildNodeSnapshot(latencies, namespaces);
+
+		latencies.put(CommandType.GET,
+			new HistogramSnapshot(new long[]{1}, 1, 1, 1.0, 1));
+		namespaces.add(new NamespaceSnapshot(
+			"test", 0, 0, 0, 0, 0,
+			Collections.emptyMap(), Collections.emptyMap()
+		));
+
+		assertTrue(snapshot.commandLatencies.isEmpty());
+		assertTrue(snapshot.namespaces.isEmpty());
+	}
+
+	private static MetricsSnapshot buildMinimalSnapshot() {
+		List<NodeSnapshot> nodes = new ArrayList<>();
+		nodes.add(buildMinimalNodeSnapshot());
+
+		return new MetricsSnapshot(
+			Instant.now(),
+			true,
+			"test-cluster",
+			"java",
+			"1.0.0",
+			"test-app",
+			Collections.emptyMap(),
+			0, 0, 0, 0, 1, 1, 0, 0,
+			0.0, 0, 0,
+			Collections.<EventLoopSnapshot>emptyList(),
+			nodes,
+			null,
+			HistogramType.LOGARITHMIC,
+			LatencyUnit.MILLISECONDS,
+			2, 7
+		);
+	}
+
+	private static NodeSnapshot buildMinimalNodeSnapshot() {
+		Map<CommandType, HistogramSnapshot> emptyLatencies = new HashMap<>();
+		List<NamespaceSnapshot> emptyNamespaces = new ArrayList<>();
+		return buildNodeSnapshot(emptyLatencies, emptyNamespaces);
+	}
+
+	private static NodeSnapshot buildNodeSnapshot(
+		Map<CommandType, HistogramSnapshot> commandLatencies,
+		List<NamespaceSnapshot> namespaces
+	) {
+		ConnectionSnapshot syncConns = new ConnectionSnapshot(1, 5, 10, 2);
+		ConnectionSnapshot asyncConns = new ConnectionSnapshot(0, 0, 0, 0);
+
+		return new NodeSnapshot(
+			"node1", "127.0.0.1", 3000,
+			syncConns, asyncConns,
+			0, 0, 0, 0, 0, 0, 0, 0, 0,
+			6, 0, 0,
+			0, 0, 0, 0, 0, 0, 0, 0,
+			commandLatencies, namespaces
+		);
+	}
+}

--- a/test/src/resources/aerospikeconfig.yaml
+++ b/test/src/resources/aerospikeconfig.yaml
@@ -138,6 +138,7 @@ dynamic:
     respond_all_keys: false
   metrics:
     enable: false
+    enable_extended_metrics: true
     latency_shift: 2
     latency_columns: 7
     labels:


### PR DESCRIPTION
## Summary

- Add `IMetricsExporter` support for structured client metrics export.
- Add immutable `MetricsSnapshot` models for cluster, node, namespace, connection, event-loop, command, and histogram metrics.
- Build and dispatch metrics outside the tend thread.
- Isolate exporters with timeout, failure suspension, and retry handling.
- Support standard and extended metric collection.
- Preserve the existing `MetricsListener` path for backward compatibility.
- Add a Metrics example and dynamic configuration support.

## Testing

- [x] 30 server-independent metrics tests passed.
- [x] Full offline Maven package build passed.
- [x] Server-backed integration tests compile.
- [ ] Run metrics integration tests against a live Aerospike server.

## Related

- Task: [OM-330](https://aerospike.atlassian.net/browse/OM-330)
- [Metrics Exporter tech spec](https://aerospike.atlassian.net/wiki/spaces/CLIENTS/pages/4624777275/Metrics+Exporter+Tech+Spec)
- [Client Metrics Exporter Design ](https://aerospike.atlassian.net/wiki/spaces/~712020bb8a55fc25ee40adaf0ddba0871496d2/pages/5554012222/Draft+RFC+Aerospike+Client+Metrics+Exporter+Design)

[OM-330]: https://aerospike.atlassian.net/browse/OM-330?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ